### PR TITLE
Harden error handling: XSS-safe status link, tighter patterns, fail-fast preview

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,15 +1,26 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   zig
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -20,14 +31,12 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -35,45 +44,48 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
 #
-#  * `activate_project`: Activates a project by name.
+#  * `activate_project`: Activates a project based on the project name or path.
 #  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
 #  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
 #  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
 #  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
 #  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
 #  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
 #  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
 #  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
 #  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
 #  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
 #  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -82,7 +94,8 @@ initial_prompt: ""
 # the name by which the project can be referenced within Serena
 project_name: "WeMeditateWeb"
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -125,3 +138,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/components/molecules/ErrorFallback/ErrorFallback.tsx
+++ b/components/molecules/ErrorFallback/ErrorFallback.tsx
@@ -1,16 +1,8 @@
 /**
  * ErrorFallback - Error boundary fallback UI
  *
- * This molecule is used with Sentry.ErrorBoundary to display a user-friendly
- * error message when an unexpected React render error occurs.
- *
- * Features:
- * - Detects error type (network, server, client, unknown)
- * - Shows contextual error messages
- * - Optional status page link for server errors
- * - Retry button with page reload
- *
- * Built with existing atoms: Icon, Heading, Button
+ * Used by Sentry.ErrorBoundary and the +Page.tsx error route to display a
+ * contextual, user-friendly error message.
  *
  * @example
  * <ErrorFallback
@@ -22,90 +14,89 @@
 
 import { ExclamationCircleIcon, WifiIcon, ServerIcon } from '@heroicons/react/24/outline'
 import { Icon, Heading, Button } from '../../atoms'
-import { detectErrorType, ErrorType, getUserFriendlyErrorMessage } from '../../../server/error-utils'
+import {
+  detectErrorType,
+  ErrorType,
+  getUserFriendlyErrorMessage,
+  isSafeHttpUrl,
+} from '../../../server/error-utils'
 
 export interface ErrorFallbackProps {
-  /**
-   * The Error object that was thrown
-   */
+  /** The Error object that was thrown */
   error: Error
 
-  /**
-   * Function to reset the error boundary and retry
-   * Defaults to reloading the page
-   */
+  /** Override automatic error classification. Useful when the caller knows the error category (e.g. a 404 route) and doesn't want to rely on message-based detection. */
+  errorType?: ErrorType
+
+  /** Function to reset the error boundary and retry. Defaults to reloading the page. */
   resetError?: () => void
 
-  /**
-   * Show technical error details (recommended for DEV only)
-   */
+  /** Show technical error details (recommended for DEV only) */
   showDetails?: boolean
 
-  /**
-   * Optional URL to external status page
-   * Shown for server errors to provide updates
-   */
+  /** Optional URL to external status page, shown for server errors. Must be an http(s) URL — other schemes are ignored. */
   statusPageUrl?: string
