### PR TITLE
feat(meditations): background music + viewport-aware Dropdown popover

### DIFF
--- a/components/atoms/Dropdown/Dropdown.stories.tsx
+++ b/components/atoms/Dropdown/Dropdown.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = () => (
     <StorySection title="Sizes">
       <div className="flex flex-col gap-8">
         <StorySection title="Small" variant="subsection">
-          <Dropdown trigger={<Button variant="secondary">Small Dropdown</Button>} size="sm">
+          <Dropdown size="sm" trigger={<Button variant="secondary">Small Dropdown</Button>}>
             <DropdownItem href="#" size="sm">
               Menu Item 1
             </DropdownItem>
@@ -38,7 +38,7 @@ export const Default: Story = () => (
         </StorySection>
 
         <StorySection title="Medium (Default)" variant="subsection">
-          <Dropdown trigger={<Button variant="secondary">Medium Dropdown</Button>} size="md">
+          <Dropdown size="md" trigger={<Button variant="secondary">Medium Dropdown</Button>}>
             <DropdownItem href="#" size="md">
               Menu Item 1
             </DropdownItem>
@@ -52,7 +52,7 @@ export const Default: Story = () => (
         </StorySection>
 
         <StorySection title="Large" variant="subsection">
-          <Dropdown trigger={<Button variant="secondary">Large Dropdown</Button>} size="lg">
+          <Dropdown size="lg" trigger={<Button variant="secondary">Large Dropdown</Button>}>
             <DropdownItem href="#" size="lg">
               Menu Item 1
             </DropdownItem>
@@ -110,7 +110,7 @@ export const Default: Story = () => (
     <StorySection title="Alignment">
       <div className="flex flex-col gap-8">
         <StorySection title="Left Aligned (Default)" variant="subsection">
-          <Dropdown trigger={<Button variant="secondary">Left Aligned</Button>} align="left">
+          <Dropdown align="left" trigger={<Button variant="secondary">Left Aligned</Button>}>
             <DropdownItem href="#">This dropdown opens to the left</DropdownItem>
             <DropdownItem href="#">Perfect for left-side triggers</DropdownItem>
           </Dropdown>
@@ -118,7 +118,7 @@ export const Default: Story = () => (
 
         <StorySection title="Right Aligned" variant="subsection">
           <div className="flex justify-end">
-            <Dropdown trigger={<Button variant="secondary">Right Aligned</Button>} align="right">
+            <Dropdown align="right" trigger={<Button variant="secondary">Right Aligned</Button>}>
               <DropdownItem href="#">This dropdown opens to the right</DropdownItem>
               <DropdownItem href="#">Perfect for right-side triggers</DropdownItem>
             </Dropdown>
@@ -127,11 +127,69 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection title="Examples" inContext={true}>
+    <StorySection title="Placement">
+      <p className="mb-6 max-w-prose text-sm text-gray-600">
+        The panel opens on <code>side</code> and automatically <strong>flips</strong> to the
+        opposite side and <strong>shifts</strong> along the cross-axis to stay within the viewport
+        (open one near a screen edge to see it). Positioning is handled by Floating UI, and the
+        panel is portaled so it is never clipped by an ancestor&rsquo;s overflow.
+      </p>
+      <div className="flex flex-wrap gap-8">
+        {(['bottom', 'top', 'left', 'right'] as const).map((side) => (
+          <StorySection key={side} title={`side="${side}"`} variant="subsection">
+            <Dropdown
+              align="center"
+              side={side}
+              trigger={<Button variant="secondary">Open {side}</Button>}
+            >
+              <DropdownItem href="#">Menu Item 1</DropdownItem>
+              <DropdownItem href="#">Menu Item 2</DropdownItem>
+            </Dropdown>
+          </StorySection>
+        ))}
+      </div>
+    </StorySection>
+
+    <StorySection title="Dialog panel">
+      <p className="mb-6 max-w-prose text-sm text-gray-600">
+        With <code>role=&quot;dialog&quot;</code> the panel holds rich, non-menu content (as the
+        meditation player&rsquo;s audio controls do). Pair it with <code>ariaLabel</code> so the
+        popover is announced.
+      </p>
+      <Dropdown
+        align="center"
+        ariaLabel="Display settings"
+        role="dialog"
+        side="top"
+        trigger={
+          <Button icon={Cog6ToothIcon} variant="secondary">
+            Settings
+          </Button>
+        }
+      >
+        <div className="flex w-64 flex-col gap-3 p-4 text-left">
+          <p className="text-sm font-medium text-gray-700">Display options</p>
+          <label className="flex items-center justify-between gap-3 text-sm text-gray-600">
+            Brightness
+            <input
+              aria-label="Brightness"
+              className="h-1 flex-1 cursor-pointer appearance-none rounded-lg bg-gray-300 accent-teal-600"
+              max="1"
+              min="0"
+              step="0.01"
+              type="range"
+            />
+          </label>
+        </div>
+      </Dropdown>
+    </StorySection>
+
+    <StorySection inContext={true} title="Examples">
       <div className="flex flex-col gap-8">
         <div>
           <h3 className="text-sm font-semibold mb-4 text-gray-700">User Menu</h3>
           <Dropdown
+            align="right"
             trigger={
               <button className="flex items-center gap-2 px-4 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600">
                 <Icon icon={UserIcon} size="sm" />
@@ -139,18 +197,17 @@ export const Default: Story = () => (
                 <Icon icon={ChevronDownIcon} size="xs" />
               </button>
             }
-            align="right"
           >
-            <DropdownItem href="#" className="flex items-center gap-2">
+            <DropdownItem className="flex items-center gap-2" href="#">
               <Icon icon={UserIcon} size="sm" />
               Profile
             </DropdownItem>
-            <DropdownItem href="#" className="flex items-center gap-2">
+            <DropdownItem className="flex items-center gap-2" href="#">
               <Icon icon={Cog6ToothIcon} size="sm" />
               Settings
             </DropdownItem>
             <hr className="my-2" />
-            <DropdownItem href="#" className="flex items-center gap-2 text-error">
+            <DropdownItem className="flex items-center gap-2 text-error" href="#">
               <Icon icon={ArrowRightStartOnRectangleIcon} size="sm" />
               Logout
             </DropdownItem>
@@ -170,7 +227,7 @@ export const Default: Story = () => (
             <DropdownItem href="#">Duplicate</DropdownItem>
             <DropdownItem href="#">Archive</DropdownItem>
             <hr className="my-2" />
-            <DropdownItem href="#" className="text-error">
+            <DropdownItem className="text-error" href="#">
               Delete
             </DropdownItem>
           </Dropdown>

--- a/components/atoms/Dropdown/Dropdown.test.tsx
+++ b/components/atoms/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Dropdown } from './Dropdown'
+
+/**
+ * SSR markup assertions only. The panel is closed on first render (and portaled +
+ * positioned by Floating UI on the client), so we assert the trigger contract and
+ * that the panel content is absent until opened. Interactive behavior (open,
+ * placement, flip/shift, dismiss) is verified in Ladle / the browser.
+ */
+describe('Dropdown', () => {
+  it('renders the trigger as a focusable button and keeps the panel closed', () => {
+    const html = renderToStaticMarkup(
+      <Dropdown trigger={<span>Open</span>}>
+        <div>Panel content</div>
+      </Dropdown>,
+    )
+
+    expect(html).toContain('role="button"')
+    expect(html).toContain('aria-haspopup="menu"')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('tabindex="0"')
+    expect(html).toContain('Open')
+    // Closed by default → the panel (and its content) is not in the SSR output.
+    expect(html).not.toContain('Panel content')
+  })
+
+  it('does not turn the wrapper into a button in focus (autocomplete) mode', () => {
+    const html = renderToStaticMarkup(
+      <Dropdown openOnFocus role="listbox" trigger={<input aria-label="Search" />}>
+        <div>suggestions</div>
+      </Dropdown>,
+    )
+
+    // The inner control owns focus in this mode; the wrapper stays transparent.
+    expect(html).not.toContain('role="button"')
+    expect(html).not.toContain('tabindex="0"')
+    expect(html).toContain('aria-label="Search"')
+  })
+})

--- a/components/atoms/Dropdown/Dropdown.tsx
+++ b/components/atoms/Dropdown/Dropdown.tsx
@@ -226,11 +226,17 @@ export function Dropdown({
         onFocus: () => setIsOpen(true),
         onBlur: (event: React.FocusEvent<HTMLDivElement>) => {
           if (!closeOnBlur) return
-          // Keep open while focus moves into the panel (which lives in a portal,
-          // so check the floating element, not a DOM descendant of the trigger).
           const next = event.relatedTarget as Node | null
 
-          if (next && refs.floating.current?.contains(next)) return
+          // Only close on a *real* focus-out to an element outside both the
+          // trigger and the (portaled) panel — i.e. tab/focus moving away. A null
+          // relatedTarget means focus didn't land on a focusable element (e.g. a
+          // mouse press on non-focusable panel chrome, or a press on a suggestion
+          // before it focuses); that's not a focus-out, so leave dismissal of true
+          // outside presses to useDismiss and keep the panel open here.
+          if (!next) return
+          if (refs.floating.current?.contains(next)) return
+          if (refs.domReference.current?.contains(next)) return
           setIsOpen(false)
         },
       }
@@ -258,9 +264,11 @@ export function Dropdown({
         <FloatingPortal>
           <FloatingFocusManager
             context={context}
-            // Non-modal so background stays interactive; don't pull focus into the
-            // panel on open (preserves autocomplete typing / avoids focus jumps).
-            disabled={openOnFocus}
+            // Non-modal so the background stays interactive, and initialFocus={-1}
+            // so opening never pulls focus into the panel (preserves autocomplete
+            // typing). Keeping it enabled in focus mode inserts focus guards so Tab
+            // still flows from the trigger into the portaled panel. Don't return
+            // focus in focus mode — the trigger's own control already owns it.
             initialFocus={-1}
             modal={false}
             returnFocus={!openOnFocus}

--- a/components/atoms/Dropdown/Dropdown.tsx
+++ b/components/atoms/Dropdown/Dropdown.tsx
@@ -1,4 +1,31 @@
-import { ComponentProps, ReactNode, useEffect, useRef, useState } from 'react'
+import { ComponentProps, ReactNode, useState } from 'react'
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  size,
+  useClick,
+  useDismiss,
+  useRole,
+  useInteractions,
+  FloatingPortal,
+  FloatingFocusManager,
+  type Placement,
+} from '@floating-ui/react'
+
+/** Side of the trigger the panel opens on. */
+export type DropdownSide = 'top' | 'bottom' | 'left' | 'right'
+
+/**
+ * Alignment of the panel along the chosen side. `'left'`/`'right'` are kept as
+ * aliases for `'start'`/`'end'` so existing callers don't have to change.
+ */
+export type DropdownAlign = 'start' | 'center' | 'end' | 'left' | 'right'
+
+/** ARIA role applied to the panel (and wired into the trigger). */
+export type DropdownRole = 'menu' | 'dialog' | 'listbox'
 
 /**
  * Props for the Dropdown component
@@ -8,9 +35,30 @@ export interface DropdownProps {
   trigger: ReactNode
   /** The content to display in the dropdown */
   children: ReactNode
-  /** Alignment of the dropdown relative to trigger */
-  align?: 'left' | 'right'
-  /** Size variant controlling spacing and dimensions */
+  /**
+   * Side of the trigger the panel opens on. The panel automatically flips to the
+   * opposite side and shifts along the cross-axis to stay within the viewport.
+   * @default 'bottom'
+   */
+  side?: DropdownSide
+  /**
+   * Alignment of the panel along `side`. `'left'`/`'right'` are accepted as
+   * aliases for `'start'`/`'end'`.
+   * @default 'start'
+   */
+  align?: DropdownAlign
+  /**
+   * ARIA role for the panel — `'menu'` for action lists, `'listbox'` for
+   * autocomplete results, `'dialog'` for rich content panels.
+   * @default 'menu'
+   */
+  role?: DropdownRole
+  /**
+   * Accessible name for the panel. Recommended for `role="dialog"` panels so the
+   * popover is announced (e.g. "Audio settings").
+   */
+  ariaLabel?: string
+  /** Size variant controlling the panel's minimum width */
   size?: 'sm' | 'md' | 'lg'
   /** Additional CSS classes for the trigger wrapper */
   className?: string
@@ -18,11 +66,11 @@ export interface DropdownProps {
   isOpen?: boolean
   /** Callback when open state changes (for controlled mode) */
   onOpenChange?: (isOpen: boolean) => void
-  /** Open dropdown when trigger receives focus */
+  /** Open dropdown when the trigger (or a child of it) receives focus */
   openOnFocus?: boolean
-  /** Close dropdown when trigger loses focus */
+  /** Close dropdown when focus leaves the trigger and the panel */
   closeOnBlur?: boolean
-  /** Make dropdown width match trigger width (useful for autocomplete) */
+  /** Make the panel width match the trigger width (useful for autocomplete) */
   fullWidth?: boolean
 }
 
@@ -62,34 +110,65 @@ export function DropdownItem({
   )
 }
 
+const sizeWidthStyles = {
+  sm: 'min-w-56', // 224px (14rem)
+  md: 'min-w-64', // 256px (16rem)
+  lg: 'min-w-72', // 288px (18rem)
+}
+
+/** Map the friendly `side` + `align` props to a Floating UI placement. */
+function toPlacement(side: DropdownSide, align: DropdownAlign): Placement {
+  const alignment = align === 'left' ? 'start' : align === 'right' ? 'end' : align
+
+  return alignment === 'center' ? side : (`${side}-${alignment}` as Placement)
+}
+
 /**
- * A generic dropdown component with keyboard accessibility.
- * Handles click-outside and Escape key to close.
- * Supports both controlled and uncontrolled modes.
+ * A generic popover/dropdown with viewport-aware placement, keyboard
+ * accessibility, and click-outside / Escape dismissal.
+ *
+ * Positioning is handled by Floating UI: the panel opens on `side`, automatically
+ * **flips** to the opposite side when there isn't room, and **shifts** along the
+ * cross-axis to stay on screen. The panel is rendered in a portal, so it is never
+ * clipped by an ancestor's `overflow` or `@container`/transform context.
+ *
+ * Supports both click-to-open (default) and focus-to-open (`openOnFocus`, for
+ * autocomplete) modes, and controlled or uncontrolled open state.
  *
  * @example
- * Uncontrolled (default):
+ * // Uncontrolled menu (default)
  * <Dropdown trigger={<button>Open Menu</button>}>
  *   <DropdownItem href="/link1">Link 1</DropdownItem>
- *   <DropdownItem href="/link2">Link 2</DropdownItem>
  * </Dropdown>
  *
- * Controlled with focus behavior:
+ * @example
+ * // Rich panel opening above and centered on the trigger
+ * <Dropdown side="top" align="center" role="dialog" trigger={<IconButton />}>
+ *   <VolumeControls />
+ * </Dropdown>
+ *
+ * @example
+ * // Controlled autocomplete matching the input width
  * <Dropdown
  *   isOpen={isOpen}
  *   onOpenChange={setIsOpen}
- *   openOnFocus={true}
- *   fullWidth={true}
+ *   openOnFocus
+ *   closeOnBlur
+ *   fullWidth
+ *   role="listbox"
  *   trigger={<Input />}
  * >
- *   Autocomplete suggestions
+ *   {suggestions}
  * </Dropdown>
  */
 export function Dropdown({
   trigger,
   children,
-  align = 'left',
-  size = 'md',
+  side = 'bottom',
+  align = 'start',
+  role: roleProp = 'menu',
+  ariaLabel,
+  size: sizeVariant = 'md',
   className = '',
   isOpen: controlledIsOpen,
   onOpenChange,
@@ -98,112 +177,107 @@ export function Dropdown({
   fullWidth = false,
 }: DropdownProps) {
   const [internalIsOpen, setInternalIsOpen] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const triggerRef = useRef<HTMLDivElement>(null)
 
-  // Use controlled state if provided, otherwise use internal state
-  const isOpen = controlledIsOpen !== undefined ? controlledIsOpen : internalIsOpen
+  // Use controlled state if provided, otherwise internal state.
+  const isControlled = controlledIsOpen !== undefined
+  const isOpen = isControlled ? controlledIsOpen : internalIsOpen
   const setIsOpen = (value: boolean) => {
-    if (controlledIsOpen !== undefined) {
-      // Controlled mode - call callback
+    if (isControlled) {
       onOpenChange?.(value)
     } else {
-      // Uncontrolled mode - update internal state
       setInternalIsOpen(value)
     }
   }
 
-  const sizeWidthStyles = {
-    sm: 'min-w-56',  // 224px (14rem)
-    md: 'min-w-64',  // 256px (16rem)
-    lg: 'min-w-72',  // 288px (18rem)
-  }
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: toPlacement(side, align),
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(8),
+      flip({ padding: 8 }),
+      shift({ padding: 8 }),
+      // Match the panel width to the trigger (e.g. autocomplete under an input).
+      ...(fullWidth
+        ? [
+            size({
+              apply({ rects, elements }) {
+                elements.floating.style.width = `${rects.reference.width}px`
+              },
+            }),
+          ]
+        : []),
+    ],
+  })
 
-  // Close on click outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
+  // Click-to-open for the default mode. Focus-to-open is handled with React's
+  // (bubbling) onFocus/onBlur below, because Floating UI's useFocus binds native
+  // focus on the reference element, which does not fire when a *child* of the
+  // trigger (e.g. an autocomplete <input/>) is focused.
+  const click = useClick(context, { enabled: !openOnFocus })
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: roleProp })
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role])
+
+  const focusProps = openOnFocus
+    ? {
+        onFocus: () => setIsOpen(true),
+        onBlur: (event: React.FocusEvent<HTMLDivElement>) => {
+          if (!closeOnBlur) return
+          // Keep open while focus moves into the panel (which lives in a portal,
+          // so check the floating element, not a DOM descendant of the trigger).
+          const next = event.relatedTarget as Node | null
+
+          if (next && refs.floating.current?.contains(next)) return
+          setIsOpen(false)
+        },
       }
-    }
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [isOpen])
-
-  // Close on Escape key
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsOpen(false)
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape)
-      return () => document.removeEventListener('keydown', handleEscape)
-    }
-  }, [isOpen])
+    : {}
 
   return (
-    <div
-      ref={dropdownRef}
-      className={`relative ${fullWidth ? 'w-full' : 'inline-block'} ${className}`}
-    >
-      {/* Trigger */}
+    <>
       <div
-        ref={triggerRef}
-        onClick={() => {
-          if (!openOnFocus) {
-            setIsOpen(!isOpen)
-          }
-        }}
-        onFocus={() => {
-          if (openOnFocus) {
-            setIsOpen(true)
-          }
-        }}
-        onBlur={(e) => {
-          if (closeOnBlur) {
-            // Check if focus is moving to dropdown content
-            if (
-              dropdownRef.current &&
-              !dropdownRef.current.contains(e.relatedTarget as Node)
-            ) {
-              setIsOpen(false)
-            }
-          }
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            if (!openOnFocus) {
-              e.preventDefault()
-              setIsOpen(!isOpen)
-            }
-          }
-        }}
-        role="button"
-        tabIndex={0}
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        className={openOnFocus ? '' : 'cursor-pointer'}
+        ref={refs.setReference}
+        {...getReferenceProps({
+          ...focusProps,
+          // In click mode the wrapper is the focusable button (callers may keep
+          // their inner control out of the tab order). In focus mode the inner
+          // control (e.g. an Input) owns focus, so the wrapper stays transparent.
+          ...(openOnFocus ? {} : { role: 'button', tabIndex: 0 }),
+        })}
+        className={`${fullWidth ? 'w-full' : 'inline-block'} ${
+          openOnFocus ? '' : 'cursor-pointer'
+        } ${className}`}
       >
         {trigger}
       </div>
 
