### PR TITLE
fix(ladle): dedupe React so audio player stories don't crash

### DIFF
--- a/.ladle/vite.config.ts
+++ b/.ladle/vite.config.ts
@@ -1,8 +1,20 @@
-import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [tailwindcss()],
   // Make PUBLIC__ prefixed environment variables available (same as main app)
   envPrefix: 'PUBLIC__',
-});
+  resolve: {
+    // Force a single React instance. Without this, Ladle's dev pipeline can
+    // bind react-use-audio-player (AudioPlayerProvider) to a separate copy of
+    // React, producing "Invalid hook call" / null-dispatcher errors in the
+    // Meditation/Audio player stories.
+    dedupe: ['react', 'react-dom'],
+  },
+  optimizeDeps: {
+    // Pre-bundle the audio player and its dep against the deduped React so the
+    // hooks share the renderer's dispatcher.
+    include: ['react-use-audio-player', 'howler'],
+  },
+})


### PR DESCRIPTION
## Problem

Loading the **Meditation Player** (and **Audio Player**) story in Ladle crashed with:

```
Invalid hook call. Hooks can only be called inside of the body of a function component.
TypeError: Cannot read properties of null (reading 'useRef')
    at react-use-audio-player ... AudioPlayerProvider
```

## Root cause

This is the classic **two-copies-of-React** symptom (null hook dispatcher). `react-use-audio-player`'s `AudioPlayerProvider` calls `useRef` internally, but in Ladle's Vite dev pipeline it bound to a *different* React module instance than the one driving the render, so its dispatcher was never populated.

There's only one `react` in `node_modules` — the duplication came from Ladle's Vite config. The main app dedupes React via the Vike preset, but `.ladle/vite.config.ts` was a bare config with no `dedupe`.

## Fix

Add `resolve.dedupe` + `optimizeDeps.include` to `.ladle/vite.config.ts` to force a single React instance and pre-bundle the audio player against it.

## Verification

Cleared the Vite dep cache, restarted Ladle, and loaded both stories in a real browser (Puppeteer):
- **Organisms / MeditationPlayer** — renders the full player UI (all four layout sections) instead of the ErrorBoundary fallback.
- **Molecules / Media / AudioPlayer** (same provider) — renders cleanly, no hook errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)