+}
+
+const ICON_BY_TYPE = {
+  [ErrorType.NETWORK]: WifiIcon,
+  [ErrorType.SERVER]: ServerIcon,
+  [ErrorType.CLIENT]: ExclamationCircleIcon,
+  [ErrorType.UNKNOWN]: ExclamationCircleIcon,
+}
+
+const TITLE_BY_TYPE = {
+  [ErrorType.NETWORK]: 'Connection Issue',
+  [ErrorType.SERVER]: 'Service Temporarily Unavailable',
+  [ErrorType.CLIENT]: 'Content Not Found',
+  [ErrorType.UNKNOWN]: 'Oops! Something went wrong',
 }
 
 export function ErrorFallback({
   error,
+  errorType,
   resetError = () => window.location.reload(),
   showDetails = false,
   statusPageUrl,
 }: ErrorFallbackProps) {
-  const errorType = detectErrorType(error)
-  const userMessage = getUserFriendlyErrorMessage(error, statusPageUrl)
-
-  // Choose icon based on error type
-  const getErrorIcon = () => {
-    switch (errorType) {
-      case ErrorType.NETWORK:
-        return WifiIcon
-      case ErrorType.SERVER:
-        return ServerIcon
-      default:
-        return ExclamationCircleIcon
-    }
-  }
-
-  // Get error title based on type
-  const getErrorTitle = () => {
-    switch (errorType) {
-      case ErrorType.NETWORK:
-        return 'Connection Issue'
-      case ErrorType.SERVER:
-        return 'Service Temporarily Unavailable'
-      case ErrorType.CLIENT:
-        return 'Content Not Found'
-      default:
-        return 'Oops! Something went wrong'
-    }
-  }
+  const resolvedType = errorType ?? detectErrorType(error)
+  const userMessage = getUserFriendlyErrorMessage(error)
+  const showStatusLink = resolvedType === ErrorType.SERVER && !!statusPageUrl && isSafeHttpUrl(statusPageUrl)
 
   return (
     <div className="flex flex-col items-center justify-center p-8 text-center min-h-[400px]">
-      {/* Error Icon */}
       <Icon
-        icon={getErrorIcon()}
+        icon={ICON_BY_TYPE[resolvedType]}
         size="2xl"
         color="secondary"
         className="mb-6"
         aria-label="Error"
       />
 
-      {/* Error Title */}
       <Heading level="h3" className="mb-2">
-        {getErrorTitle()}
+        {TITLE_BY_TYPE[resolvedType]}
       </Heading>
 
-      {/* Error Description with HTML support for status page link */}
-      <div
-        className="text-base sm:text-lg font-light text-gray-700 mb-6 max-w-md"
-        dangerouslySetInnerHTML={{ __html: userMessage }}
-      />
+      <p className="text-base sm:text-lg font-light text-gray-700 mb-2 max-w-md">
+        {userMessage}
+      </p>
 
-      {/* Technical Details (collapsible, optional) */}
+      {showStatusLink && (
+        <p className="text-base sm:text-lg font-light text-gray-700 mb-6 max-w-md">
+          Check our{' '}
+          <a
+            href={statusPageUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-teal-600 hover:text-teal-700 underline"
+          >
+            status page
+          </a>{' '}
+          for updates.
+        </p>
+      )}
+      {!showStatusLink && <div className="mb-4" />}
+
       {showDetails && (
         <details className="mb-6 max-w-md text-left w-full">
           <summary className="cursor-pointer text-sm text-gray-600 hover:text-gray-900 mb-2 text-center">
@@ -113,7 +104,7 @@ export function ErrorFallback({
           </summary>
           <div className="mt-2 p-4 bg-gray-100 rounded text-xs font-mono break-words">
             <p className="mb-2">
-              <strong>Error Type:</strong> {errorType}
+              <strong>Error Type:</strong> {resolvedType}
             </p>
             <p>
               <strong>Error Message:</strong> {error.message}
@@ -122,7 +113,6 @@ export function ErrorFallback({
         </details>
       )}
 
-      {/* Action Buttons */}
       <div className="flex flex-col sm:flex-row gap-3">
         <Button onClick={resetError} variant="secondary" size="md">
           Try Again

--- a/components/molecules/ErrorFallback/ErrorFallback.tsx
+++ b/components/molecules/ErrorFallback/ErrorFallback.tsx
@@ -77,7 +77,11 @@ export function ErrorFallback({
         {TITLE_BY_TYPE[resolvedType]}
       </Heading>
 
-      <p className="text-base sm:text-lg font-light text-gray-700 mb-2 max-w-md">
+      <p
+        className={`text-base sm:text-lg font-light text-gray-700 max-w-md ${
+          showStatusLink ? 'mb-2' : 'mb-6'
+        }`}
+      >
         {userMessage}
       </p>
 
@@ -95,7 +99,6 @@ export function ErrorFallback({
           for updates.
         </p>
       )}
-      {!showStatusLink && <div className="mb-4" />}
 
       {showDetails && (
         <details className="mb-6 max-w-md text-left w-full">

--- a/pages/_error/+Page.tsx
+++ b/pages/_error/+Page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
   const { is404, abortReason } = usePageContext()
   const statusPageUrl = import.meta.env.PUBLIC__STATUS_PAGE_URL
 
-  const errorType = is404 ? ErrorType.CLIENT : ErrorType.UNKNOWN
+  const errorType = is404 ? ErrorType.CLIENT : ErrorType.SERVER
   const message = is404
     ? "The page you're looking for doesn't exist."
     : typeof abortReason === 'string'

--- a/pages/_error/+Page.tsx
+++ b/pages/_error/+Page.tsx
@@ -1,42 +1,32 @@
 /**
- * Error page - Displayed for 404 and 500 errors
+ * Error page - Displayed for 404 and 500 errors.
  *
- * This page is rendered when:
+ * Rendered when:
  * - Page not found (404)
  * - Server error during data fetching (500)
  * - CMS unreachable after retries
- *
- * Features:
- * - Uses ErrorFallback component for consistent error UI
- * - Vertically centered on full viewport
- * - Uses minimal LayoutError (no data dependencies)
- * - Optional status page link for server errors
  */
 
 import { usePageContext } from 'vike-react/usePageContext'
 import { ErrorFallback } from '../../components/molecules'
+import { ErrorType } from '../../server/error-utils'
 
 export default function Page() {
   const { is404, abortReason } = usePageContext()
   const statusPageUrl = import.meta.env.PUBLIC__STATUS_PAGE_URL
 
-  // Create appropriate error object based on error type
-  const error = is404
-    ? // 404 error - client error type
-      Object.assign(new Error('The page you are looking for does not exist.'), {
-        response: { status: 404 },
-      })
-    : // 500 error - network/server error type
-      new Error(
-        typeof abortReason === 'string'
-          ? abortReason
-          : 'Network connection lost.'
-      )
+  const errorType = is404 ? ErrorType.CLIENT : ErrorType.UNKNOWN
+  const message = is404
+    ? "The page you're looking for doesn't exist."
+    : typeof abortReason === 'string'
+      ? abortReason
+      : 'An unexpected error occurred.'
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-white">
       <ErrorFallback
-        error={error}
+        error={new Error(message)}
+        errorType={errorType}
         resetError={() => window.location.reload()}
         showDetails={import.meta.env.DEV}
         statusPageUrl={statusPageUrl}

--- a/server/error-utils.test.ts
+++ b/server/error-utils.test.ts
@@ -7,98 +7,98 @@ import {
   detectErrorType,
   ErrorType,
   getUserFriendlyErrorMessage,
+  isSafeHttpUrl,
   withRetry,
 } from './error-utils'
 
 describe('detectErrorType', () => {
   describe('Network Errors', () => {
     it('should detect fetch failed errors', () => {
-      const error = new Error('fetch failed')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+      expect(detectErrorType(new Error('fetch failed'))).toBe(ErrorType.NETWORK)
     })
 
     it('should detect ECONNREFUSED errors', () => {
-      const error = new Error('connect ECONNREFUSED 127.0.0.1:3000')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+      expect(detectErrorType(new Error('connect ECONNREFUSED 127.0.0.1:3000'))).toBe(ErrorType.NETWORK)
     })
 
     it('should detect ETIMEDOUT errors', () => {
-      const error = new Error('request ETIMEDOUT')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+      expect(detectErrorType(new Error('request ETIMEDOUT'))).toBe(ErrorType.NETWORK)
     })
 
     it('should detect DNS errors', () => {
-      const error = new Error('getaddrinfo ENOTFOUND api.example.com')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+      expect(detectErrorType(new Error('getaddrinfo ENOTFOUND api.example.com'))).toBe(ErrorType.NETWORK)
     })
 
-    it('should detect timeout errors', () => {
-      const error = new Error('Request timeout')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+    it('should detect request timeout phrase', () => {
+      expect(detectErrorType(new Error('Request timeout'))).toBe(ErrorType.NETWORK)
     })
 
     it('should detect connection refused errors', () => {
-      const error = new Error('Connection refused by server')
-      expect(detectErrorType(error)).toBe(ErrorType.NETWORK)
+      expect(detectErrorType(new Error('Connection refused by server'))).toBe(ErrorType.NETWORK)
+    })
+
+    it('should detect socket hang up', () => {
+      expect(detectErrorType(new Error('socket hang up'))).toBe(ErrorType.NETWORK)
+    })
+  })
+
+  describe('Pattern tightening (regression guard)', () => {
+    // Previously these would false-positive as NETWORK because of substring matches
+    // on the bare word "network" or "timeout".
+    it('should NOT classify "network policy violation" as NETWORK', () => {
+      expect(detectErrorType(new Error('network policy violation'))).toBe(ErrorType.UNKNOWN)
+    })
+
+    it('should NOT classify "timeout period" as NETWORK', () => {
+      expect(detectErrorType(new Error('The timeout period for this operation has elapsed'))).toBe(ErrorType.UNKNOWN)
     })
   })
 
   describe('Server Errors', () => {
     it('should detect 500 status code', () => {
-      const error = { response: { status: 500 }, message: 'Server Error' }
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType({ response: { status: 500 }, message: 'Server Error' })).toBe(ErrorType.SERVER)
     })
 
     it('should detect 502 Bad Gateway', () => {
-      const error = { response: { status: 502 }, message: 'Bad Gateway' }
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType({ response: { status: 502 }, message: 'Bad Gateway' })).toBe(ErrorType.SERVER)
     })
 
     it('should detect 503 Service Unavailable', () => {
-      const error = { response: { status: 503 }, message: 'Service Unavailable' }
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType({ response: { status: 503 }, message: 'Service Unavailable' })).toBe(ErrorType.SERVER)
     })
 
     it('should detect 504 Gateway Timeout', () => {
-      const error = { response: { status: 504 }, message: 'Gateway Timeout' }
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType({ response: { status: 504 }, message: 'Gateway Timeout' })).toBe(ErrorType.SERVER)
     })
 
     it('should detect internal server error in message', () => {
-      const error = new Error('Internal Server Error occurred')
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType(new Error('Internal Server Error occurred'))).toBe(ErrorType.SERVER)
     })
 
     it('should detect status property directly on error object', () => {
-      const error = { status: 500, message: 'Server Error' }
-      expect(detectErrorType(error)).toBe(ErrorType.SERVER)
+      expect(detectErrorType({ status: 500, message: 'Server Error' })).toBe(ErrorType.SERVER)
     })
   })
 
   describe('Client Errors', () => {
     it('should detect 400 Bad Request', () => {
-      const error = { response: { status: 400 }, message: 'Bad Request' }
-      expect(detectErrorType(error)).toBe(ErrorType.CLIENT)
+      expect(detectErrorType({ response: { status: 400 }, message: 'Bad Request' })).toBe(ErrorType.CLIENT)
     })
 
     it('should detect 401 Unauthorized', () => {
-      const error = { response: { status: 401 }, message: 'Unauthorized' }
-      expect(detectErrorType(error)).toBe(ErrorType.CLIENT)
+      expect(detectErrorType({ response: { status: 401 }, message: 'Unauthorized' })).toBe(ErrorType.CLIENT)
     })
 
     it('should detect 403 Forbidden', () => {
-      const error = { response: { status: 403 }, message: 'Forbidden' }
-      expect(detectErrorType(error)).toBe(ErrorType.CLIENT)
+      expect(detectErrorType({ response: { status: 403 }, message: 'Forbidden' })).toBe(ErrorType.CLIENT)
     })
 
     it('should detect 404 Not Found', () => {
-      const error = { response: { status: 404 }, message: 'Not Found' }
-      expect(detectErrorType(error)).toBe(ErrorType.CLIENT)
+      expect(detectErrorType({ response: { status: 404 }, message: 'Not Found' })).toBe(ErrorType.CLIENT)
     })
 
     it('should detect status property directly on error object', () => {
-      const error = { status: 404, message: 'Not Found' }
-      expect(detectErrorType(error)).toBe(ErrorType.CLIENT)
+      expect(detectErrorType({ status: 404, message: 'Not Found' })).toBe(ErrorType.CLIENT)
     })
   })
 
@@ -112,54 +112,74 @@ describe('detectErrorType', () => {
     })
 
     it('should return UNKNOWN for generic errors', () => {
-      const error = new Error('Something went wrong')
-      expect(detectErrorType(error)).toBe(ErrorType.UNKNOWN)
+      expect(detectErrorType(new Error('Something went wrong'))).toBe(ErrorType.UNKNOWN)
     })
 
     it('should return UNKNOWN for non-error objects', () => {
       expect(detectErrorType({ foo: 'bar' })).toBe(ErrorType.UNKNOWN)
     })
+
+    it('should return UNKNOWN for non-numeric status', () => {
+      expect(detectErrorType({ response: { status: 'oops' } })).toBe(ErrorType.UNKNOWN)
+    })
   })
 })
 
 describe('getUserFriendlyErrorMessage', () => {
-  it('should return network error message', () => {
-    const error = new Error('fetch failed')
-    const message = getUserFriendlyErrorMessage(error)
+  it('returns network error message', () => {
+    const message = getUserFriendlyErrorMessage(new Error('fetch failed'))
     expect(message).toContain('Unable to connect')
     expect(message).toContain('internet connection')
   })
 
-  it('should return server error message without status page', () => {
-    const error = { response: { status: 500 }, message: 'Server Error' }
-    const message = getUserFriendlyErrorMessage(error)
+  it('returns server error message', () => {
+    const message = getUserFriendlyErrorMessage({ response: { status: 500 } })
     expect(message).toContain('servers are experiencing issues')
-    expect(message).not.toContain('status page')
   })
 
-  it('should return server error message with status page link', () => {
-    const error = { response: { status: 503 }, message: 'Service Unavailable' }
-    const statusPageUrl = 'https://status.example.com'
-    const message = getUserFriendlyErrorMessage(error, statusPageUrl)
-    expect(message).toContain('servers are experiencing issues')
-    expect(message).toContain('status page')
-    expect(message).toContain(statusPageUrl)
-    expect(message).toContain('target="_blank"')
-    expect(message).toContain('rel="noopener noreferrer"')
-  })
-
-  it('should return client error message', () => {
-    const error = { response: { status: 404 }, message: 'Not Found' }
-    const message = getUserFriendlyErrorMessage(error)
+  it('returns client error message', () => {
+    const message = getUserFriendlyErrorMessage({ response: { status: 404 } })
     expect(message).toContain('not available')
     expect(message).toContain('moved or deleted')
   })
 
-  it('should return generic error message for unknown errors', () => {
-    const error = new Error('Unexpected error')
-    const message = getUserFriendlyErrorMessage(error)
+  it('returns generic error message for unknown errors', () => {
+    const message = getUserFriendlyErrorMessage(new Error('Unexpected error'))
     expect(message).toContain('Something went wrong')
     expect(message).toContain('try again')
+  })
+
+  it('never embeds HTML (messages are plain text)', () => {
+    const message = getUserFriendlyErrorMessage({ response: { status: 500 } })
+    expect(message).not.toContain('<')
+    expect(message).not.toContain('href=')
+  })
+})
+
+describe('isSafeHttpUrl', () => {
+  it('accepts https URLs', () => {
+    expect(isSafeHttpUrl('https://status.example.com')).toBe(true)
+  })
+
+  it('accepts http URLs', () => {
+    expect(isSafeHttpUrl('http://status.example.com')).toBe(true)
+  })
+
+  it('rejects javascript: URLs', () => {
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects data: URLs', () => {
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+  })
+
+  it('rejects file: URLs', () => {
+    expect(isSafeHttpUrl('file:///etc/passwd')).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(isSafeHttpUrl('not a url')).toBe(false)
+    expect(isSafeHttpUrl('')).toBe(false)
   })
 })
 
@@ -188,14 +208,8 @@ describe('withRetry', () => {
       .mockRejectedValueOnce(new Error('ETIMEDOUT'))
       .mockResolvedValue('success')
 
-    const promise = withRetry(mockFn, {
-      maxAttempts: 3,
-      baseDelayMs: 100,
-    })
-
-    // Fast-forward through delays
+    const promise = withRetry(mockFn, { maxAttempts: 3, baseDelayMs: 100 })
     await vi.runAllTimersAsync()
-
     const result = await promise
 
     expect(result).toBe('success')
@@ -209,14 +223,8 @@ describe('withRetry', () => {
       .mockRejectedValueOnce({ response: { status: 503 } })
       .mockResolvedValue('success')
 
-    const promise = withRetry(mockFn, {
-      maxAttempts: 3,
-      baseDelayMs: 100,
-    })
-
-    // Fast-forward through delays
+    const promise = withRetry(mockFn, { maxAttempts: 3, baseDelayMs: 100 })
     await vi.runAllTimersAsync()
-
     const result = await promise
 
     expect(result).toBe('success')
@@ -226,10 +234,7 @@ describe('withRetry', () => {
   it('should NOT retry on client errors', async () => {
     const mockFn = vi.fn().mockRejectedValue({ response: { status: 404 } })
 
-    await expect(
-      withRetry(mockFn, { maxAttempts: 3 })
-    ).rejects.toEqual({ response: { status: 404 } })
-
+    await expect(withRetry(mockFn, { maxAttempts: 3 })).rejects.toEqual({ response: { status: 404 } })
     expect(mockFn).toHaveBeenCalledTimes(1)
   })
 
@@ -237,98 +242,80 @@ describe('withRetry', () => {
     const networkError = new Error('fetch failed')
     const mockFn = vi.fn().mockRejectedValue(networkError)
 
-    // Start the retry operation and handle timers concurrently
-    const promise = withRetry(mockFn, {
-      maxAttempts: 3,
-      baseDelayMs: 100,
-    })
+    const promise = withRetry(mockFn, { maxAttempts: 3, baseDelayMs: 100 })
 
-    // Run all timers and wait for rejection concurrently
-    const [rejection] = await Promise.allSettled([
-      promise,
-      vi.runAllTimersAsync(),
-    ])
+    const [rejection] = await Promise.allSettled([promise, vi.runAllTimersAsync()])
 
     expect(rejection.status).toBe('rejected')
-    expect(rejection.reason).toEqual(networkError)
+    expect(rejection.status === 'rejected' && rejection.reason).toEqual(networkError)
     expect(mockFn).toHaveBeenCalledTimes(3)
   })
 
-  it('should use exponential backoff', async () => {
+  it('should cap delay at maxDelayMs (full jitter returns max when random=1)', async () => {
+    // Force Math.random() = 0.9999... so jitter returns (essentially) the full cap.
+    // This pins the delay to maxDelayMs and lets us assert the upper bound.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9999999)
+
     const mockFn = vi
       .fn()
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockResolvedValue('success')
-
-    const promise = withRetry(mockFn, {
-      maxAttempts: 3,
-      baseDelayMs: 1000,
-      maxDelayMs: 10000,
-    })
-
-    // First attempt - immediate
-    expect(mockFn).toHaveBeenCalledTimes(1)
-
-    // Advance by ~1 second (first retry delay)
-    await vi.advanceTimersByTimeAsync(1200)
-    expect(mockFn).toHaveBeenCalledTimes(2)
-
-    // Advance by ~2 seconds (second retry delay - exponential)
-    await vi.advanceTimersByTimeAsync(2400)
-    expect(mockFn).toHaveBeenCalledTimes(3)
-
-    const result = await promise
-    expect(result).toBe('success')
-  })
-
-  it('should respect custom shouldRetry function', async () => {
-    const mockFn = vi.fn().mockRejectedValue(new Error('custom error'))
-
-    const customShouldRetry = vi.fn().mockReturnValue(false)
-
-    await expect(
-      withRetry(mockFn, {
-        maxAttempts: 3,
-        shouldRetry: customShouldRetry,
-      })
-    ).rejects.toThrow('custom error')
-
-    expect(mockFn).toHaveBeenCalledTimes(1)
-    expect(customShouldRetry).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'custom error' }),
-      0
-    )
-  })
-
-  it('should cap delays at maxDelayMs', async () => {
-    const mockFn = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockRejectedValueOnce(new Error('network error'))
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockRejectedValueOnce(new Error('fetch failed'))
       .mockResolvedValue('success')
 
     const promise = withRetry(mockFn, {
       maxAttempts: 4,
       baseDelayMs: 1000,
-      maxDelayMs: 2500, // Cap at 2.5 seconds
+      maxDelayMs: 2500,
     })
 
-    // First retry: ~1s
-    await vi.advanceTimersByTimeAsync(1200)
+    // Attempt 1 fires immediately.
+    expect(mockFn).toHaveBeenCalledTimes(1)
+
+    // Exponential caps: 1000, 2000, 2500. With random=0.9999 delay ≈ cap.
+    await vi.advanceTimersByTimeAsync(1000)
     expect(mockFn).toHaveBeenCalledTimes(2)
 
-    // Second retry: ~2s (capped from 2s)
-    await vi.advanceTimersByTimeAsync(2400)
+    await vi.advanceTimersByTimeAsync(2000)
     expect(mockFn).toHaveBeenCalledTimes(3)
 
-    // Third retry: ~2.5s (capped from 4s)
-    await vi.advanceTimersByTimeAsync(3000)
+    await vi.advanceTimersByTimeAsync(2500)
     expect(mockFn).toHaveBeenCalledTimes(4)
 
     const result = await promise
     expect(result).toBe('success')
+    randomSpy.mockRestore()
+  })
+
+  it('should use zero delay when random=0 (full jitter lower bound)', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue('success')
+
+    const promise = withRetry(mockFn, { maxAttempts: 2, baseDelayMs: 1000 })
+
+    // Delay of 0 means the retry schedules immediately — one microtask turn is enough.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockFn).toHaveBeenCalledTimes(2)
+
+    const result = await promise
+    expect(result).toBe('success')
+    randomSpy.mockRestore()
+  })
+
+  it('should respect custom shouldRetry function', async () => {
+    const mockFn = vi.fn().mockRejectedValue(new Error('custom error'))
+    const customShouldRetry = vi.fn().mockReturnValue(false)
+
+    await expect(
+      withRetry(mockFn, { maxAttempts: 3, shouldRetry: customShouldRetry })
+    ).rejects.toThrow('custom error')
+
+    expect(mockFn).toHaveBeenCalledTimes(1)
+    expect(customShouldRetry).toHaveBeenCalledWith(expect.objectContaining({ message: 'custom error' }))
   })
 
   it('should handle promises that resolve immediately', async () => {

--- a/server/error-utils.ts
+++ b/server/error-utils.ts
@@ -1,17 +1,12 @@
 /**
  * Error handling utilities for graceful degradation when CMS is unreachable.
  *
- * This module provides:
- * - Error type detection (network vs server errors)
- * - Retry logic with exponential backoff
- * - User-friendly error categorization
+ * Provides error type detection, retry logic with exponential backoff,
+ * and user-friendly message generation.
  */
 
 import * as Sentry from '@sentry/react'
 
-/**
- * Error types for better error handling and user messaging
- */
 export enum ErrorType {
   /** Network connectivity issues (DNS, timeout, connection refused) */
   NETWORK = 'NETWORK',
@@ -23,9 +18,6 @@ export enum ErrorType {
   UNKNOWN = 'UNKNOWN',
 }
 
-/**
- * Configuration for retry behavior
- */
 export interface RetryConfig {
   /** Maximum number of retry attempts (default: 3) */
   maxAttempts?: number
@@ -34,83 +26,76 @@ export interface RetryConfig {
   /** Maximum delay in milliseconds (default: 10000ms) */
   maxDelayMs?: number
   /** Function to determine if error should be retried (default: retry network/server errors only) */
-  shouldRetry?: (error: unknown, attempt: number) => boolean
+  shouldRetry?: (error: unknown) => boolean
 }
 
-/**
- * Default retry configuration
- */
 const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
   maxAttempts: 3,
   baseDelayMs: 1000,
   maxDelayMs: 10000,
-  shouldRetry: (error: unknown, attempt: number) => {
+  shouldRetry: (error: unknown) => {
     const errorType = detectErrorType(error)
-    // Retry network and server errors, but not client errors
     return errorType === ErrorType.NETWORK || errorType === ErrorType.SERVER
   },
 }
 
 /**
- * Detects the type of error for better handling and messaging.
- *
- * @param error - The error to classify
- * @returns The error type classification
+ * Shape of HTTP-like errors we can inspect for status codes.
+ */
+interface HttpErrorLike {
+  response?: { status?: unknown }
+  status?: unknown
+}
+
+function readStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const e = error as HttpErrorLike
+  const responseStatus = e.response?.status
+  if (typeof responseStatus === 'number') return responseStatus
+  if (typeof e.status === 'number') return e.status
+  return undefined
+}
+
+// Error code patterns matched as substrings (codes like ECONNREFUSED can appear
+// mid-token, e.g. "connect ECONNREFUSED 127.0.0.1").
+const NETWORK_CODE_PATTERNS = [
+  'econnrefused',
+  'econnreset',
+  'enotfound',
+  'etimedout',
+  'eai_again',
+  'getaddrinfo',
+]
+
+// English phrases matched at word boundaries to avoid false positives like
+// "network policy violation" or "timeout: operation completed successfully".
+const NETWORK_PHRASE_PATTERN = /\b(fetch failed|network error|connection refused|connection reset|dns|request timeout|request timed out|socket hang up)\b/i
+
+const SERVER_PHRASE_PATTERN = /\b(internal server error|bad gateway|service unavailable|gateway timeout|50[0-9])\b/i
+
+/**
+ * Classifies an error as NETWORK, SERVER, CLIENT, or UNKNOWN.
  */
 export function detectErrorType(error: unknown): ErrorType {
   if (!error) return ErrorType.UNKNOWN
 
-  const errorMessage = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  // HTTP status codes take precedence — they're unambiguous.
+  const status = readStatus(error)
+  if (status !== undefined) {
+    if (status >= 500) return ErrorType.SERVER
+    if (status >= 400) return ErrorType.CLIENT
+  }
 
-  // Network connectivity issues
-  const networkPatterns = [
-    'fetch failed',
-    'network',
-    'econnrefused',
-    'enotfound',
-    'etimedout',
-    'connection refused',
-    'dns',
-    'timeout',
-    'getaddrinfo',
-  ]
+  const errorMessage = error instanceof Error ? error.message : String(error)
+  const lower = errorMessage.toLowerCase()
 
-  if (networkPatterns.some(pattern => errorMessage.includes(pattern))) {
+  if (NETWORK_CODE_PATTERNS.some(code => lower.includes(code))) {
     return ErrorType.NETWORK
   }
-
-  // Check for GraphQL/HTTP error responses
-  if (typeof error === 'object' && error !== null) {
-    const errorObj = error as any
-
-    // GraphQL errors from graphql-request
-    if (errorObj.response?.status) {
-      const status = errorObj.response.status
-      if (status >= 500) return ErrorType.SERVER
-      if (status >= 400) return ErrorType.CLIENT
-    }
-
-    // Standard HTTP errors
-    if (errorObj.status) {
-      const status = errorObj.status
-      if (status >= 500) return ErrorType.SERVER
-      if (status >= 400) return ErrorType.CLIENT
-    }
+  if (NETWORK_PHRASE_PATTERN.test(errorMessage)) {
+    return ErrorType.NETWORK
   }
-
-  // Server error patterns in message
-  const serverPatterns = [
-    'internal server error',
-    '500',
-    '502',
-    '503',
-    '504',
-    'bad gateway',
-    'service unavailable',
-    'gateway timeout',
-  ]
-
-  if (serverPatterns.some(pattern => errorMessage.includes(pattern))) {
+  if (SERVER_PHRASE_PATTERN.test(errorMessage)) {
     return ErrorType.SERVER
   }
 
@@ -118,23 +103,16 @@ export function detectErrorType(error: unknown): ErrorType {
 }
 
 /**
- * Gets a user-friendly error message based on error type.
- *
- * @param error - The error to get a message for
- * @param statusPageUrl - Optional URL to external status page
- * @returns User-friendly error message
+ * Returns a plain-text, user-friendly message for an error.
+ * Callers that want to surface a status page link should render it separately
+ * as a React element — never interpolate URLs into HTML here.
  */
-export function getUserFriendlyErrorMessage(error: unknown, statusPageUrl?: string): string {
-  const errorType = detectErrorType(error)
-
-  switch (errorType) {
+export function getUserFriendlyErrorMessage(error: unknown): string {
+  switch (detectErrorType(error)) {
     case ErrorType.NETWORK:
       return 'Unable to connect to our content servers. Please check your internet connection and try again.'
     case ErrorType.SERVER:
-      const statusMsg = statusPageUrl
-        ? ` Check our <a href="${statusPageUrl}" target="_blank" rel="noopener noreferrer" class="text-teal-600 hover:text-teal-700 underline">status page</a> for updates.`
-        : ''
-      return `Our content servers are experiencing issues. We're working to resolve this.${statusMsg}`
+      return "Our content servers are experiencing issues. We're working to resolve this."
     case ErrorType.CLIENT:
       return 'This content is not available. It may have been moved or deleted.'
     default:
@@ -143,54 +121,44 @@ export function getUserFriendlyErrorMessage(error: unknown, statusPageUrl?: stri
 }
 
 /**
- * Sleeps for a specified duration (for retry delays).
- *
- * @param ms - Milliseconds to sleep
+ * True if the URL parses and uses an http(s) scheme. Used to gate rendering of
+ * externally-configured status page links to avoid `javascript:` / `data:` XSS.
  */
+export function isSafeHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**
- * Calculates exponential backoff delay with jitter.
- *
- * @param attempt - Current attempt number (0-indexed)
- * @param baseDelayMs - Base delay in milliseconds
- * @param maxDelayMs - Maximum delay cap
- * @returns Delay in milliseconds
+ * Exponential backoff with full jitter: delay is a random value in
+ * [0, min(base * 2^attempt, maxDelay)]. Spreads retries more evenly than
+ * additive jitter, per AWS "Exponential Backoff And Jitter".
  */
 function calculateBackoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
-  // Exponential: baseDelay * 2^attempt
   const exponentialDelay = baseDelayMs * Math.pow(2, attempt)
-
-  // Cap at maxDelay
   const cappedDelay = Math.min(exponentialDelay, maxDelayMs)
-
-  // Add jitter (random 0-20% variation) to avoid thundering herd
-  const jitter = cappedDelay * 0.2 * Math.random()
-
-  return Math.floor(cappedDelay + jitter)
+  return Math.floor(Math.random() * cappedDelay)
 }
 
 /**
  * Executes an async function with automatic retry and exponential backoff.
  *
- * This function will:
- * 1. Execute the provided async function
- * 2. On failure, determine if the error should be retried
- * 3. If retryable, wait with exponential backoff and retry
- * 4. Log all attempts to Sentry for monitoring
- * 5. Throw the last error if all retries are exhausted
- *
- * @param fn - Async function to execute with retry
- * @param config - Retry configuration
- * @returns Promise resolving to the function's result
- * @throws The last error encountered if all retries fail
+ * Retries are only attempted when `shouldRetry(error)` returns true. The default
+ * retries NETWORK and SERVER errors but not CLIENT or UNKNOWN. All attempts are
+ * reported to Sentry.
  *
  * @example
  * ```typescript
  * const data = await withRetry(
- *   async () => await client.request(query, variables),
+ *   () => client.request(query, variables),
  *   { maxAttempts: 3, baseDelayMs: 1000 }
  * )
  * ```
@@ -200,14 +168,11 @@ export async function withRetry<T>(
   config: RetryConfig = {}
 ): Promise<T> {
   const finalConfig = { ...DEFAULT_RETRY_CONFIG, ...config }
-  let lastError: unknown
 
   for (let attempt = 0; attempt < finalConfig.maxAttempts; attempt++) {
     try {
-      // Execute the function
       const result = await fn()
 
-      // If this was a retry that succeeded, log to Sentry
       if (attempt > 0) {
         console.log(`Request succeeded after ${attempt} ${attempt === 1 ? 'retry' : 'retries'}`)
         Sentry.captureMessage(`Request succeeded after ${attempt} retries`, {
@@ -218,20 +183,17 @@ export async function withRetry<T>(
 
       return result
     } catch (error) {
-      lastError = error
       const isLastAttempt = attempt === finalConfig.maxAttempts - 1
+      const errorType = detectErrorType(error)
 
-      // Check if we should retry
-      if (!isLastAttempt && finalConfig.shouldRetry(error, attempt)) {
+      if (!isLastAttempt && finalConfig.shouldRetry(error)) {
         const delay = calculateBackoffDelay(attempt, finalConfig.baseDelayMs, finalConfig.maxDelayMs)
-        const errorType = detectErrorType(error)
 
         console.log(
           `Request failed (attempt ${attempt + 1}/${finalConfig.maxAttempts}), ` +
           `error type: ${errorType}, retrying in ${delay}ms...`
         )
 
-        // Log retry to Sentry for monitoring
         Sentry.captureException(error, {
           level: 'warning',
           tags: {
@@ -239,40 +201,33 @@ export async function withRetry<T>(
             max_attempts: finalConfig.maxAttempts,
             error_type: errorType,
           },
-          extra: {
-            delay_ms: delay,
-            will_retry: true,
-          },
+          extra: { delay_ms: delay, will_retry: true },
         })
 
         await sleep(delay)
-      } else {
-        // Last attempt or non-retryable error
-        const errorType = detectErrorType(error)
-        console.error(
-          `Request failed permanently after ${attempt + 1} ${attempt === 0 ? 'attempt' : 'attempts'}, ` +
-          `error type: ${errorType}`
-        )
-
-        // Log final failure to Sentry
-        Sentry.captureException(error, {
-          level: 'error',
-          tags: {
-            retry_attempt: attempt + 1,
-            max_attempts: finalConfig.maxAttempts,
-            error_type: errorType,
-          },
-          extra: {
-            will_retry: false,
-            exhausted_retries: isLastAttempt,
-          },
-        })
-
-        throw error
+        continue
       }
+
+      console.error(
+        `Request failed permanently after ${attempt + 1} ${attempt === 0 ? 'attempt' : 'attempts'}, ` +
+        `error type: ${errorType}`
+      )
+
+      Sentry.captureException(error, {
+        level: 'error',
+        tags: {
+          retry_attempt: attempt + 1,
+          max_attempts: finalConfig.maxAttempts,
+          error_type: errorType,
+        },
+        extra: { will_retry: false, exhausted_retries: isLastAttempt },
+      })
+
+      throw error
     }
   }
 
-  // This should never be reached, but TypeScript needs it
-  throw lastError
+  // Unreachable: the loop either returns or throws on every iteration.
+  // TypeScript requires a terminator because it can't prove maxAttempts >= 1.
+  throw new Error('withRetry: unreachable')
 }

--- a/server/error-utils.ts
+++ b/server/error-utils.ts
@@ -169,6 +169,10 @@ export async function withRetry<T>(
 ): Promise<T> {
   const finalConfig = { ...DEFAULT_RETRY_CONFIG, ...config }
 
+  if (finalConfig.maxAttempts < 1) {
+    throw new Error(`withRetry: maxAttempts must be >= 1, got ${finalConfig.maxAttempts}`)
+  }
+
   for (let attempt = 0; attempt < finalConfig.maxAttempts; attempt++) {
     try {
       const result = await fn()

--- a/server/kv-cache.ts
+++ b/server/kv-cache.ts
@@ -178,7 +178,7 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
  *   fetchFn: async () => await client.request(query, variables)
  * })
  *
- * // For preview mode (bypass cache, still retries):
+ * // For preview mode (bypass cache and retries, fail fast):
  * const previewPage = await withCache({
  *   cacheKey: generateCacheKey('page', { id: '123', locale: 'en' }),
  *   ttl: CacheTTL.PAGE,
@@ -202,9 +202,10 @@ export async function withCache<T>(options: {
   // Get retry configuration (use provided config or defaults)
   const finalRetryConfig = retryConfig || DEFAULT_RETRY_CONFIG
 
-  // If bypass flag is set, skip cache but still use retry
+  // Preview/bypass mode: fail fast so editors see errors immediately rather
+  // than waiting through ~7s of exponential backoff.
   if (bypassCache) {
-    return await withRetry(fetchFn, finalRetryConfig)
+    return await fetchFn()
   }
 
   // Try to get from cache first


### PR DESCRIPTION
## Summary

Follow-up to the review of #8. Addresses issues found in the existing error-handling code on `main` without re-introducing the stale branch.

- **XSS fix**: `ErrorFallback` no longer uses `dangerouslySetInnerHTML`. Status page link renders as a real `<a>` element, gated by `isSafeHttpUrl()` so only `http:`/`https:` schemes render (blocks `javascript:`, `data:`, `file:`).
- **Plain-text messages**: `getUserFriendlyErrorMessage()` returns plain text; HTML can't be smuggled through it anymore.
- **Explicit errorType prop** on `ErrorFallback` replaces the `Object.assign(new Error, { response: { status: 404 } })` hack in `pages/_error/+Page.tsx`.
- **Fail-fast preview**: `kv-cache.ts` skips retry when `bypassCache=true` so editors see errors in ~1s instead of waiting ~7s through exponential backoff.
- **Tighter error classification**: replaced `as any` with a typed guard, split broad substring matching into word-boundary regex (no more false positives on "network policy violation" / "timeout period"), switched to full jitter per AWS guidance.
- **Tests**: 66 passing. Added `isSafeHttpUrl` coverage (6 schemes), regression tests for tightened pattern matching, deterministic jitter bounds via `Math.random` spy.

## Test plan

- [x] `pnpm test:run` — 66/66 pass
- [x] `pnpm exec tsc --noEmit` — no new errors (pre-existing `playwright.config.ts` unrelated)
- [ ] Manual: visit `/nonexistent` → "Content Not Found" with correct icon
- [ ] Manual: break `SAHAJCLOUD_API_KEY` → server-error messaging, status link renders only for `https://` values
- [ ] Manual: preview URL with bad key fails within ~1s (no retry wait)

Supersedes #8, which is being closed as stale — its core contribution (`server/error-utils.ts`, `vitest.config.ts`) already landed via #10 and the branch is ~30 files behind main with merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)