-      {/* Dropdown Content */}
       {isOpen && (
-        <div
-          className={`absolute top-full mt-2 z-50 bg-white border border-gray-200 shadow-lg ${
-            fullWidth ? 'w-full' : sizeWidthStyles[size]
-          } ${align === 'right' ? 'right-0' : 'left-0'}`}
-          role="menu"
-        >
-          {children}
-        </div>
+        <FloatingPortal>
+          <FloatingFocusManager
+            context={context}
+            // Non-modal so background stays interactive; don't pull focus into the
+            // panel on open (preserves autocomplete typing / avoids focus jumps).
+            disabled={openOnFocus}
+            initialFocus={-1}
+            modal={false}
+            returnFocus={!openOnFocus}
+          >
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps({ 'aria-label': ariaLabel })}
+              className={`z-50 rounded-lg border border-gray-200 bg-white shadow-xl ${
+                fullWidth ? '' : sizeWidthStyles[sizeVariant]
+              }`}
+            >
+              {children}
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
       )}
-    </div>
+    </>
   )
 }

--- a/components/atoms/Tooltip/Tooltip.stories.tsx
+++ b/components/atoms/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,58 @@
+import type { Story, StoryDefault } from '@ladle/react'
+import { Tooltip } from './Tooltip'
+import { Button } from '../Button'
+import { StorySection, StoryWrapper } from '../../ladle'
+import { ArrowPathRoundedSquareIcon } from '@heroicons/react/24/solid'
+
+export default {
+  title: 'Atoms / Interactive',
+} satisfies StoryDefault
+
+/**
+ * Tooltip showing a short hint on hover or keyboard focus. Viewport-aware
+ * (flips/shifts near edges) and portaled so it is never clipped.
+ */
+export const Default: Story = () => (
+  <StoryWrapper>
+    <StorySection title="Basic">
+      <p className="mb-6 max-w-prose text-sm text-gray-600">
+        Hover (or tab to) the trigger to reveal the tooltip. It appears after a short delay on hover
+        and immediately on keyboard focus.
+      </p>
+      <Tooltip label="Play a different background music track">
+        <Button
+          aria-label="Shuffle music track"
+          icon={ArrowPathRoundedSquareIcon}
+          size="md"
+          variant="ghost"
+        />
+      </Tooltip>
+    </StorySection>
+
+    <StorySection title="Sides">
+      <div className="flex flex-wrap gap-12 py-8">
+        {(['top', 'bottom', 'left', 'right'] as const).map((side) => (
+          <StorySection key={side} title={`side="${side}"`} variant="subsection">
+            <Tooltip label={`Tooltip on the ${side}`} side={side}>
+              <Button variant="secondary">{side}</Button>
+            </Tooltip>
+          </StorySection>
+        ))}
+      </div>
+    </StorySection>
+
+    <StorySection title="On text">
+      <p className="text-sm text-gray-600">
+        Tooltips also work on inline triggers, like{' '}
+        <Tooltip label="An explanatory note">
+          <span className="cursor-help underline decoration-dotted">this term</span>
+        </Tooltip>
+        .
+      </p>
+    </StorySection>
+
+    <div />
+  </StoryWrapper>
+)
+
+Default.storyName = 'Tooltip'

--- a/components/atoms/Tooltip/Tooltip.stories.tsx
+++ b/components/atoms/Tooltip/Tooltip.stories.tsx
@@ -19,7 +19,7 @@ export const Default: Story = () => (
         Hover (or tab to) the trigger to reveal the tooltip. It appears after a short delay on hover
         and immediately on keyboard focus.
       </p>
-      <Tooltip label="Play a different background music track">
+      <Tooltip label="Change background music track">
         <Button
           aria-label="Shuffle music track"
           icon={ArrowPathRoundedSquareIcon}

--- a/components/atoms/Tooltip/Tooltip.test.tsx
+++ b/components/atoms/Tooltip/Tooltip.test.tsx
@@ -11,7 +11,7 @@ import { Tooltip } from './Tooltip'
 describe('Tooltip', () => {
   it('renders the trigger and keeps the label hidden until hovered/focused', () => {
     const html = renderToStaticMarkup(
-      <Tooltip label="Play a different background music track">
+      <Tooltip label="Change background music track">
         <button aria-label="Shuffle music track">icon</button>
       </Tooltip>,
     )
@@ -19,6 +19,6 @@ describe('Tooltip', () => {
     expect(html).toContain('aria-label="Shuffle music track"')
     expect(html).toContain('icon')
     // Closed by default → the label is not in the SSR output.
-    expect(html).not.toContain('Play a different background music track')
+    expect(html).not.toContain('Change background music track')
   })
 })

--- a/components/atoms/Tooltip/Tooltip.test.tsx
+++ b/components/atoms/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Tooltip } from './Tooltip'
+
+/**
+ * SSR markup assertions only. The tooltip bubble is hidden on first render (it
+ * opens on hover/focus on the client and is portaled), so we assert the trigger
+ * renders and the bubble content is absent until shown. Hover/focus/placement
+ * are verified in Ladle / the browser.
+ */
+describe('Tooltip', () => {
+  it('renders the trigger and keeps the label hidden until hovered/focused', () => {
+    const html = renderToStaticMarkup(
+      <Tooltip label="Play a different background music track">
+        <button aria-label="Shuffle music track">icon</button>
+      </Tooltip>,
+    )
+
+    expect(html).toContain('aria-label="Shuffle music track"')
+    expect(html).toContain('icon')
+    // Closed by default → the label is not in the SSR output.
+    expect(html).not.toContain('Play a different background music track')
+  })
+})

--- a/components/atoms/Tooltip/Tooltip.tsx
+++ b/components/atoms/Tooltip/Tooltip.tsx
@@ -49,7 +49,7 @@ export interface TooltipProps {
  * still resolve to the child via event bubbling.
  *
  * @example
- * <Tooltip label="Play a different background music track">
+ * <Tooltip label="Change background music track">
  *   <Button icon={ArrowPathRoundedSquareIcon} aria-label="Shuffle music track" />
  * </Tooltip>
  */

--- a/components/atoms/Tooltip/Tooltip.tsx
+++ b/components/atoms/Tooltip/Tooltip.tsx
@@ -1,0 +1,100 @@
+import { ReactNode, useState } from 'react'
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  useHover,
+  useFocus,
+  useDismiss,
+  useRole,
+  useInteractions,
+  FloatingPortal,
+} from '@floating-ui/react'
+
+/** Side of the trigger the tooltip prefers (it flips to stay on screen). */
+export type TooltipSide = 'top' | 'bottom' | 'left' | 'right'
+
+export interface TooltipProps {
+  /** The short text shown on hover or keyboard focus of the trigger. */
+  label: ReactNode
+  /** The trigger element the tooltip describes (e.g. an icon button). */
+  children: ReactNode
+  /**
+   * Preferred side; the tooltip automatically flips to the opposite side and
+   * shifts to stay within the viewport.
+   * @default 'top'
+   */
+  side?: TooltipSide
+  /**
+   * Delay in milliseconds before the tooltip appears on hover (it hides
+   * immediately). Keyboard focus shows it without delay.
+   * @default 200
+   */
+  delay?: number
+  /** Additional classes for the inline trigger wrapper. */
+  className?: string
+}
+
+/**
+ * A small text tooltip that appears on hover or keyboard focus, built on
+ * Floating UI: it is viewport-aware (flips/shifts near edges), rendered in a
+ * portal so it is never clipped, and wired with `role="tooltip"` +
+ * `aria-describedby` for assistive tech. Dismisses on mouse-leave, blur, or
+ * Escape.
+ *
+ * The trigger is wrapped in an inline element rather than cloned, so it works
+ * with any child (including components that don't forward a ref); hover/focus
+ * still resolve to the child via event bubbling.
+ *
+ * @example
+ * <Tooltip label="Play a different background music track">
+ *   <Button icon={ArrowPathRoundedSquareIcon} aria-label="Shuffle music track" />
+ * </Tooltip>
+ */
+export function Tooltip({
+  label,
+  children,
+  side = 'top',
+  delay = 200,
+  className = '',
+}: TooltipProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: side,
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(6), flip({ padding: 8 }), shift({ padding: 8 })],
+  })
+
+  const hover = useHover(context, { move: false, delay: { open: delay, close: 0 } })
+  const focus = useFocus(context)
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: 'tooltip' })
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, dismiss, role])
+
+  return (
+    <>
+      <span ref={refs.setReference} {...getReferenceProps()} className={`inline-flex ${className}`}>
+        {children}
+      </span>
+
+      {isOpen && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="z-50 max-w-xs rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white shadow-lg"
+          >
+            {label}
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  )
+}

--- a/components/atoms/Tooltip/index.ts
+++ b/components/atoms/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip, type TooltipProps, type TooltipSide } from './Tooltip'

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -19,8 +19,10 @@ export type { LinkProps } from './Link'
 // Interactive
 export { Button } from './Button'
 export { Dropdown, DropdownItem } from './Dropdown'
+export { Tooltip } from './Tooltip'
 export type { ButtonProps } from './Button'
 export type { DropdownProps, DropdownItemProps } from './Dropdown'
+export type { TooltipProps, TooltipSide } from './Tooltip'
 
 // Form Inputs
 export { Input } from './Input'

--- a/components/organisms/MeditationPlayer/MeditationPlayer.stories.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.stories.tsx
@@ -20,6 +20,26 @@ export const Default: Story = () => {
     duration: 485, // 8:05
   }
 
+  // Background-music tracks (as returned by GET /api/meditations/:id/songs). Open
+  // the speaker popover to reveal the Voice + Music sliders and the shuffle button.
+  const sampleMusicTracks = [
+    {
+      id: 1,
+      title: 'Raag Durga',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+    },
+    {
+      id: 2,
+      title: 'Raag Bhairavi',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3',
+    },
+    {
+      id: 3,
+      title: 'Raag Yaman',
+      url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3',
+    },
+  ]
+
   const sampleFrames = [
     {
       timestamp: 0,
@@ -67,6 +87,17 @@ export const Default: Story = () => {
         <div className="w-full">
           <MeditationPlayer
             frames={sampleFrames}
+            subtitle="All pervading power"
+            track={sampleTrack}
+          />
+        </div>
+      </StorySection>
+
+      <StorySection title="With Background Music">
+        <div className="w-full">
+          <MeditationPlayer
+            frames={sampleFrames}
+            musicTracks={sampleMusicTracks}
             subtitle="All pervading power"
             track={sampleTrack}
           />

--- a/components/organisms/MeditationPlayer/MeditationPlayer.test.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MeditationPlayer } from './MeditationPlayer'
+import type { Track } from '../../molecules/AudioPlayer/types'
+
+const track: Track = {
+  url: 'https://example.com/voice.mp3',
+  title: 'Test Meditation',
+  credit: '',
+  creditURL: '',
+  thumbnailURL: '',
+  duration: 600,
+}
+
+const musicTrack = { id: 1, title: 'Raag Durga', url: 'https://example.com/music.mp3' }
+
+/**
+ * SSR markup assertions only. The audio-settings popover is closed on first
+ * render (and useEffect doesn't run under SSR), so the Voice/Music sliders and
+ * shuffle button aren't asserted here — those interactive affordances are
+ * verified visually in Ladle. What SSR can prove is the voice-only vs.
+ * with-music contract: the speaker trigger and the background-music <audio>.
+ */
+describe('MeditationPlayer audio controls', () => {
+  it('renders the audio-settings speaker button (replacing the inline volume slider)', () => {
+    const html = renderToStaticMarkup(<MeditationPlayer frames={[]} track={track} />)
+
+    expect(html).toContain('aria-label="Audio settings"')
+    // The old single control was labeled "Volume"; it should be gone.
+    expect(html).not.toContain('aria-label="Volume"')
+  })
+
+  it('renders a looping background-music <audio> with the track URL when songs exist', () => {
+    const html = renderToStaticMarkup(
+      <MeditationPlayer frames={[]} musicTracks={[musicTrack]} track={track} />,
+    )
+
+    expect(html).toContain('<audio')
+    expect(html).toContain('https://example.com/music.mp3')
+    expect(html).toContain('loop')
+  })
+
+  it('omits the background-music <audio> when there are no songs (voice-only)', () => {
+    const html = renderToStaticMarkup(<MeditationPlayer frames={[]} track={track} />)
+
+    expect(html).not.toContain('<audio')
+  })
+})

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -16,7 +16,7 @@ import {
   SpeakerXMarkIcon,
   ArrowPathRoundedSquareIcon,
 } from '@heroicons/react/24/solid'
-import { Avatar, Button, Link } from '../../atoms'
+import { Avatar, Button, Dropdown, Link } from '../../atoms'
 import { SimpleLeafSvg } from '../../atoms/svgs/SimpleLeafSvg'
 import { useCircularProgress } from './useCircularProgress'
 import { pickRandomIndex, pickNextRandomIndex } from './musicSelection'
@@ -217,11 +217,11 @@ interface AudioControlsProps {
 }
 
 /**
- * Speaker button that opens a popover centered above it, holding independent
- * Voice and Music volume sliders (each with its own mute toggle) and a shuffle
- * button for the music track. The Music row is hidden when no songs are
- * available. Closes on outside click or Escape; the speaker icon reflects the
- * voice mute state.
+ * Speaker button that opens a popover (above and centered on the trigger via the
+ * shared Dropdown atom, which keeps it on-screen near viewport edges) holding
+ * independent Voice and Music volume sliders — each with its own mute toggle —
+ * and a shuffle button for the music track. The Music row is hidden when no
+ * songs are available; the speaker icon reflects the voice mute state.
  */
 function AudioControls({
   voiceVolume,
@@ -237,83 +237,56 @@ function AudioControls({
   onToggleMusicMute,
   onShuffle,
 }: AudioControlsProps) {
-  const [isOpen, setIsOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-
-  // Close the popover on outside click or Escape while it's open.
-  useEffect(() => {
-    if (!isOpen) return
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsOpen(false)
-    }
-
-    document.addEventListener('mousedown', handlePointerDown)
-    document.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [isOpen])
-
   return (
-    <div ref={containerRef} className="relative inline-flex">
-      <Button
-        aria-expanded={isOpen}
-        aria-haspopup="true"
-        aria-label="Audio settings"
-        icon={voiceMuted ? SpeakerXMarkIcon : SpeakerWaveIcon}
-        size="lg"
-        variant="ghost"
-        onClick={() => setIsOpen((open) => !open)}
-      />
-
-      {isOpen && (
-        <div
+    <Dropdown
+      align="center"
+      ariaLabel="Audio settings"
+      role="dialog"
+      side="top"
+      trigger={
+        <Button
           aria-label="Audio settings"
-          className="absolute bottom-full left-1/2 z-50 mb-3 w-64 -translate-x-1/2 rounded-lg border border-gray-200 bg-white p-4 text-left shadow-xl"
-          role="dialog"
-        >
-          <div className="flex flex-col gap-4">
-            <VolumeRow
-              label="Voice"
-              muted={voiceMuted}
-              volume={voiceVolume}
-              onToggleMute={onToggleVoiceMute}
-              onVolumeChange={onVoiceVolumeChange}
-            />
+          icon={voiceMuted ? SpeakerXMarkIcon : SpeakerWaveIcon}
+          size="lg"
+          variant="ghost"
+          // The Dropdown wrapper is the focusable trigger (role=button,
+          // aria-expanded); keep this inner button out of the tab order.
+          tabIndex={-1}
+        />
+      }
+    >
+      <div className="flex w-64 flex-col gap-4 p-4 text-left">
+        <VolumeRow
+          label="Voice"
+          muted={voiceMuted}
+          volume={voiceVolume}
+          onToggleMute={onToggleVoiceMute}
+          onVolumeChange={onVoiceVolumeChange}
+        />
 
-            {hasMusic && (
-              <VolumeRow
-                action={
-                  canShuffle ? (
-                    <Button
-                      aria-label="Shuffle music track"
-                      icon={ArrowPathRoundedSquareIcon}
-                      size="md"
-                      variant="ghost"
-                      onClick={onShuffle}
-                    />
-                  ) : undefined
-                }
-                label="Music"
-                muted={musicMuted}
-                sublabel={musicTrackTitle}
-                volume={musicVolume}
-                onToggleMute={onToggleMusicMute}
-                onVolumeChange={onMusicVolumeChange}
-              />
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+        {hasMusic && (
+          <VolumeRow
+            action={
+              canShuffle ? (
+                <Button
+                  aria-label="Shuffle music track"
+                  icon={ArrowPathRoundedSquareIcon}
+                  size="md"
+                  variant="ghost"
+                  onClick={onShuffle}
+                />
+              ) : undefined
+            }
+            label="Music"
+            muted={musicMuted}
+            sublabel={musicTrackTitle}
+            volume={musicVolume}
+            onToggleMute={onToggleMusicMute}
+            onVolumeChange={onMusicVolumeChange}
+          />
+        )}
+      </div>
+    </Dropdown>
   )
 }
 

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -771,11 +771,19 @@ function MeditationPlayerInner({
                 musicVolume={musicVolume}
                 voiceMuted={state.isMuted}
                 voiceVolume={state.volume}
-                onMusicVolumeChange={setMusicVolume}
+                // Adjusting a channel's volume always unmutes it (idempotent), so
+                // a muted track can be brought back simply by moving its slider.
+                onMusicVolumeChange={(volume) => {
+                  setMusicVolume(volume)
+                  setMusicMuted(false)
+                }}
                 onShuffle={handleShuffle}
                 onToggleMusicMute={() => setMusicMuted((muted) => !muted)}
                 onToggleVoiceMute={controls.toggleMute}
-                onVoiceVolumeChange={controls.setVolume}
+                onVoiceVolumeChange={(volume) => {
+                  controls.setVolume(volume)
+                  controls.unmute()
+                }}
               />
             </div>
           </div>

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentProps,
   ReactNode,
+  useId,
   useMemo,
   useCallback,
   useEffect,
@@ -351,9 +352,25 @@ function MeditationPlayerInner({
   className = '',
   ...props
 }: MeditationPlayerProps) {
+  // react-use-audio-player caches Howl instances in a module-global map keyed by
+  // `src`, so multiple players on one page sharing a track URL (e.g. the Ladle
+  // story) would drive a single shared audio instance — pressing play on one
+  // plays them all, and unmounting one unloads the others. Give each player
+  // instance a unique audio URL via an ignored query param so every player owns
+  // an isolated Howl. The CMS server ignores the extra param; Howler strips the
+  // query before codec detection, so playback is unaffected. In production there
+  // is only ever one player per page, so this adds no real cost there.
+  const instanceId = useId()
+  const isolatedTrackUrl = useMemo(() => {
+    if (!track.url) return track.url
+    const separator = track.url.includes('?') ? '&' : '?'
+
+    return `${track.url}${separator}__player=${encodeURIComponent(instanceId)}`
+  }, [track.url, instanceId])
+
   // Core audio player hook (handles time polling, seek callbacks, track loading)
   const [state, controls] = useAudioPlayer({
-    url: track.url,
+    url: isolatedTrackUrl,
     onPlay,
     onPause,
     onPlaybackTimeUpdate,

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -1,11 +1,28 @@
-import { ComponentProps, useMemo, useCallback, useEffect, useEffectEvent, useRef } from 'react'
+import {
+  ComponentProps,
+  ReactNode,
+  useMemo,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react'
 import { AudioPlayerProvider } from 'react-use-audio-player'
-import { PlayIcon, PauseIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from '@heroicons/react/24/solid'
+import {
+  PlayIcon,
+  PauseIcon,
+  SpeakerWaveIcon,
+  SpeakerXMarkIcon,
+  ArrowPathRoundedSquareIcon,
+} from '@heroicons/react/24/solid'
 import { Avatar, Button, Link } from '../../atoms'
 import { SimpleLeafSvg } from '../../atoms/svgs/SimpleLeafSvg'
 import { useCircularProgress } from './useCircularProgress'
+import { pickRandomIndex, pickNextRandomIndex } from './musicSelection'
 import { useAudioPlayer } from '../../../hooks/audio'
 import type { Track } from '../../molecules/AudioPlayer/types'
+import type { MeditationSong } from '../../../server/cms-types'
 import founderImage from '../../../assets/smnd.webp'
 
 export type { Track } from '../../molecules/AudioPlayer/types'
@@ -14,8 +31,13 @@ export type { Track } from '../../molecules/AudioPlayer/types'
 const PROGRESS_RADIUS = 48
 const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS
 
+// Default background-music level — sits clearly under the guided voice (~1.0).
+const DEFAULT_MUSIC_VOLUME = 0.4
+
 // Placeholder image for when no frames are available (teal gradient)
-const PLACEHOLDER_IMAGE = 'data:image/svg+xml,' + encodeURIComponent(`
+const PLACEHOLDER_IMAGE =
+  'data:image/svg+xml,' +
+  encodeURIComponent(`
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
     <defs>
       <radialGradient id="g" cx="50%" cy="50%" r="70%">
@@ -34,6 +56,7 @@ function formatTime(seconds: number): string {
   if (!isFinite(seconds)) return '0:00'
   const mins = Math.floor(seconds / 60)
   const secs = Math.floor(seconds % 60)
+
   return `${mins}:${secs.toString().padStart(2, '0')}`
 }
 
@@ -73,6 +96,13 @@ export interface MeditationPlayerProps extends Omit<ComponentProps<'div'>, 'titl
    */
   frames: MeditationFrame[]
   /**
+   * Background-music tracks layered under the guided voice. One is auto-selected
+   * (with a shuffle control to switch). When empty, the player is voice-only and
+   * the Music slider / shuffle button are hidden.
+   * @default []
+   */
+  musicTracks?: MeditationSong[]
+  /**
    * Optional upsell message variant
    * - 'web': Link to more meditations on wemeditate.com
    * - 'app': Link to interactive meditations in the free app
@@ -102,6 +132,189 @@ export interface MeditationPlayerProps extends Omit<ComponentProps<'div'>, 'titl
    * Uses { timestamp, id } format so each command is unique, allowing repeated seeks to the same position.
    */
   seekTo?: { timestamp: number; id: number } | null
+}
+
+interface VolumeRowProps {
+  /** Visible label (e.g. "Voice", "Music"); also drives the control aria-labels. */
+  label: string
+  /** Optional secondary text shown next to the label (e.g. the music track title). */
+  sublabel?: string
+  /** Current volume 0–1. */
+  volume: number
+  /** Whether this channel is muted (slider reads 0 while muted). */
+  muted: boolean
+  onVolumeChange: (volume: number) => void
+  onToggleMute: () => void
+  /** Optional trailing control (e.g. the music shuffle button). */
+  action?: ReactNode
+}
+
+/**
+ * One labeled volume channel inside the audio popover: a mute toggle, a slider,
+ * and an optional trailing action. Used for both the Voice and Music channels so
+ * the two stay visually consistent and independently mutable.
+ */
+function VolumeRow({
+  label,
+  sublabel,
+  volume,
+  muted,
+  onVolumeChange,
+  onToggleMute,
+  action,
+}: VolumeRowProps) {
+  const labelLower = label.toLowerCase()
+
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-600">
+        {label}
+        {sublabel ? (
+          <span className="ml-1 font-normal normal-case text-gray-400">· {sublabel}</span>
+        ) : null}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          aria-label={muted ? `Unmute ${labelLower}` : `Mute ${labelLower}`}
+          icon={muted ? SpeakerXMarkIcon : SpeakerWaveIcon}
+          size="md"
+          variant="ghost"
+          onClick={onToggleMute}
+        />
+        <input
+          aria-label={`${label} volume`}
+          className="h-1 flex-1 cursor-pointer appearance-none rounded-lg bg-gray-300 accent-teal-600"
+          max="1"
+          min="0"
+          step="0.01"
+          type="range"
+          value={muted ? 0 : volume}
+          onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
+        />
+        {action}
+      </div>
+    </div>
+  )
+}
+
+interface AudioControlsProps {
+  /** Guided-voice volume (0–1) and mute state, plus their setters. */
+  voiceVolume: number
+  voiceMuted: boolean
+  onVoiceVolumeChange: (volume: number) => void
+  onToggleVoiceMute: () => void
+  /** Whether any background music is available — gates the Music row entirely. */
+  hasMusic: boolean
+  musicVolume: number
+  musicMuted: boolean
+  /** Title of the currently selected music track (shown beside the Music label). */
+  musicTrackTitle?: string
+  /** Whether shuffle is offered (only when more than one track exists). */
+  canShuffle: boolean
+  onMusicVolumeChange: (volume: number) => void
+  onToggleMusicMute: () => void
+  onShuffle: () => void
+}
+
+/**
+ * Speaker button that opens a popover centered above it, holding independent
+ * Voice and Music volume sliders (each with its own mute toggle) and a shuffle
+ * button for the music track. The Music row is hidden when no songs are
+ * available. Closes on outside click or Escape; the speaker icon reflects the
+ * voice mute state.
+ */
+function AudioControls({
+  voiceVolume,
+  voiceMuted,
+  onVoiceVolumeChange,
+  onToggleVoiceMute,
+  hasMusic,
+  musicVolume,
+  musicMuted,
+  musicTrackTitle,
+  canShuffle,
+  onMusicVolumeChange,
+  onToggleMusicMute,
+  onShuffle,
+}: AudioControlsProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // Close the popover on outside click or Escape while it's open.
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false)
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <Button
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-label="Audio settings"
+        icon={voiceMuted ? SpeakerXMarkIcon : SpeakerWaveIcon}
+        size="lg"
+        variant="ghost"
+        onClick={() => setIsOpen((open) => !open)}
+      />
+
+      {isOpen && (
+        <div
+          aria-label="Audio settings"
+          className="absolute bottom-full left-1/2 z-50 mb-3 w-64 -translate-x-1/2 rounded-lg border border-gray-200 bg-white p-4 text-left shadow-xl"
+          role="dialog"
+        >
+          <div className="flex flex-col gap-4">
+            <VolumeRow
+              label="Voice"
+              muted={voiceMuted}
+              volume={voiceVolume}
+              onToggleMute={onToggleVoiceMute}
+              onVolumeChange={onVoiceVolumeChange}
+            />
+
+            {hasMusic && (
+              <VolumeRow
+                action={
+                  canShuffle ? (
+                    <Button
+                      aria-label="Shuffle music track"
+                      icon={ArrowPathRoundedSquareIcon}
+                      size="md"
+                      variant="ghost"
+                      onClick={onShuffle}
+                    />
+                  ) : undefined
+                }
+                label="Music"
+                muted={musicMuted}
+                sublabel={musicTrackTitle}
+                volume={musicVolume}
+                onToggleMute={onToggleMusicMute}
+                onVolumeChange={onMusicVolumeChange}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 /**
@@ -153,6 +366,7 @@ function MeditationPlayerInner({
   track,
   subtitle,
   frames,
+  musicTracks = [],
   upsell,
   onPlay,
   onPause,
@@ -172,15 +386,71 @@ function MeditationPlayerInner({
 
   const effectiveDuration = state.duration > 0 ? state.duration : track.duration
 
+  // --- Background-music layer (optional, mixed under the guided voice) ---
+  const hasMusic = musicTracks.length > 0
+  const [musicIndex, setMusicIndex] = useState(0)
+  const [musicVolume, setMusicVolume] = useState(DEFAULT_MUSIC_VOLUME)
+  const [musicMuted, setMusicMuted] = useState(false)
+  const musicRef = useRef<HTMLAudioElement | null>(null)
+  const currentMusicTrack = hasMusic ? musicTracks[musicIndex] : undefined
+  const currentMusicUrl = currentMusicTrack?.url
+
+  // On mount, start from a random track. The endpoint already returns songs in
+  // randomized order (so SSR's docs[0] is itself random per cache window); this
+  // adds per-load variety on the client with no SSR/hydration mismatch, and runs
+  // before playback so the source swap is inaudible.
+  useEffect(() => {
+    if (musicTracks.length > 1) {
+      setMusicIndex(pickRandomIndex(musicTracks.length))
+    }
+  }, [musicTracks])
+
+  // Tie the music layer's play/pause to the meditation's. Re-runs when the track
+  // changes (shuffle) so the new source resumes if the meditation is playing.
+  useEffect(() => {
+    const el = musicRef.current
+
+    if (!el || !hasMusic) return
+
+    if (state.isPlaying) {
+      const playPromise = el.play()
+
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => {})
+      }
+    } else {
+      el.pause()
+    }
+  }, [state.isPlaying, hasMusic, currentMusicUrl])
+
+  // Keep the music element's volume/mute in sync, independent of the voice track.
+  useEffect(() => {
+    const el = musicRef.current
+
+    if (!el) return
+
+    el.volume = musicVolume
+    el.muted = musicMuted
+  }, [musicVolume, musicMuted, currentMusicUrl])
+
+  // Shuffle to a different random track (no immediate repeat); playback continues
+  // seamlessly via the sync effect above when the source changes.
+  const handleShuffle = useCallback(() => {
+    setMusicIndex((current) => pickNextRandomIndex(musicTracks.length, current))
+  }, [musicTracks.length])
+
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const lastAudioTimeRef = useRef(0)
   const lastFrameKeyRef = useRef<string | null>(null)
   const pendingSeekRef = useRef<number | null>(null)
 
   // Seek handler wrapped in useCallback for stable reference in useCircularProgress
-  const handleSeek = useCallback((time: number) => {
-    controls.seek(time)
-  }, [controls])
+  const handleSeek = useCallback(
+    (time: number) => {
+      controls.seek(time)
+    },
+    [controls],
+  )
 
   const applyExternalSeek = useEffectEvent((timestamp: number) => {
     controls.seek(timestamp)
@@ -216,6 +486,7 @@ function MeditationPlayerInner({
 
     // Find the last frame whose timestamp is less than or equal to display time
     let currentFrame = sortedFrames[0]
+
     for (const frame of sortedFrames) {
       if (frame.timestamp <= timeForSync) {
         currentFrame = frame
@@ -242,11 +513,13 @@ function MeditationPlayerInner({
   // Apply any pending seek once metadata is available
   useEffect(() => {
     const video = videoRef.current
+
     if (!video) return
 
     const handleLoadedMetadata = () => {
       if (pendingSeekRef.current !== null) {
         const target = pendingSeekRef.current
+
         pendingSeekRef.current = null
         try {
           video.currentTime = target
@@ -257,14 +530,17 @@ function MeditationPlayerInner({
     }
 
     video.addEventListener('loadedmetadata', handleLoadedMetadata)
+
     return () => video.removeEventListener('loadedmetadata', handleLoadedMetadata)
   }, [frameKey])
 
   // Keep video frames synchronized to the audio timeline
   useEffect(() => {
     const video = videoRef.current
+
     if (!video || currentMedia.type !== 'video') {
       lastFrameKeyRef.current = null
+
       return
     }
 
@@ -286,6 +562,7 @@ function MeditationPlayerInner({
 
     if (shouldSnap && Number.isFinite(targetTime)) {
       const diff = Math.abs(video.currentTime - targetTime)
+
       if (diff > 0.2) {
         if (video.readyState >= 1) {
           try {
@@ -301,6 +578,7 @@ function MeditationPlayerInner({
 
     if (state.isPlaying) {
       const playPromise = video.play()
+
       if (playPromise && typeof playPromise.catch === 'function') {
         playPromise.catch(() => {})
       }
@@ -335,10 +613,15 @@ function MeditationPlayerInner({
       className={`@container w-full h-full min-h-0 flex items-center justify-center bg-linear-to-b from-transparent via-teal-200/60 to-transparent ${className}`}
       {...props}
     >
+      {/* Background-music layer: a hidden, looping <audio> mixed under the guided
+          voice. Its play/pause, volume and mute are driven by the effects above. */}
+      {currentMusicTrack && (
+        <audio ref={musicRef} loop aria-hidden="true" preload="auto" src={currentMusicTrack.url} />
+      )}
+
       <div className="w-full max-w-7xl mx-auto px-6 py-4 flex-1 min-h-0 flex flex-col justify-center">
         {/* Unified responsive grid layout */}
         <div className="grid grid-cols-1 @4xl:grid-cols-12 gap-4 @4xl:items-center">
-
           {/* Label + Founder Info - Top on narrow, right on wide */}
           <div className="flex items-start justify-between @4xl:col-span-3 @4xl:flex-col @4xl:items-end @4xl:justify-start @4xl:order-3 @4xl:space-y-4">
             <div className="@4xl:hidden">
@@ -348,15 +631,17 @@ function MeditationPlayerInner({
             </div>
             <div className="flex flex-col items-end gap-2">
               <Avatar
-                src={founderImage}
                 alt="Shri Mataji Nirmala Devi"
-                size="xl"
                 className="@4xl:w-32 @4xl:h-32"
                 shape="circle"
+                size="xl"
+                src={founderImage}
               />
               <div className="text-right">
                 <p className="text-xs @4xl:text-sm font-medium text-gray-800">
-                  Shri Mataji<br />Nirmala Devi
+                  Shri Mataji
+                  <br />
+                  Nirmala Devi
                 </p>
                 <p className="text-xs @4xl:text-sm italic text-gray-600">founder</p>
               </div>
@@ -381,8 +666,8 @@ function MeditationPlayerInner({
                       loop
                       muted
                       playsInline
-                      draggable={false}
                       className="w-full h-full object-cover"
+                      draggable={false}
                     >
                       <source
                         src={currentMedia.src}
@@ -394,10 +679,10 @@ function MeditationPlayerInner({
                     </video>
                   ) : (
                     <img
-                      src={currentMedia.src}
                       alt={track.title}
-                      draggable={false}
                       className="w-full h-full object-cover"
+                      draggable={false}
+                      src={currentMedia.src}
                     />
                   )}
 
@@ -407,19 +692,21 @@ function MeditationPlayerInner({
                   )}
 
                   {/* Play/Pause Button - Fades in/out when paused or hovering */}
-                  <div className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${!state.isPlaying || state.isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none group-hover:opacity-100'}`}>
+                  <div
+                    className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${!state.isPlaying || state.isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none group-hover:opacity-100'}`}
+                  >
                     <Button
+                      aria-label={state.isPlaying ? 'Pause' : 'Play'}
+                      className="border-0 shadow-2xl"
                       icon={state.isPlaying ? PauseIcon : PlayIcon}
-                      variant="neutral"
+                      isLoading={state.isLoading}
                       shape="circular"
                       size="lg"
+                      variant="neutral"
                       onClick={(event) => {
                         event.stopPropagation()
                         handlePlayPause()
                       }}
-                      isLoading={state.isLoading}
-                      aria-label={state.isPlaying ? 'Pause' : 'Play'}
-                      className="border-0 shadow-2xl"
                     />
                   </div>
                 </div>
@@ -434,11 +721,11 @@ function MeditationPlayerInner({
                   <circle
                     cx="50"
                     cy="50"
-                    r={PROGRESS_RADIUS}
                     fill="none"
+                    r={PROGRESS_RADIUS}
                     stroke="#0f766e"
-                    strokeWidth="1.5"
                     strokeDasharray={`${(progressPercent / 100) * PROGRESS_CIRCUMFERENCE} ${PROGRESS_CIRCUMFERENCE}`}
+                    strokeWidth="1.5"
                   />
                 </svg>
 
@@ -476,7 +763,7 @@ function MeditationPlayerInner({
                   {formatTime(
                     timeDisplay === 'countdown'
                       ? Math.max(0, effectiveDuration - displayTime)
-                      : displayTime
+                      : displayTime,
                   )}
                 </span>
               </div>
@@ -491,33 +778,27 @@ function MeditationPlayerInner({
             </p>
 
             {subtitle && (
-              <p className="mb-4 text-sm sm:text-base font-light text-gray-700">
-                {subtitle}
-              </p>
+              <p className="mb-4 text-sm sm:text-base font-light text-gray-700">{subtitle}</p>
             )}
 
-            {/* Volume Control */}
-            <div className="flex items-center justify-center @4xl:justify-start gap-2">
-              <Button
-                icon={state.isMuted ? SpeakerXMarkIcon : SpeakerWaveIcon}
-                variant="ghost"
-                size="lg"
-                onClick={controls.toggleMute}
-                aria-label={state.isMuted ? 'Unmute' : 'Mute'}
-              />
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.01"
-                value={state.isMuted ? 0 : state.volume}
-                onChange={(e) => controls.setVolume(parseFloat(e.target.value))}
-                className="w-24 h-1 bg-gray-300 rounded-lg appearance-none cursor-pointer accent-teal-600"
-                aria-label="Volume"
+            {/* Audio controls: speaker button → popover with Voice + Music sliders */}
+            <div className="flex items-center justify-center @4xl:justify-start">
+              <AudioControls
+                canShuffle={musicTracks.length > 1}
+                hasMusic={hasMusic}
+                musicMuted={musicMuted}
+                musicTrackTitle={currentMusicTrack?.title || undefined}
+                musicVolume={musicVolume}
+                voiceMuted={state.isMuted}
+                voiceVolume={state.volume}
+                onMusicVolumeChange={setMusicVolume}
+                onShuffle={handleShuffle}
+                onToggleMusicMute={() => setMusicMuted((muted) => !muted)}
+                onToggleVoiceMute={controls.toggleMute}
+                onVoiceVolumeChange={controls.setVolume}
               />
             </div>
           </div>
-
         </div>
 
         {/* Upsell Message */}
@@ -527,14 +808,14 @@ function MeditationPlayerInner({
               {upsell === 'web' ? (
                 <>
                   Find more meditations on{' '}
-                  <Link href="https://wemeditate.com/meditations" variant="primary" external>
+                  <Link external href="https://wemeditate.com/meditations" variant="primary">
                     wemeditate.com
                   </Link>
                 </>
               ) : (
                 <>
                   Find interactive meditations with meditation music in our{' '}
-                  <Link href="https://wemeditate.com/app" variant="primary" external>
+                  <Link external href="https://wemeditate.com/app" variant="primary">
                     free app
                   </Link>
                 </>

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -392,7 +392,10 @@ function MeditationPlayerInner({
   const [musicVolume, setMusicVolume] = useState(DEFAULT_MUSIC_VOLUME)
   const [musicMuted, setMusicMuted] = useState(false)
   const musicRef = useRef<HTMLAudioElement | null>(null)
-  const currentMusicTrack = hasMusic ? musicTracks[musicIndex] : undefined
+  // Clamp the index so a track list that ever shrinks (without the index being
+  // reset yet) can't index past the end and silently drop the music layer.
+  const safeMusicIndex = hasMusic ? Math.min(musicIndex, musicTracks.length - 1) : 0
+  const currentMusicTrack = hasMusic ? musicTracks[safeMusicIndex] : undefined
   const currentMusicUrl = currentMusicTrack?.url
 
   // On mount, start from a random track. The endpoint already returns songs in

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -268,7 +268,7 @@ function AudioControls({
           <VolumeRow
             action={
               canShuffle ? (
-                <Tooltip label="Play a different background music track">
+                <Tooltip label="Change background music track">
                   <Button
                     aria-label="Shuffle music track"
                     icon={ArrowPathRoundedSquareIcon}

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -424,6 +424,8 @@ function MeditationPlayerInner({
   }, [state.isPlaying, hasMusic, currentMusicUrl])
 
   // Keep the music element's volume/mute in sync, independent of the voice track.
+  // No need to react to the track URL: an <audio> element preserves its volume
+  // and muted properties across a src swap, so this stays correct after a shuffle.
   useEffect(() => {
     const el = musicRef.current
 
@@ -431,7 +433,7 @@ function MeditationPlayerInner({
 
     el.volume = musicVolume
     el.muted = musicMuted
-  }, [musicVolume, musicMuted, currentMusicUrl])
+  }, [musicVolume, musicMuted])
 
   // Shuffle to a different random track (no immediate repeat); playback continues
   // seamlessly via the sync effect above when the source changes.
@@ -616,7 +618,7 @@ function MeditationPlayerInner({
       {/* Background-music layer: a hidden, looping <audio> mixed under the guided
           voice. Its play/pause, volume and mute are driven by the effects above. */}
       {currentMusicTrack && (
-        <audio ref={musicRef} loop aria-hidden="true" preload="auto" src={currentMusicTrack.url} />
+        <audio ref={musicRef} loop aria-hidden="true" preload="none" src={currentMusicTrack.url} />
       )}
 
       <div className="w-full max-w-7xl mx-auto px-6 py-4 flex-1 min-h-0 flex flex-col justify-center">

--- a/components/organisms/MeditationPlayer/MeditationPlayer.tsx
+++ b/components/organisms/MeditationPlayer/MeditationPlayer.tsx
@@ -16,7 +16,7 @@ import {
   SpeakerXMarkIcon,
   ArrowPathRoundedSquareIcon,
 } from '@heroicons/react/24/solid'
-import { Avatar, Button, Dropdown, Link } from '../../atoms'
+import { Avatar, Button, Dropdown, Link, Tooltip } from '../../atoms'
 import { SimpleLeafSvg } from '../../atoms/svgs/SimpleLeafSvg'
 import { useCircularProgress } from './useCircularProgress'
 import { pickRandomIndex, pickNextRandomIndex } from './musicSelection'
@@ -268,13 +268,15 @@ function AudioControls({
           <VolumeRow
             action={
               canShuffle ? (
-                <Button
-                  aria-label="Shuffle music track"
-                  icon={ArrowPathRoundedSquareIcon}
-                  size="md"
-                  variant="ghost"
-                  onClick={onShuffle}
-                />
+                <Tooltip label="Play a different background music track">
+                  <Button
+                    aria-label="Shuffle music track"
+                    icon={ArrowPathRoundedSquareIcon}
+                    size="md"
+                    variant="ghost"
+                    onClick={onShuffle}
+                  />
+                </Tooltip>
               ) : undefined
             }
             label="Music"

--- a/components/organisms/MeditationPlayer/musicSelection.test.ts
+++ b/components/organisms/MeditationPlayer/musicSelection.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { pickRandomIndex, pickNextRandomIndex } from './musicSelection'
+
+describe('pickRandomIndex', () => {
+  it('returns 0 for empty or single-item lists', () => {
+    expect(pickRandomIndex(0)).toBe(0)
+    expect(pickRandomIndex(1)).toBe(0)
+  })
+
+  it('maps the rng value across the full range', () => {
+    // rng just below each 1/length boundary selects the matching index.
+    expect(pickRandomIndex(4, () => 0)).toBe(0)
+    expect(pickRandomIndex(4, () => 0.26)).toBe(1)
+    expect(pickRandomIndex(4, () => 0.51)).toBe(2)
+    expect(pickRandomIndex(4, () => 0.99)).toBe(3)
+  })
+
+  it('stays within [0, length) for real Math.random', () => {
+    for (let i = 0; i < 1000; i++) {
+      const idx = pickRandomIndex(5)
+
+      expect(idx).toBeGreaterThanOrEqual(0)
+      expect(idx).toBeLessThan(5)
+    }
+  })
+})
+
+describe('pickNextRandomIndex', () => {
+  it('returns 0 for empty or single-item lists', () => {
+    expect(pickNextRandomIndex(0, 0)).toBe(0)
+    expect(pickNextRandomIndex(1, 0)).toBe(0)
+  })
+
+  it('never returns the current index when more than one track exists', () => {
+    for (let length = 2; length <= 6; length++) {
+      for (let current = 0; current < length; current++) {
+        for (let i = 0; i < 200; i++) {
+          const next = pickNextRandomIndex(length, current)
+
+          expect(next).not.toBe(current)
+          expect(next).toBeGreaterThanOrEqual(0)
+          expect(next).toBeLessThan(length)
+        }
+      }
+    }
+  })
+
+  it('skips past the current index deterministically', () => {
+    // length 3, current 1 → candidates {0, 2}; offsets {0, 1} map around current.
+    expect(pickNextRandomIndex(3, 1, () => 0)).toBe(0)
+    expect(pickNextRandomIndex(3, 1, () => 0.99)).toBe(2)
+    // current 0 → offsets shift up to {1, 2}, never 0.
+    expect(pickNextRandomIndex(3, 0, () => 0)).toBe(1)
+    expect(pickNextRandomIndex(3, 0, () => 0.99)).toBe(2)
+  })
+
+  it('can reach every other index', () => {
+    const seen = new Set<number>()
+
+    for (let i = 0; i < 500; i++) {
+      seen.add(pickNextRandomIndex(4, 2))
+    }
+    expect([...seen].sort()).toEqual([0, 1, 3])
+  })
+})

--- a/components/organisms/MeditationPlayer/musicSelection.ts
+++ b/components/organisms/MeditationPlayer/musicSelection.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers for choosing which background-music track plays in the
+ * MeditationPlayer. Kept separate from the component so the random-pick and
+ * no-immediate-repeat logic can be unit-tested deterministically (the optional
+ * `rng` defaults to `Math.random` but is injected as a stub in tests).
+ *
+ * `rng` must return a value in [0, 1) — the same contract as `Math.random`.
+ */
+
+/**
+ * Pick a random index in `[0, length)`. Returns `0` for an empty or single-item
+ * list (nothing meaningful to randomize).
+ */
+export function pickRandomIndex(length: number, rng: () => number = Math.random): number {
+  if (length <= 1) return 0
+
+  return Math.floor(rng() * length)
+}
+
+/**
+ * Pick a random index in `[0, length)` that differs from `current` whenever the
+ * list has more than one track — so shuffling never immediately repeats the
+ * track that is already playing. Returns `0` for a single-item or empty list.
+ *
+ * Works by picking uniformly over the `length - 1` *other* indices and skipping
+ * past `current`, so every other track is equally likely and `current` is never
+ * returned.
+ */
+export function pickNextRandomIndex(
+  length: number,
+  current: number,
+  rng: () => number = Math.random,
+): number {
+  if (length <= 1) return 0
+  const offset = Math.floor(rng() * (length - 1))
+
+  return offset < current ? offset : offset + 1
+}

--- a/components/templates/MeditationTemplate.tsx
+++ b/components/templates/MeditationTemplate.tsx
@@ -14,7 +14,7 @@
  * <MeditationTemplate meditation={meditationData} />
  */
 
-import type { Meditation } from '../../server/cms-types'
+import type { Meditation, MeditationSong } from '../../server/cms-types'
 import { MeditationPlayer, type MeditationFrame } from '../organisms/MeditationPlayer'
 import { EmbedButton } from '../molecules'
 import { populatedImageUrl } from '../../lib/cms-relationships'
@@ -24,6 +24,12 @@ export interface MeditationTemplateProps {
    * Meditation data from SahajCloud (PayloadCMS)
    */
   meditation: Meditation
+  /**
+   * Background-music tracks for this meditation (from the `/songs` endpoint),
+   * layered under the guided voice inside the player. Empty/omitted ⇒ voice-only.
+   * @default []
+   */
+  musicTracks?: MeditationSong[]
   /**
    * Optional callback fired every 100ms during playback with current time in seconds
    * Also fired on play, pause, and seek events
@@ -49,6 +55,7 @@ export interface MeditationTemplateProps {
 
 export function MeditationTemplate({
   meditation,
+  musicTracks = [],
   onPlaybackTimeUpdate,
   timeDisplay,
   seekTo,
@@ -164,6 +171,7 @@ export function MeditationTemplate({
       {/* Meditation Player */}
       <MeditationPlayer
         frames={frames}
+        musicTracks={musicTracks}
         seekTo={seekTo}
         timeDisplay={timeDisplay}
         track={{

--- a/hooks/audio/useAudioPlayer.ts
+++ b/hooks/audio/useAudioPlayer.ts
@@ -36,6 +36,8 @@ export interface AudioPlayerControls {
   seek: (time: number) => void
   setVolume: (volume: number) => void
   toggleMute: () => void
+  /** Unmute the audio (idempotent — a no-op when already unmuted). */
+  unmute: () => void
   /**
    * Load a new audio URL with options.
    * Use this for dynamic loading (e.g., playlists) instead of the url option.
@@ -90,6 +92,7 @@ export function useAudioPlayer({
       howl && soundIdRef.current !== null
         ? (howl.seek(soundIdRef.current) as number)
         : player.getPosition()
+
     setCurrentTime(time)
     onPlaybackTimeUpdate?.(time)
   })
@@ -114,6 +117,7 @@ export function useAudioPlayer({
   // Seek handler - simplified since html5 mode is disabled
   const seekTo = useEffectEvent((time: number) => {
     const howl = player.player
+
     if (howl && soundIdRef.current !== null) {
       howl.seek(time, soundIdRef.current)
     } else {
@@ -143,6 +147,7 @@ export function useAudioPlayer({
     if (player.isPlaying) {
       updateTime()
       const interval = setInterval(updateTime, 100)
+
       return () => clearInterval(interval)
     }
   }, [player.isPlaying])
@@ -162,8 +167,10 @@ export function useAudioPlayer({
   // Play/pause handlers that track a single sound id to avoid overlapping audio instances
   const play = useEffectEvent(() => {
     const howl = player.player
+
     if (!howl) {
       player.play()
+
       return
     }
 
@@ -171,6 +178,7 @@ export function useAudioPlayer({
       if (!howl.playing(soundIdRef.current)) {
         howl.play(soundIdRef.current)
       }
+
       return
     }
 
@@ -179,8 +187,10 @@ export function useAudioPlayer({
 
   const pause = useEffectEvent(() => {
     const howl = player.player
+
     if (howl) {
       howl.pause()
+
       return
     }
 
@@ -190,6 +200,7 @@ export function useAudioPlayer({
   const togglePlayPause = useEffectEvent(() => {
     if (player.isPlaying) {
       pause()
+
       return
     }
 
@@ -198,19 +209,22 @@ export function useAudioPlayer({
 
   // Dynamic load function for playlists and manual loading
   // Note: Uses useEffectEvent handlers for consistent callback behavior
-  const load = useCallback((loadUrl: string, options?: { autoplay?: boolean; onEnd?: () => void }) => {
-    soundIdRef.current = null
-    player.load(loadUrl, {
-      autoplay: options?.autoplay ?? false,
-      html5: true,
-      onplay: ((soundId?: number) => handleOnPlay(soundId)) as () => void,
-      onpause: () => handleOnPause(),
-      onend: () => {
-        soundIdRef.current = null
-        options?.onEnd?.() // Caller-provided onEnd for playlist track-end handling
-      },
-    })
-  }, [])
+  const load = useCallback(
+    (loadUrl: string, options?: { autoplay?: boolean; onEnd?: () => void }) => {
+      soundIdRef.current = null
+      player.load(loadUrl, {
+        autoplay: options?.autoplay ?? false,
+        html5: true,
+        onplay: ((soundId?: number) => handleOnPlay(soundId)) as () => void,
+        onpause: () => handleOnPause(),
+        onend: () => {
+          soundIdRef.current = null
+          options?.onEnd?.() // Caller-provided onEnd for playlist track-end handling
+        },
+      })
+    },
+    [],
+  )
 
   // Compose state
   const state: AudioPlayerState = {
@@ -233,6 +247,7 @@ export function useAudioPlayer({
     seek,
     setVolume: player.setVolume,
     toggleMute: player.toggleMute,
+    unmute: player.unmute,
     load,
   }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "types:cms": "curl -o server/payload-types.ts https://raw.githubusercontent.com/sydevs/SahajCloud/refs/heads/main/src/payload-types.ts && node scripts/strip-payload-augmentation.mjs"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@mapbox/search-js-core": "^1.5.1",

--- a/pages/meditations/[id]/(full)/+Page.tsx
+++ b/pages/meditations/[id]/(full)/+Page.tsx
@@ -7,7 +7,7 @@ import { MeditationTemplate } from '../../../../components/templates'
  * Embed button so visitors can grab the iframe snippet.
  */
 export function Page() {
-  const { meditation } = useData<MeditationPageData>()
+  const { meditation, musicTracks } = useData<MeditationPageData>()
 
-  return <MeditationTemplate meditation={meditation} />
+  return <MeditationTemplate meditation={meditation} musicTracks={musicTracks} />
 }

--- a/pages/meditations/[id]/_meditation.ts
+++ b/pages/meditations/[id]/_meditation.ts
@@ -1,11 +1,16 @@
 import type { PageContextServer } from 'vike/types'
 import { render } from 'vike/abort'
-import type { Meditation } from '../../../server/cms-types'
-import { getDocumentById } from '../../../server/cms-client'
+import type { Meditation, MeditationSong } from '../../../server/cms-types'
+import { getDocumentById, getMeditationSongs } from '../../../server/cms-client'
 import { idSchema } from '../../../server/validation'
 
 export interface MeditationData {
   meditation: Meditation
+  /**
+   * Background-music tracks layered under the guided voice in the player. Empty
+   * when the meditation has no eligible songs (the player renders voice-only).
+   */
+  musicTracks: MeditationSong[]
   locale: string
   id: string
 }
@@ -26,11 +31,16 @@ export async function loadMeditation(pageContext: PageContextServer): Promise<Me
     throw render(404, error instanceof Error ? error.message : 'Invalid ID')
   }
 
-  const meditation = await getDocumentById({ collection: 'meditations', id, locale })
+  // Fetch the meditation and its background-music tracks in parallel. Both the
+  // full and embed routes call this, so music reaches both.
+  const [meditation, musicTracks] = await Promise.all([
+    getDocumentById({ collection: 'meditations', id, locale }),
+    getMeditationSongs({ id, locale }),
+  ])
 
   if (!meditation) {
     throw render(404, `Meditation with ID "${id}" not found.`)
   }
 
-  return { meditation, locale, id }
+  return { meditation, musicTracks, locale, id }
 }

--- a/pages/meditations/[id]/embed/+Page.tsx
+++ b/pages/meditations/[id]/embed/+Page.tsx
@@ -9,7 +9,9 @@ import { MeditationTemplate } from '../../../../components/templates'
  * button is hidden to avoid offering embed-in-embed.
  */
 export function Page() {
-  const { meditation } = useData<MeditationEmbedPageData>()
+  const { meditation, musicTracks } = useData<MeditationEmbedPageData>()
 
-  return <MeditationTemplate meditation={meditation} showEmbedButton={false} />
+  return (
+    <MeditationTemplate meditation={meditation} musicTracks={musicTracks} showEmbedButton={false} />
+  )
 }

--- a/pages/preview/(full)/+Page.tsx
+++ b/pages/preview/(full)/+Page.tsx
@@ -22,16 +22,6 @@ export { Page }
 
 function Page() {
   const data = useData<PreviewPageData>()
-  // Narrow on the discriminant so musicTracks is only read for meditations.
-  const musicTracks = data.collection === 'meditations' ? data.musicTracks : []
-  const { collection, locale, initialData } = data
 
-  return (
-    <Preview
-      collection={collection}
-      initialData={initialData}
-      locale={locale}
-      musicTracks={musicTracks}
-    />
-  )
+  return <Preview data={data} />
 }

--- a/pages/preview/(full)/+Page.tsx
+++ b/pages/preview/(full)/+Page.tsx
@@ -21,7 +21,17 @@ import { Preview } from '../_components'
 export { Page }
 
 function Page() {
-  const { collection, locale, initialData } = useData<PreviewPageData>()
+  const data = useData<PreviewPageData>()
+  // Narrow on the discriminant so musicTracks is only read for meditations.
+  const musicTracks = data.collection === 'meditations' ? data.musicTracks : []
+  const { collection, locale, initialData } = data
 
-  return <Preview collection={collection} initialData={initialData} locale={locale} />
+  return (
+    <Preview
+      collection={collection}
+      initialData={initialData}
+      locale={locale}
+      musicTracks={musicTracks}
+    />
+  )
 }

--- a/pages/preview/(full)/+data.ts
+++ b/pages/preview/(full)/+data.ts
@@ -17,7 +17,7 @@
  */
 
 import type { PageContextServer } from 'vike/types'
-import { getDocumentById, getWebConfig } from '../../../server/cms-client'
+import { getDocumentById, getMeditationSongs, getWebConfig } from '../../../server/cms-client'
 import { resolveContentIndexBlocks } from '../../../server/content-index'
 import { render } from 'vike/abort'
 import { type CollectionType, type FullPreviewData } from '../_components'
@@ -96,11 +96,16 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
     })
   }
 
+  // Background music for meditation previews — keeps the live player in sync
+  // with the published routes (other collections have none).
+  const musicTracks = collection === 'meditations' ? await getMeditationSongs({ id, locale }) : []
+
   // Return discriminated union based on collection type
   return {
     collection: collection as CollectionType,
     initialData: data,
     locale,
+    musicTracks,
     settings,
   } as PreviewPageData
 }

--- a/pages/preview/_components/MeditationPreview.tsx
+++ b/pages/preview/_components/MeditationPreview.tsx
@@ -8,12 +8,19 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { Meditation } from './types'
+import type { Meditation, MeditationSong } from './types'
 import { MeditationTemplate } from '../../../components/templates'
 import { mergePreviewData } from './mergePreviewData'
 
 export interface MeditationPreviewProps {
   initialData: Meditation
+  /**
+   * Background-music tracks for this meditation (from the loader). Live preview
+   * updates only carry editable meditation fields, so the song list stays fixed
+   * for the preview session.
+   * @default []
+   */
+  musicTracks?: MeditationSong[]
   /** Whether the underlying template shows the Embed button. @default true */
   showEmbedButton?: boolean
 }
@@ -45,7 +52,11 @@ function getSahajCloudOrigin(): string {
   }
 }
 
-export function MeditationPreview({ initialData, showEmbedButton = true }: MeditationPreviewProps) {
+export function MeditationPreview({
+  initialData,
+  musicTracks = [],
+  showEmbedButton = true,
+}: MeditationPreviewProps) {
   // Get the server URL, defaulting to empty string if not configured
   const serverURL = import.meta.env.PUBLIC__SAHAJCLOUD_URL || ''
 
@@ -143,6 +154,7 @@ export function MeditationPreview({ initialData, showEmbedButton = true }: Medit
   return (
     <MeditationTemplate
       meditation={meditation}
+      musicTracks={musicTracks}
       seekTo={seekCommand}
       showEmbedButton={showEmbedButton}
       timeDisplay="elapsed"

--- a/pages/preview/_components/Preview.tsx
+++ b/pages/preview/_components/Preview.tsx
@@ -7,7 +7,7 @@
 
 'use client'
 
-import type { BasePreviewData, Page, Meditation, Lecture } from './types'
+import type { BasePreviewData, Page, Meditation, Lecture, MeditationSong } from './types'
 import { PreviewBanner } from './PreviewBanner'
 import { PagePreview } from './PagePreview'
 import { MeditationPreview } from './MeditationPreview'
@@ -18,6 +18,13 @@ export interface PreviewProps {
   locale: string
   initialData: Page | Meditation | Lecture
   /**
+   * Background-music tracks for a meditation preview (ignored by other
+   * collections). Threaded into the player so live preview matches the
+   * published routes.
+   * @default []
+   */
+  musicTracks?: MeditationSong[]
+  /**
    * Whether the meditation/lecture preview should show the Embed button.
    * The embed preview (/preview/embed) renders inside an iframe, so it passes
    * false to avoid embed-in-embed — matching the /meditations/:id/embed and
@@ -27,7 +34,13 @@ export interface PreviewProps {
   showEmbedButton?: boolean
 }
 
-export function Preview({ collection, locale, initialData, showEmbedButton = true }: PreviewProps) {
+export function Preview({
+  collection,
+  locale,
+  initialData,
+  musicTracks = [],
+  showEmbedButton = true,
+}: PreviewProps) {
   switch (collection) {
     case 'pages':
       return <PagePreview initialData={initialData as Page} />
@@ -35,6 +48,7 @@ export function Preview({ collection, locale, initialData, showEmbedButton = tru
       return (
         <MeditationPreview
           initialData={initialData as Meditation}
+          musicTracks={musicTracks}
           showEmbedButton={showEmbedButton}
         />
       )

--- a/pages/preview/_components/Preview.tsx
+++ b/pages/preview/_components/Preview.tsx
@@ -7,23 +7,21 @@
 
 'use client'
 
-import type { BasePreviewData, Page, Meditation, Lecture, MeditationSong } from './types'
+import type { BasePreviewData } from './types'
 import { PreviewBanner } from './PreviewBanner'
 import { PagePreview } from './PagePreview'
 import { MeditationPreview } from './MeditationPreview'
 import { LecturePreview } from './LecturePreview'
 
 export interface PreviewProps {
-  collection: BasePreviewData['collection']
-  locale: string
-  initialData: Page | Meditation | Lecture
   /**
-   * Background-music tracks for a meditation preview (ignored by other
-   * collections). Threaded into the player so live preview matches the
-   * published routes.
-   * @default []
+   * The previewed document as a discriminated union (collection + initialData +
+   * locale, plus musicTracks for meditations). Preview narrows on `collection`,
+   * so collection-specific payloads (e.g. a meditation's music) stay type-safe
+   * here without per-route narrowing or casts. FullPreviewData (which also
+   * carries `settings`) is accepted structurally.
    */
-  musicTracks?: MeditationSong[]
+  data: BasePreviewData
   /**
    * Whether the meditation/lecture preview should show the Embed button.
    * The embed preview (/preview/embed) renders inside an iframe, so it passes
@@ -34,29 +32,23 @@ export interface PreviewProps {
   showEmbedButton?: boolean
 }
 
-export function Preview({
-  collection,
-  locale,
-  initialData,
-  musicTracks = [],
-  showEmbedButton = true,
-}: PreviewProps) {
-  switch (collection) {
+export function Preview({ data, showEmbedButton = true }: PreviewProps) {
+  switch (data.collection) {
     case 'pages':
-      return <PagePreview initialData={initialData as Page} />
+      return <PagePreview initialData={data.initialData} />
     case 'meditations':
       return (
         <MeditationPreview
-          initialData={initialData as Meditation}
-          musicTracks={musicTracks}
+          initialData={data.initialData}
+          musicTracks={data.musicTracks}
           showEmbedButton={showEmbedButton}
         />
       )
     case 'lectures':
       return (
         <LecturePreview
-          initialData={initialData as Lecture}
-          locale={locale}
+          initialData={data.initialData}
+          locale={data.locale}
           showEmbedButton={showEmbedButton}
         />
       )

--- a/pages/preview/_components/index.ts
+++ b/pages/preview/_components/index.ts
@@ -26,4 +26,5 @@ export {
   type Meditation,
   type Lecture,
   type WebConfig,
+  type MeditationSong,
 } from './types'

--- a/pages/preview/_components/types.ts
+++ b/pages/preview/_components/types.ts
@@ -7,7 +7,13 @@
  * to avoid bundling server code in client bundles.
  */
 
-import type { Page, Meditation, Lecture, WebConfig } from '../../../server/cms-types'
+import type {
+  Page,
+  Meditation,
+  Lecture,
+  WebConfig,
+  MeditationSong,
+} from '../../../server/cms-types'
 
 export type CollectionType = 'pages' | 'meditations' | 'lectures'
 
@@ -26,6 +32,7 @@ export type BasePreviewData =
   | {
       collection: 'meditations'
       initialData: Meditation
+      musicTracks: MeditationSong[]
       locale: string
     }
   | {
@@ -47,6 +54,7 @@ export type FullPreviewData =
   | {
       collection: 'meditations'
       initialData: Meditation
+      musicTracks: MeditationSong[]
       locale: string
       settings: WebConfig
     }
@@ -58,4 +66,4 @@ export type FullPreviewData =
     }
 
 // Re-export types for convenience
-export type { Page, Meditation, Lecture, WebConfig }
+export type { Page, Meditation, Lecture, WebConfig, MeditationSong }

--- a/pages/preview/embed/+Page.tsx
+++ b/pages/preview/embed/+Page.tsx
@@ -22,13 +22,17 @@ import { Preview } from '../_components'
 export { Page }
 
 function Page() {
-  const { collection, locale, initialData } = useData<EmbedPreviewPageData>()
+  const data = useData<EmbedPreviewPageData>()
+  // Narrow on the discriminant so musicTracks is only read for meditations.
+  const musicTracks = data.collection === 'meditations' ? data.musicTracks : []
+  const { collection, locale, initialData } = data
 
   return (
     <Preview
       collection={collection}
-      locale={locale}
       initialData={initialData}
+      locale={locale}
+      musicTracks={musicTracks}
       // Embed preview already renders inside an iframe — no embed-in-embed.
       showEmbedButton={false}
     />

--- a/pages/preview/embed/+Page.tsx
+++ b/pages/preview/embed/+Page.tsx
@@ -23,16 +23,10 @@ export { Page }
 
 function Page() {
   const data = useData<EmbedPreviewPageData>()
-  // Narrow on the discriminant so musicTracks is only read for meditations.
-  const musicTracks = data.collection === 'meditations' ? data.musicTracks : []
-  const { collection, locale, initialData } = data
 
   return (
     <Preview
-      collection={collection}
-      initialData={initialData}
-      locale={locale}
-      musicTracks={musicTracks}
+      data={data}
       // Embed preview already renders inside an iframe — no embed-in-embed.
       showEmbedButton={false}
     />

--- a/pages/preview/embed/+data.ts
+++ b/pages/preview/embed/+data.ts
@@ -13,7 +13,7 @@
  */
 
 import type { PageContextServer } from 'vike/types'
-import { getDocumentById } from '../../../server/cms-client'
+import { getDocumentById, getMeditationSongs } from '../../../server/cms-client'
 import { render } from 'vike/abort'
 import { type CollectionType, type BasePreviewData } from '../_components'
 import { idSchema, collectionSchema } from '../../../server/validation'
@@ -79,10 +79,15 @@ export async function data(pageContext: PageContextServer): Promise<EmbedPreview
     throw render(404, `${collection} content not found.`)
   }
 
+  // Background music for meditation previews — keeps the live player in sync
+  // with the published embed route (other collections have none).
+  const musicTracks = collection === 'meditations' ? await getMeditationSongs({ id, locale }) : []
+
   // Return discriminated union based on collection type
   return {
     collection: collection as CollectionType,
     initialData: data,
     locale,
+    musicTracks,
   } as EmbedPreviewPageData
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/react':
+        specifier: ^0.27.19
+        version: 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -21,6 +21,7 @@
 
 import { createPayloadClient, validateSDKResponse } from './payload-client'
 import { generateCacheKey, withCache, CacheTTL } from './kv-cache'
+import { getCmsContext } from './cms-context'
 import { resolveLecture, type ResolvedLecture } from '../lib/lecture-shape'
 import * as Sentry from '@sentry/react'
 import type {
@@ -37,7 +38,7 @@ import type {
   VideosSelect,
   WmWebConfigSelect,
 } from './payload-types'
-import type { Locale, Page, Song, WebConfig, PageListItem } from './cms-types'
+import type { Locale, Page, Song, WebConfig, PageListItem, MeditationSong } from './cms-types'
 
 // ============================================================================
 // Common Options Interfaces
@@ -632,6 +633,75 @@ export async function getSongsByTags(
       if (!result?.docs) return []
 
       return result.docs as Song[]
+    },
+  })
+}
+
+/**
+ * Retrieves the background-music tracks eligible for a meditation via the custom
+ * nested route `GET /api/meditations/:id/songs`.
+ *
+ * Unlike the standard collection reads above, this endpoint encapsulates the
+ * songTag + `includeForMeditations` selection server-side and returns a fixed
+ * minimal projection (`{ id, title, url, tags }`) — it does NOT accept `select`
+ * and ignores `populate`/`depth`/`limit` (it honors `locale`). Because it is not
+ * a collection `find`, the PayloadCMS SDK can't model it, so we issue a raw
+ * authenticated fetch (same `clients API-Key` header the SDK sends) wrapped in
+ * the shared cache + retry layer.
+ *
+ * The endpoint returns songs in randomized order on every request; callers pick
+ * a track client-side, so a per-TTL-window cached list is fine. Degrades to an
+ * empty list for meditations with no eligible songs (HTTP 200 `{ docs: [] }`)
+ * and for an unknown id (HTTP 404) so the player simply renders voice-only.
+ *
+ * @param options.id - The meditation document ID
+ * @param options.locale - The locale to retrieve songs in
+ * @returns Playable music tracks (`{ id, title, url }`, url guaranteed non-empty)
+ */
+export async function getMeditationSongs(
+  options: LocalizedQueryOptions & {
+    id: string
+  },
+): Promise<MeditationSong[]> {
+  const cacheKey = generateCacheKey('meditation-songs', {
+    id: options.id,
+    locale: options.locale,
+  })
+
+  return withCache({
+    cacheKey,
+    ttl: CacheTTL.SONG,
+    fetchFn: async () => {
+      const { apiKey, baseURL } = getCmsContext()
+      const url = `${baseURL}/api/meditations/${encodeURIComponent(
+        options.id,
+      )}/songs?locale=${encodeURIComponent(options.locale)}`
+
+      const response = await fetch(url, {
+        headers: { Authorization: `clients API-Key ${apiKey}` },
+      })
+
+      // Mirror the SDK's request logging so the dev request log stays complete.
+      console.log(`[PayloadCMS] GET ${url} → ${response.status}`)
+
+      // Unknown meditation id (or no songs route) → no music, not an error.
+      if (response.status === 404) return []
+
+      // Let server/network errors propagate so withCache's retry kicks in.
+      if (!response.ok) {
+        throw new Error(`getMeditationSongs(${options.id}) failed: ${response.status}`)
+      }
+
+      const body = (await response.json()) as {
+        docs?: Array<{ id: number; title?: string | null; url?: string | null }>
+      }
+      const docs = Array.isArray(body.docs) ? body.docs : []
+
+      // Keep only playable tracks (the player needs a real URL); the endpoint
+      // omits duration/artwork/credit, so title + url are all we surface.
+      return docs
+        .filter((doc) => typeof doc.url === 'string' && doc.url.length > 0)
+        .map((doc) => ({ id: doc.id, title: doc.title ?? '', url: doc.url as string }))
     },
   })
 }

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -668,40 +668,58 @@ export async function getMeditationSongs(
     locale: options.locale,
   })
 
-  return withCache({
-    cacheKey,
-    ttl: CacheTTL.SONG,
-    fetchFn: async () => {
-      const { apiKey, baseURL } = getCmsContext()
-      const url = `${baseURL}/api/meditations/${encodeURIComponent(
-        options.id,
-      )}/songs?locale=${encodeURIComponent(options.locale)}`
+  try {
+    return await withCache({
+      cacheKey,
+      ttl: CacheTTL.SONG,
+      fetchFn: async () => {
+        const { apiKey, baseURL } = getCmsContext()
+        const url = `${baseURL}/api/meditations/${encodeURIComponent(
+          options.id,
+        )}/songs?locale=${encodeURIComponent(options.locale)}`
 
-      const response = await fetch(url, {
-        headers: { Authorization: `clients API-Key ${apiKey}` },
-      })
+        const response = await fetch(url, {
+          headers: { Authorization: `clients API-Key ${apiKey}` },
+        })
 
-      // Mirror the SDK's request logging so the dev request log stays complete.
-      console.log(`[PayloadCMS] GET ${url} → ${response.status}`)
+        // Mirror the SDK's request logging so the dev request log stays complete.
+        console.log(`[PayloadCMS] GET ${url} → ${response.status}`)
 
-      // Unknown meditation id (or no songs route) → no music, not an error.
-      if (response.status === 404) return []
+        // Unknown meditation id (or no songs route) → no music, not an error.
+        if (response.status === 404) return []
 
-      // Let server/network errors propagate so withCache's retry kicks in.
-      if (!response.ok) {
-        throw new Error(`getMeditationSongs(${options.id}) failed: ${response.status}`)
-      }
+        // Let server/network errors propagate so withCache's retry kicks in.
+        if (!response.ok) {
+          throw new Error(`getMeditationSongs(${options.id}) failed: ${response.status}`)
+        }
 
-      const body = (await response.json()) as {
-        docs?: Array<{ id: number; title?: string | null; url?: string | null }>
-      }
-      const docs = Array.isArray(body.docs) ? body.docs : []
+        const body = (await response.json()) as {
+          docs?: Array<{ id: number; title?: string | null; url?: string | null }>
+        }
+        const docs = Array.isArray(body.docs) ? body.docs : []
 
-      // Keep only playable tracks (the player needs a real URL); the endpoint
-      // omits duration/artwork/credit, so title + url are all we surface.
-      return docs
-        .filter((doc) => typeof doc.url === 'string' && doc.url.length > 0)
-        .map((doc) => ({ id: doc.id, title: doc.title ?? '', url: doc.url as string }))
-    },
-  })
+        // Keep only playable tracks (the player needs a real URL); the endpoint
+        // omits duration/artwork/credit, so title + url are all we surface.
+        return docs
+          .filter((doc) => typeof doc.url === 'string' && doc.url.length > 0)
+          .map((doc) => ({ id: doc.id, title: doc.title ?? '', url: doc.url as string }))
+      },
+    })
+  } catch (error) {
+    // Background music is supplementary — a failure to load it (after withCache's
+    // retries) must never break the meditation page. Degrade to voice-only and
+    // surface the gap to Sentry. The failed result isn't cached, so the next
+    // request retries.
+    console.warn(
+      `[getMeditationSongs] degrading to voice-only for meditation ${options.id}:`,
+      error,
+    )
+    Sentry.captureMessage('getMeditationSongs failed; rendering meditation voice-only', {
+      level: 'warning',
+      tags: { source: 'getMeditationSongs' },
+      extra: { meditationId: options.id, locale: options.locale ?? null },
+    })
+
+    return []
+  }
 }

--- a/server/cms-types.ts
+++ b/server/cms-types.ts
@@ -92,3 +92,18 @@ export interface MeditationListItem {
   title: string | null
   thumbnail: import('./payload-types').Image | null
 }
+
+/**
+ * Background-music track for a meditation, as returned by the
+ * `GET /api/meditations/:id/songs` endpoint.
+ *
+ * That endpoint emits a fixed minimal projection (no album/artwork/duration/
+ * credit) and encapsulates the songTag + `includeForMeditations` selection
+ * server-side. The player layers one of these under the guided voice and needs
+ * only a playable URL plus a title; see `getMeditationSongs` in cms-client.
+ */
+export interface MeditationSong {
+  id: number
+  title: string
+  url: string
+}


### PR DESCRIPTION
## Summary

- Background music plays **inside** the meditation player — a random track from `GET /api/meditations/:id/songs`, layered under the guided voice, looping and tied to play/pause, on both the full and embed routes.
- The inline volume slider is replaced by a **speaker button → popover** with independent **Voice** and **Music** sliders (each separately mutable) plus a **shuffle** button; music controls hide when a meditation has no songs.
- **Dropdown atom rebuilt on Floating UI** for viewport-aware placement (flip/shift + portal) and the new popover style; the player's audio controls now use it. (Added in a follow-up to this branch — see below.)
- Related content from #26 is **deferred to #42** (meditations have no queryable `subtleSystemNodes` relationship; list queries return null titles/durations — needs backend support).

## Background music

- `server/cms-client.ts` — `getMeditationSongs({id, locale})`: raw authenticated fetch to the custom nested `/songs` route (the SDK can't model it; mirrors the existing `server/content-index.ts` precedent), cached + retried, degrades to voice-only (empty list + Sentry warning) on failure so supplementary music never 500s the page.
- `pages/meditations/[id]/_meditation.ts` fetches songs in parallel with the meditation; threaded through `MeditationTemplate` → player and through the preview pipeline.
- `MeditationPlayer` — hidden looping `<audio preload="none">` music layer + audio-controls popover; `musicSelection.ts` shuffle helper (no immediate repeat).

## Dropdown: viewport-aware placement (Floating UI)

Rebuilds the shared `Dropdown` atom on `@floating-ui/react` so panels keep themselves on screen: configurable `side` (default `bottom`) with automatic **flip** + **shift** near viewport edges, rendered in a **portal** (never clipped by `overflow`/`@container`), plus `align`/`role`/`ariaLabel` props and the `rounded-lg`/`shadow-xl` popover style. Dismissal + focus management come from Floating UI; the focus-to-open autocomplete mode keeps React's bubbling `onFocus`/`onBlur` (a child `<input>` can't be observed by Floating UI's native `useFocus`). The player's audio controls now render through it. `@floating-ui/react` was already a transitive dependency, so this adds ~no bundle weight.

The three existing callers (LanguageDropdown, LocationSearch autocomplete, EmbedButton) are preserved and were verified in-browser.

## Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 232 passed (`pnpm test:run`) — incl. shuffle logic, MeditationPlayer SSR markup, and the Dropdown trigger contract
- Build: ✓ Success (`pnpm build`)

## Manual verification (in-browser, Ladle)

- **MeditationPlayer popover**: opens above & centered, sliders/shuffle (changes track)/mute (toggles `audio.muted`) fire through the portal, Escape closes.
- **Dropdown**: portals to `<body>`, collision **shift** keeps it on-screen near the right edge, left/right alignment correct, Escape + outside-press dismiss.
- **LocationSearch autocomplete**: typing keeps focus in the input with live Mapbox suggestions, panel is full-width and **flips above** when there's no room below, clicking a suggestion reaches its handler.
- **LanguageDropdown / EmbedButton**: open, content renders, dismiss.
- Background music verified live against the production CMS: `/meditations/1` (7 songs) renders the looping `<audio>`; `/meditations/142` (no songs) is voice-only; embed includes music.

## Notes for reviewer

- **Related content deferred to #42** (data-model mismatch documented there).
- **Dropdown** is a shared nav atom — the autocomplete (LocationSearch) is the highest-risk caller; its focus-open, full-width match, suggestion-click, and dismissal were verified in a real browser, not just unit tests (interactive behavior isn't unit-testable here).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
