### PR TITLE
feat(header): add knowledgePages mega-menu dropdown to nav

### DIFF
--- a/components/organisms/Header/Header.stories.tsx
+++ b/components/organisms/Header/Header.stories.tsx
@@ -56,7 +56,8 @@ export const Default: Story = () => (
           { label: 'Meditate Now', href: '/meditate' },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
-          { label: 'About Meditation', href: '/about', dropdown: aboutDropdown },
+          // Link-less: opens the mega-menu, no navigation of its own.
+          { label: 'About Meditation', dropdown: aboutDropdown },
         ]}
         theme="light"
       />
@@ -102,7 +103,8 @@ export const Default: Story = () => (
           { label: 'Meditate Now', href: '/meditate' },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
-          { label: 'About Meditation', href: '/about', dropdown: aboutDropdown },
+          // Link-less: opens the mega-menu, no navigation of its own.
+          { label: 'About Meditation', dropdown: aboutDropdown },
         ]}
         theme="dark"
       />

--- a/components/organisms/Header/Header.stories.tsx
+++ b/components/organisms/Header/Header.stories.tsx
@@ -1,10 +1,36 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { Header } from "./Header";
-import { StoryWrapper, StorySection } from '../../ladle';
+import type { Story, StoryDefault } from '@ladle/react'
+import { Header } from './Header'
+import { StoryWrapper, StorySection } from '../../ladle'
 
 export default {
-  title: "Organisms"
-} satisfies StoryDefault;
+  title: 'Organisms',
+} satisfies StoryDefault
+
+/** Mega-menu payload for the final nav item ("About Meditation"). */
+const aboutDropdown = {
+  title: 'About Meditation',
+  links: [
+    { label: 'History of Meditation', href: '#/about/history' },
+    { label: 'Chakras & Channels', href: '#/about/chakras' },
+    { label: 'Inner Energy', href: '#/about/energy' },
+    { label: 'Founder of Sahaja Yoga', href: '#/about/founder' },
+    { label: 'Further Reading', href: '#/about/reading' },
+  ],
+  featuredArticles: [
+    {
+      title: 'History of Meditation',
+      image: 'https://picsum.photos/seed/article1/400/400',
+      imageAlt: 'Abstract meditation artwork',
+      href: '#/articles/history',
+    },
+    {
+      title: 'Rabindranath Tagore: Between the finite and the infinite',
+      image: 'https://picsum.photos/seed/article2/400/400',
+      imageAlt: 'Portrait of Rabindranath Tagore',
+      href: '#/articles/tagore',
+    },
+  ],
+}
 
 /**
  * Complete page header with logo, navigation menu, action link, and breadcrumbs.
@@ -13,47 +39,43 @@ export default {
 export const Default: Story = () => (
   <StoryWrapper>
     <StorySection
+      description="Scroll down to see the navigation become sticky with a white background and gray text"
       title="Light Theme (Default)"
       variant="scrollable"
-      description="Scroll down to see the navigation become sticky with a white background and gray text"
     >
       <Header
-        theme="light"
-        logoHref="/"
-        actionLinkText="Classes near me"
         actionLinkHref="/classes"
+        actionLinkText="Classes near me"
+        breadcrumbs={[
+          { label: 'Home Page', href: '/' },
+          { label: 'About Meditation', href: '/about' },
+          { label: 'Improving Your Meditation' },
+        ]}
+        logoHref="/"
         navItems={[
           { label: 'Meditate Now', href: '/meditate' },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
-          { label: 'About Meditation', href: '/about' }
+          { label: 'About Meditation', href: '/about', dropdown: aboutDropdown },
         ]}
-        breadcrumbs={[
-          { label: 'Home Page', href: '/' },
-          { label: 'About Meditation', href: '/about' },
-          { label: 'Improving Your Meditation' }
-        ]}
+        theme="light"
       />
 
       {/* Long content to demonstrate sticky navigation */}
       <div className="max-w-4xl mx-auto px-6 py-12 space-y-8">
-        <h1 className="text-4xl font-semibold text-gray-700">
-          Improving Your Meditation Practice
-        </h1>
+        <h1 className="text-4xl font-semibold text-gray-700">Improving Your Meditation Practice</h1>
 
         <p className="text-base text-gray-600 leading-relaxed">
-          This is the default variant suitable for light backgrounds.
-          Notice how the sticky navigation maintains visibility as you scroll through the page.
+          This is the default variant suitable for light backgrounds. Notice how the sticky
+          navigation maintains visibility as you scroll through the page.
         </p>
 
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i}>
-            <h2 className="text-2xl font-medium text-gray-700 mt-8">
-              Section {i + 1}
-            </h2>
+            <h2 className="text-2xl font-medium text-gray-700 mt-8">Section {i + 1}</h2>
             <p className="text-base text-gray-600 leading-relaxed">
-              Content for section {i + 1}. Notice how the sticky navigation maintains visibility
-              as you scroll through the page.
+              Content for section {i + 1}. Notice how the sticky navigation maintains visibility as
+              you scroll through the page.
             </p>
           </div>
         ))}
@@ -61,49 +83,45 @@ export const Default: Story = () => (
     </StorySection>
 
     <StorySection
-      title="Dark Theme"
-      theme="dark"
       background="gradient"
-      variant="scrollable"
       description="Scroll down to see how the navigation transitions from white text on dark background to gray text on white background when it becomes sticky"
+      theme="dark"
+      title="Dark Theme"
+      variant="scrollable"
     >
       <Header
-        theme="dark"
-        logoHref="/"
-        actionLinkText="Classes near me"
         actionLinkHref="/classes"
+        actionLinkText="Classes near me"
+        breadcrumbs={[
+          { label: 'Home Page', href: '/' },
+          { label: 'About Meditation', href: '/about' },
+          { label: 'Improving Your Meditation' },
+        ]}
+        logoHref="/"
         navItems={[
           { label: 'Meditate Now', href: '/meditate' },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
-          { label: 'About Meditation', href: '/about' }
+          { label: 'About Meditation', href: '/about', dropdown: aboutDropdown },
         ]}
-        breadcrumbs={[
-          { label: 'Home Page', href: '/' },
-          { label: 'About Meditation', href: '/about' },
-          { label: 'Improving Your Meditation' }
-        ]}
+        theme="dark"
       />
 
       {/* Long content to demonstrate sticky navigation */}
       <div className="max-w-4xl mx-auto px-6 py-12 space-y-8">
-        <h1 className="text-4xl font-semibold text-white">
-          Dark Theme for Dark Backgrounds
-        </h1>
+        <h1 className="text-4xl font-semibold text-white">Dark Theme for Dark Backgrounds</h1>
 
         <p className="text-base text-white/90 leading-relaxed">
-          The header, navigation, and breadcrumbs all use white text to contrast with the dark background.
-          Notice how readability is maintained in all states.
+          The header, navigation, and breadcrumbs all use white text to contrast with the dark
+          background. Notice how readability is maintained in all states.
         </p>
 
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i}>
-            <h2 className="text-2xl font-medium text-white mt-8">
-              Section {i + 1}
-            </h2>
+            <h2 className="text-2xl font-medium text-white mt-8">Section {i + 1}</h2>
             <p className="text-base text-white/90 leading-relaxed">
-              Content for section {i + 1}. This demonstrates the scrolling behavior
-              with the sticky header.
+              Content for section {i + 1}. This demonstrates the scrolling behavior with the sticky
+              header.
             </p>
           </div>
         ))}
@@ -112,6 +130,6 @@ export const Default: Story = () => (
 
     <div />
   </StoryWrapper>
-);
+)
 
-Default.storyName = "Header"
+Default.storyName = 'Header'

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -14,9 +14,10 @@ export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> 
   actionLinkHref?: string
   /**
    * Main navigation menu items. An item with a `dropdown` renders as a
-   * hover/click mega-menu (HeaderNavDropdown) instead of a flat link.
+   * link-less hover/click mega-menu (HeaderNavDropdown) instead of a flat link;
+   * such items omit `href`. Plain link items provide `href`.
    */
-  navItems?: Array<{ label: string; href: string; dropdown?: HeaderDropdownProps }>
+  navItems?: Array<{ label: string; href?: string; dropdown?: HeaderDropdownProps }>
   /** Breadcrumb navigation items */
   breadcrumbs?: BreadcrumbItem[]
   /**

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -2,6 +2,8 @@ import { ComponentProps, useState, useEffect, useRef } from 'react'
 import { MapPinIcon } from '@heroicons/react/24/outline'
 import { Link, Breadcrumbs, BreadcrumbItem, Logo, Button, Icon } from '../../atoms'
 import { HeaderIllustrationSvg } from '../../atoms/svgs'
+import { HeaderNavDropdown } from './HeaderNavDropdown'
+import type { HeaderDropdownProps } from '../HeaderDropdown'
 
 export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> {
   /** Logo href (default: "/") */
@@ -10,8 +12,11 @@ export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> 
   actionLinkText?: string
   /** Action link href */
   actionLinkHref?: string
-  /** Main navigation menu items */
-  navItems?: Array<{ label: string; href: string }>
+  /**
+   * Main navigation menu items. An item with a `dropdown` renders as a
+   * hover/click mega-menu (HeaderNavDropdown) instead of a flat link.
+   */
+  navItems?: Array<{ label: string; href: string; dropdown?: HeaderDropdownProps }>
   /** Breadcrumb navigation items */
   breadcrumbs?: BreadcrumbItem[]
   /**
@@ -45,6 +50,7 @@ export function Header({
 
   useEffect(() => {
     const sentinel = sentinelRef.current
+
     if (!sentinel) return
 
     const observer = new IntersectionObserver(
@@ -52,7 +58,7 @@ export function Header({
         // When sentinel goes out of view (scrolled past), nav becomes sticky
         setIsSticky(!entry.isIntersecting)
       },
-      { threshold: [0] }
+      { threshold: [0] },
     )
 
     observer.observe(sentinel)
@@ -68,46 +74,43 @@ export function Header({
 
   return (
     <>
-      <header
-        className={className}
-        {...props}
-      >
+      <header className={className} {...props}>
         {/* Top banner with logo, illustration, and action link */}
         <div className={`flex items-center justify-between gap-8 py-4 ${textColorClass}`}>
-        {/* Logo - responsive: lg inline-text on mobile, sm inline-text on desktop */}
-        <div className="shrink-0">
-          <Logo
-            variant="text"
-            align="left"
-            href={logoHref}
-            size="sm"
-            className="hidden lg:flex"
-          />
-        </div>
-
-        {/* Decorative illustration - hidden on mobile */}
-        <div className="flex-1 mx-8 hidden lg:block">
-          <HeaderIllustrationSvg />
-        </div>
-
-        {/* Action link - regular link, not button */}
-        {actionLinkText && actionLinkHref && (
-          <div className="shrink-0 max-w-20 text-right">
-            <Link
-              href={actionLinkHref}
-              variant="unstyled"
+          {/* Logo - responsive: lg inline-text on mobile, sm inline-text on desktop */}
+          <div className="shrink-0">
+            <Logo
+              align="left"
+              className="hidden lg:flex"
+              href={logoHref}
               size="sm"
-              className="no-underline leading-none hover:opacity-75 transition-opacity"
-            >
-              {actionLinkText}
-            </Link>
+              variant="text"
+            />
           </div>
-        )}
-      </div>
+
+          {/* Decorative illustration - hidden on mobile */}
+          <div className="flex-1 mx-8 hidden lg:block">
+            <HeaderIllustrationSvg />
+          </div>
+
+          {/* Action link - regular link, not button */}
+          {actionLinkText && actionLinkHref && (
+            <div className="shrink-0 max-w-20 text-right">
+              <Link
+                className="no-underline leading-none hover:opacity-75 transition-opacity"
+                href={actionLinkHref}
+                size="sm"
+                variant="unstyled"
+              >
+                {actionLinkText}
+              </Link>
+            </div>
+          )}
+        </div>
       </header>
 
       {/* Sentinel element to detect when nav should be sticky */}
-      <div ref={sentinelRef} className="h-0" aria-hidden="true" />
+      <div ref={sentinelRef} aria-hidden="true" className="h-0" />
 
       {/* Main navigation menu - sticky on scroll (outside header so it can stick globally) */}
       {navItems.length > 0 && (
@@ -127,28 +130,38 @@ export function Header({
           <div className="flex items-center justify-between gap-2 max-w-5xl mx-auto px-6">
             {/* Logo - only visible when sticky */}
             <Logo
-              variant="icon"
-              href={logoHref}
-              size="sm"
               className={`shrink-0 transition-opacity duration-200 ${
                 isSticky ? 'opacity-100' : 'opacity-0 pointer-events-none'
               }`}
+              href={logoHref}
+              size="sm"
+              variant="icon"
             />
 
             {/* Navigation buttons */}
             <div className="flex items-stretch justify-center gap-2 max-w-3xl flex-1">
-              {navItems.map((item, index) => (
-                <Button
-                  key={index}
-                  variant="ghost"
-                  theme={isSticky ? 'light' : theme}
-                  size="sm"
-                  href={item.href}
-                  className="px-0 basis-1/4"
-                >
-                  {item.label}
-                </Button>
-              ))}
+              {navItems.map((item, index) =>
+                item.dropdown ? (
+                  <HeaderNavDropdown
+                    key={index}
+                    className="basis-1/4"
+                    dropdown={item.dropdown}
+                    label={item.label}
+                    theme={isSticky ? 'light' : theme}
+                  />
+                ) : (
+                  <Button
+                    key={index}
+                    className="px-0 basis-1/4"
+                    href={item.href}
+                    size="sm"
+                    theme={isSticky ? 'light' : theme}
+                    variant="ghost"
+                  >
+                    {item.label}
+                  </Button>
+                ),
+              )}
             </div>
 
             {/* Map pin icon - only visible when sticky and action link exists */}
@@ -158,7 +171,11 @@ export function Header({
                   isSticky ? 'opacity-100' : 'opacity-0 pointer-events-none'
                 }`}
               >
-                <Link href={actionLinkHref} variant="unstyled" className="flex items-center gap-1 no-underline hover:opacity-75 transition-opacity">
+                <Link
+                  className="flex items-center gap-1 no-underline hover:opacity-75 transition-opacity"
+                  href={actionLinkHref}
+                  variant="unstyled"
+                >
                   <Icon icon={MapPinIcon} size="sm" />
                 </Link>
               </div>

--- a/components/organisms/Header/HeaderNavDropdown.stories.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.stories.tsx
@@ -1,0 +1,86 @@
+import type { Story, StoryDefault } from '@ladle/react'
+import { HeaderNavDropdown } from './HeaderNavDropdown'
+import { StorySection, StoryWrapper } from '../../ladle'
+
+export default {
+  title: 'Organisms',
+} satisfies StoryDefault
+
+const sampleDropdown = {
+  title: 'About Meditation',
+  links: [
+    { label: 'History of Meditation', href: '#/about/history' },
+    { label: 'Chakras & Channels', href: '#/about/chakras' },
+    { label: 'Inner Energy', href: '#/about/energy' },
+    { label: 'Founder of Sahaja Yoga', href: '#/about/founder' },
+    { label: 'About Sahaja Yoga', href: '#/about/sahaja-yoga' },
+    { label: 'Further Reading', href: '#/about/reading' },
+  ],
+  featuredArticles: [
+    {
+      title: 'History of Meditation',
+      image: 'https://picsum.photos/seed/article1/400/400',
+      imageAlt: 'Abstract meditation artwork',
+      href: '#/articles/history',
+    },
+    {
+      title: 'Rabindranath Tagore: Between the finite and the infinite',
+      image: 'https://picsum.photos/seed/article2/400/400',
+      imageAlt: 'Portrait of Rabindranath Tagore',
+      href: '#/articles/tagore',
+    },
+  ],
+}
+
+/**
+ * Header mega-menu wrapper: a nav item that opens a {@link HeaderDropdown} panel
+ * on hover or click, positioned with Floating UI and rendered in a portal.
+ *
+ * Hover or click "About Meditation" to open the panel; move the cursor onto it
+ * (safePolygon keeps it open), or press Escape / click outside to close. The
+ * trigger is keyboard-focusable and opens on Enter/Space.
+ */
+export const Default: Story = () => (
+  <StoryWrapper>
+    <StorySection
+      description="A nav row with one dropdown-capable item. Hover or click to open."
+      title="Light Theme (Default)"
+    >
+      {/* Mimic the Header nav row so the panel has room to drop below it. */}
+      <nav className="border-t border-b border-gray-200">
+        <div className="flex items-stretch justify-center gap-2 max-w-3xl mx-auto px-6">
+          <HeaderNavDropdown
+            className="basis-1/4"
+            dropdown={sampleDropdown}
+            label="About Meditation"
+          />
+        </div>
+      </nav>
+      {/* Spacer so the open panel is visible within the section. */}
+      <div className="h-96" />
+    </StorySection>
+
+    <StorySection
+      background="gradient"
+      description="Trigger uses white text for dark backgrounds; the panel styling is unchanged."
+      theme="dark"
+      title="Dark Theme"
+    >
+      <nav className="border-t border-b border-white/40">
+        <div className="flex items-stretch justify-center gap-2 max-w-3xl mx-auto px-6">
+          <HeaderNavDropdown
+            className="basis-1/4"
+            dropdown={sampleDropdown}
+            label="About Meditation"
+            theme="dark"
+          />
+        </div>
+      </nav>
+      <div className="h-96" />
+    </StorySection>
+
+    <div />
+  </StoryWrapper>
+)
+
+Default.storyName = 'Header Nav Dropdown'

--- a/components/organisms/Header/HeaderNavDropdown.test.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { HeaderNavDropdown } from './HeaderNavDropdown'
+
+const dropdown = {
+  title: 'About Meditation',
+  links: [{ label: 'History of Meditation', href: '/history-of-meditation' }],
+  featuredArticles: [
+    {
+      title: 'A Featured Article',
+      image: 'https://example.com/a.jpg',
+      imageAlt: 'Art',
+      href: '/a-featured-article',
+    },
+  ],
+}
+
+describe('HeaderNavDropdown', () => {
+  it('renders a keyboard-focusable trigger with dialog popup semantics', () => {
+    const html = renderToStaticMarkup(
+      <HeaderNavDropdown dropdown={dropdown} label="About Meditation" />,
+    )
+
+    expect(html).toContain('About Meditation')
+    // The trigger is a real <button> carrying the popup ARIA contract.
+    expect(html).toContain('<button')
+    expect(html).toContain('aria-haspopup="dialog"')
+    expect(html).toContain('aria-expanded="false"')
+  })
+
+  it('does not render the panel until opened (closed by default)', () => {
+    const html = renderToStaticMarkup(
+      <HeaderNavDropdown dropdown={dropdown} label="About Meditation" />,
+    )
+
+    // Panel content (links/articles) is portal-rendered only when open.
+    expect(html).not.toContain('History of Meditation')
+    expect(html).not.toContain('A Featured Article')
+  })
+})

--- a/components/organisms/Header/HeaderNavDropdown.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  useHover,
+  useClick,
+  useDismiss,
+  useRole,
+  useInteractions,
+  safePolygon,
+  FloatingPortal,
+} from '@floating-ui/react'
+import { Button } from '../../atoms'
+import { HeaderDropdown, type HeaderDropdownProps } from '../HeaderDropdown'
+
+export interface HeaderNavDropdownProps {
+  /** The nav trigger label (the featured page title, e.g. "About Meditation"). */
+  label: string
+  /** Mega-menu panel content, rendered in a portal when open. */
+  dropdown: HeaderDropdownProps
+  /**
+   * Trigger theme, matching the surrounding nav.
+   * @default 'light'
+   */
+  theme?: 'light' | 'dark'
+  /** Extra classes for the trigger wrapper (e.g. flex sizing to match siblings). */
+  className?: string
+}
+
+/**
+ * Header-specific mega-menu wrapper that opens a {@link HeaderDropdown} panel on
+ * hover or click of a nav item, positioned with Floating UI.
+ *
+ * The shared `Dropdown` atom is intentionally not reused: its panel is a white
+ * rounded card with a min-width, which clashes with the full-bleed gray mega
+ * menu. Instead this wires `@floating-ui/react` directly (the same pattern as
+ * `Tooltip`): the panel renders in a `FloatingPortal` with no extra chrome —
+ * `HeaderDropdown` owns 100% of the visuals.
+ *
+ * Interaction:
+ * - `useHover` + `safePolygon` so the cursor can travel from the trigger onto
+ *   the panel without it closing.
+ * - `useClick` so tap/click also toggles (covers touch / no-hover devices).
+ * - `useDismiss` (Escape + outside click) and `useRole({ role: 'dialog' })`.
+ *
+ * The trigger is a real `<Button>` carrying `aria-haspopup`/`aria-expanded`, so
+ * it is keyboard-focusable and opens on Enter/Space; positioning + interaction
+ * props live on the wrapping element (Button does not forward a ref).
+ */
+export function HeaderNavDropdown({
+  label,
+  dropdown,
+  theme = 'light',
+  className = '',
+}: HeaderNavDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'bottom',
+    whileElementsMounted: autoUpdate,
+    // Open flush below the nav; flip/shift keep the wide panel on-screen in both
+    // the static and the scroll-sticky nav states.
+    middleware: [offset(0), flip({ padding: 8 }), shift({ padding: 8 })],
+  })
+
+  const hover = useHover(context, { handleClose: safePolygon() })
+  const click = useClick(context)
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: 'dialog' })
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, click, dismiss, role])
+
+  return (
+    <>
+      <span ref={refs.setReference} {...getReferenceProps()} className={`flex ${className}`}>
+        <Button
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
+          className="px-0 w-full"
+          size="sm"
+          theme={theme}
+          variant="ghost"
+        >
+          {label}
+        </Button>
+      </span>
+
+      {isOpen && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="z-50"
+          >
+            <HeaderDropdown {...dropdown} />
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  )
+}

--- a/components/organisms/Header/HeaderNavDropdown.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.tsx
@@ -77,14 +77,19 @@ export function HeaderNavDropdown({
 
   return (
     <>
-      <span ref={refs.setReference} {...getReferenceProps()} className={`flex ${className}`}>
+      {/*
+       * The span is the positioning anchor (Button doesn't forward a ref); the
+       * interaction props + ARIA (aria-haspopup/expanded/controls from useRole,
+       * plus the hover/click/keyboard handlers) go on the focusable Button so
+       * the popup contract lives on the element a keyboard/AT user lands on.
+       */}
+      <span ref={refs.setReference} className={`flex ${className}`}>
         <Button
-          aria-expanded={isOpen}
-          aria-haspopup="dialog"
           className="px-0 w-full"
           size="sm"
           theme={theme}
           variant="ghost"
+          {...getReferenceProps()}
         >
           {label}
         </Button>

--- a/components/organisms/Header/index.ts
+++ b/components/organisms/Header/index.ts
@@ -1,2 +1,4 @@
 export { Header } from './Header'
 export type { HeaderProps } from './Header'
+export { HeaderNavDropdown } from './HeaderNavDropdown'
+export type { HeaderNavDropdownProps } from './HeaderNavDropdown'

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -9,6 +9,8 @@
 // Header
 export { Header } from './Header'
 export type { HeaderProps } from './Header'
+export { HeaderNavDropdown } from './Header'
+export type { HeaderNavDropdownProps } from './Header'
 
 // Footer
 export { Footer } from './Footer'

--- a/layouts/LayoutChrome.test.tsx
+++ b/layouts/LayoutChrome.test.tsx
@@ -14,8 +14,8 @@ const ctx: { settings: unknown } = { settings: undefined }
 vi.mock('vike-react/useData', () => ({ useData: () => ({ settings: ctx.settings }) }))
 vi.mock('vike-react/usePageContext', () => ({ usePageContext: () => ({ locale: 'en' }) }))
 vi.mock('../components/organisms/Header', () => ({
-  Header: ({ navItems }: { navItems: { label: string }[] }) => (
-    <nav>{navItems.map((n) => n.label).join(',')}</nav>
+  Header: ({ navItems }: { navItems: { label: string; dropdown?: unknown }[] }) => (
+    <nav>{navItems.map((n) => `${n.label}${n.dropdown ? '[dropdown]' : ''}`).join(',')}</nav>
   ),
 }))
 vi.mock('../components/organisms/Footer', () => ({ Footer: () => <footer /> }))
@@ -53,5 +53,38 @@ describe('LayoutChrome', () => {
 
     expect(html).toContain('About')
     expect(html).toContain('Contact')
+  })
+
+  it('gives only the last nav item a knowledge dropdown when knowledge pages exist', () => {
+    ctx.settings = {
+      featuredPages: [
+        { title: 'Meditate', slug: 'meditate' },
+        { title: 'About', slug: 'about' },
+      ],
+      knowledgePages: [{ title: 'Kundalini', slug: 'kundalini' }],
+      featuredArticles: [{ title: 'History', slug: 'history', meta: { image: { url: 'x' } } }],
+      classPages: [],
+      infoPages: [],
+    }
+    const html = renderToStaticMarkup(<LayoutChrome>page content</LayoutChrome>)
+
+    expect(html).toContain('About[dropdown]')
+    // Earlier items stay plain links.
+    expect(html).toContain('Meditate,')
+    expect(html).not.toContain('Meditate[dropdown]')
+  })
+
+  it('leaves the last nav item a plain link when there are no knowledge pages', () => {
+    ctx.settings = {
+      featuredPages: [{ title: 'About', slug: 'about' }],
+      knowledgePages: [],
+      featuredArticles: [],
+      classPages: [],
+      infoPages: [],
+    }
+    const html = renderToStaticMarkup(<LayoutChrome>page content</LayoutChrome>)
+
+    expect(html).toContain('About')
+    expect(html).not.toContain('[dropdown]')
   })
 })

--- a/layouts/LayoutChrome.test.tsx
+++ b/layouts/LayoutChrome.test.tsx
@@ -55,26 +55,29 @@ describe('LayoutChrome', () => {
     expect(html).toContain('Contact')
   })
 
-  it('gives only the last nav item a knowledge dropdown when knowledge pages exist', () => {
+  it('appends a separate link-less knowledge dropdown item (featured links stay plain)', () => {
     ctx.settings = {
       featuredPages: [
         { title: 'Meditate', slug: 'meditate' },
-        { title: 'About', slug: 'about' },
+        { title: 'Music', slug: 'music' },
       ],
-      knowledgePages: [{ title: 'Kundalini', slug: 'kundalini' }],
+      // The dropdown item is labelled from the first knowledge page (interim).
+      knowledgePages: [{ title: 'About Meditation', slug: 'about-meditation' }],
       featuredArticles: [{ title: 'History', slug: 'history', meta: { image: { url: 'x' } } }],
       classPages: [],
       infoPages: [],
     }
     const html = renderToStaticMarkup(<LayoutChrome>page content</LayoutChrome>)
 
-    expect(html).toContain('About[dropdown]')
-    // Earlier items stay plain links.
+    // The appended item carries the dropdown...
+    expect(html).toContain('About Meditation[dropdown]')
+    // ...and the featured pages remain plain links (no dropdown attached).
     expect(html).toContain('Meditate,')
     expect(html).not.toContain('Meditate[dropdown]')
+    expect(html).not.toContain('Music[dropdown]')
   })
 
-  it('leaves the last nav item a plain link when there are no knowledge pages', () => {
+  it('omits the dropdown item entirely when there are no knowledge pages', () => {
     ctx.settings = {
       featuredPages: [{ title: 'About', slug: 'about' }],
       knowledgePages: [],

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { Header } from '../components/organisms/Header'
 import { Footer } from '../components/organisms/Footer'
 import { useData } from 'vike-react/useData'
 import { usePageContext } from 'vike-react/usePageContext'
 import type { WebConfig } from '../server/cms-types'
+import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
 
 /**
  * LayoutChrome — the full site chrome (Header, nav, Footer) around page content.
@@ -32,11 +34,30 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
   const knowledgePages = settings.knowledgePages ?? []
   const infoPages = settings.infoPages ?? []
   const classPages = settings.classPages ?? []
+  const featuredArticles = settings.featuredArticles ?? []
 
-  // Build navigation items from featured pages
-  const navItems = featuredPages.map((page) => ({
+  // The final featured nav item ("About Meditation") opens a mega-menu listing
+  // every knowledge page plus 2 featured-article thumbnails. The 2 articles are
+  // picked at random once per mount (compute-once-and-reuse): because the panel
+  // is closed during SSR the picks never enter the server HTML, so this is
+  // hydration-safe. Falls back to knowledge pages when featuredArticles is empty.
+  const [articlePicks] = useState(() => pickFeaturedArticles(featuredArticles, knowledgePages))
+
+  // Build navigation items from featured pages. Only the last item gains a
+  // dropdown, and only when there are knowledge pages to show (else it stays a
+  // plain link — graceful degradation).
+  const lastIndex = featuredPages.length - 1
+  const navItems = featuredPages.map((page, index) => ({
     label: page.title,
     href: '/' + page.slug,
+    dropdown:
+      index === lastIndex && knowledgePages.length > 0
+        ? {
+            title: page.title,
+            links: knowledgePages.map(pageToLink),
+            featuredArticles: articlePicks.map(pageToArticle),
+          }
+        : undefined,
   }))
 
   // Build footer hero links from featured pages

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -4,6 +4,7 @@ import { Footer } from '../components/organisms/Footer'
 import { useData } from 'vike-react/useData'
 import { usePageContext } from 'vike-react/usePageContext'
 import type { WebConfig } from '../server/cms-types'
+import type { HeaderDropdownProps } from '../components/organisms'
 import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
 
 /**
@@ -36,29 +37,37 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
   const classPages = settings.classPages ?? []
   const featuredArticles = settings.featuredArticles ?? []
 
-  // The final featured nav item ("About Meditation") opens a mega-menu listing
-  // every knowledge page plus 2 featured-article thumbnails. The 2 articles are
-  // picked at random once per mount (compute-once-and-reuse): because the panel
-  // is closed during SSR the picks never enter the server HTML, so this is
-  // hydration-safe. Falls back to knowledge pages when featuredArticles is empty.
+  // The knowledge mega-menu shows 2 featured-article thumbnails picked at random
+  // once per mount (compute-once-and-reuse): because the panel is closed during
+  // SSR the picks never enter the server HTML, so this is hydration-safe. Falls
+  // back to knowledge pages when featuredArticles is empty.
   const [articlePicks] = useState(() => pickFeaturedArticles(featuredArticles, knowledgePages))
 
-  // Build navigation items from featured pages. Only the last item gains a
-  // dropdown, and only when there are knowledge pages to show (else it stays a
-  // plain link — graceful degradation).
-  const lastIndex = featuredPages.length - 1
-  const navItems = featuredPages.map((page, index) => ({
-    label: page.title,
-    href: '/' + page.slug,
-    dropdown:
-      index === lastIndex && knowledgePages.length > 0
-        ? {
-            title: page.title,
-            links: knowledgePages.map(pageToLink),
-            featuredArticles: articlePicks.map(pageToArticle),
-          }
-        : undefined,
-  }))
+  // Nav = the featured pages as plain links, plus a trailing link-less
+  // "About Meditation" item that only opens the knowledge mega-menu (every
+  // knowledge page as a link + the 2 featured-article thumbnails). Appended only
+  // when there are knowledge pages to show — otherwise the nav is featured-only.
+  const navItems: Array<{ label: string; href?: string; dropdown?: HeaderDropdownProps }> =
+    featuredPages.map((page) => ({
+      label: page.title,
+      href: '/' + page.slug,
+    }))
+
+  if (knowledgePages.length > 0) {
+    // TODO: Source this label from WmWebTranslations.navigation once that global
+    // is configured in the CMS. Interim: the knowledge group's first page title,
+    // matching how the footer labels the same group below (localized either way).
+    const knowledgeLabel = knowledgePages[0].title
+
+    navItems.push({
+      label: knowledgeLabel,
+      dropdown: {
+        title: knowledgeLabel,
+        links: knowledgePages.map(pageToLink),
+        featuredArticles: articlePicks.map(pageToArticle),
+      },
+    })
+  }
 
   // Build footer hero links from featured pages
   const footerHeroLinks = featuredPages.map((page) => ({

--- a/layouts/headerDropdown.test.ts
+++ b/layouts/headerDropdown.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
+import type { Page } from '../server/cms-types'
+
+const page = (over: Partial<Page>): Page => ({ id: 1, slug: 's', title: 'T', ...over }) as Page
+
+describe('pageToLink', () => {
+  it('maps a page to a slug-rooted nav link', () => {
+    expect(pageToLink(page({ title: 'Kundalini', slug: 'kundalini' }))).toEqual({
+      label: 'Kundalini',
+      href: '/kundalini',
+    })
+  })
+})
+
+describe('pageToArticle', () => {
+  it('resolves a populated meta.image to its URL', () => {
+    const article = pageToArticle(
+      page({
+        title: 'History',
+        slug: 'history',
+        meta: { image: { url: 'https://imagedelivery.net/x/y/' } } as Page['meta'],
+      }),
+    )
+
+    expect(article).toEqual({
+      title: 'History',
+      image: 'https://imagedelivery.net/x/y/',
+      imageAlt: 'History',
+      href: '/history',
+    })
+  })
+
+  it('uses meta.title for alt text when present', () => {
+    const article = pageToArticle(
+      page({
+        title: 'History',
+        slug: 'history',
+        meta: { title: 'A History of Meditation' } as Page['meta'],
+      }),
+    )
+
+    expect(article.imageAlt).toBe('A History of Meditation')
+  })
+
+  it('falls back gracefully (empty image) when meta.image is missing', () => {
+    expect(pageToArticle(page({ title: 'No Image', slug: 'no-image' })).image).toBe('')
+  })
+})
+
+describe('pickFeaturedArticles', () => {
+  const featured = [page({ id: 1 }), page({ id: 2 }), page({ id: 3 }), page({ id: 4 })]
+  const fallback = [page({ id: 10 }), page({ id: 11 })]
+
+  it('falls back to knowledge pages when featured is empty', () => {
+    expect(pickFeaturedArticles([], fallback)).toEqual(fallback)
+  })
+
+  it('returns all available when fewer than count exist (render what exists)', () => {
+    const one = [page({ id: 99 })]
+
+    expect(pickFeaturedArticles(one, fallback)).toHaveLength(1)
+  })
+
+  it('picks exactly count distinct pages from a longer list', () => {
+    // random() = 0 always → partial Fisher–Yates keeps the first `count` items.
+    const picks = pickFeaturedArticles(featured, fallback, 2, () => 0)
+
+    expect(picks).toHaveLength(2)
+    expect(new Set(picks.map((p) => p.id)).size).toBe(2)
+    // Every pick is a member of the source list.
+    expect(picks.every((p) => featured.includes(p))).toBe(true)
+  })
+
+  it('does not mutate the input arrays', () => {
+    const ids = featured.map((p) => p.id)
+
+    pickFeaturedArticles(featured, fallback, 2, () => 0.5)
+    expect(featured.map((p) => p.id)).toEqual(ids)
+  })
+})

--- a/layouts/headerDropdown.ts
+++ b/layouts/headerDropdown.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for building the header mega-menu (HeaderDropdown) payload from
+ * CMS pages. Kept framework-free so the mapping, image resolution, and random
+ * selection can be unit-tested without rendering.
+ */
+import type { Page } from '../server/cms-types'
+import { populatedImageUrl } from '../lib/cms-relationships'
+import type { HeaderDropdownArticle, HeaderDropdownLink } from '../components/organisms'
+
+/** A knowledge page → a left-column nav link (`/<slug>`). */
+export function pageToLink(page: Page): HeaderDropdownLink {
+  return { label: page.title, href: '/' + page.slug }
+}
+
+/**
+ * A page → a featured-article card. Resolves the page's `meta.image`
+ * relationship to a URL (empty string when none is populated — the article is
+ * still linkable), and falls back to the page title for alt text.
+ */
+export function pageToArticle(page: Page): HeaderDropdownArticle {
+  return {
+    title: page.title,
+    image: populatedImageUrl(page.meta?.image) ?? '',
+    imageAlt: page.meta?.title ?? page.title,
+    href: '/' + page.slug,
+  }
+}
+
+/**
+ * Pick `count` pages at random from the curated `featured` list (the CMS
+ * `featuredArticles`, which may hold more than `count`), falling back to
+ * `fallback` (knowledge pages) when `featured` is empty. Returns all available
+ * pages when fewer than `count` exist. Pure: input arrays are not mutated and
+ * `random` is injectable for deterministic tests.
+ */
+export function pickFeaturedArticles(
+  featured: Page[],
+  fallback: Page[],
+  count = 2,
+  random: () => number = Math.random,
+): Page[] {
+  const source = featured.length > 0 ? featured : fallback
+
+  if (source.length <= count) return source.slice()
+
+  // Partial Fisher–Yates: pick `count` distinct items without a full shuffle.
+  const pool = source.slice()
+
+  for (let i = 0; i < count; i++) {
+    const j = i + Math.floor(random() * (pool.length - i))
+
+    ;[pool[i], pool[j]] = [pool[j], pool[i]]
+  }
+
+  return pool.slice(0, count)
+}

--- a/server/cms-client.test.ts
+++ b/server/cms-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { getPageBySlug, partitionPublishedPages } from './cms-client'
+import { getPageBySlug, getWebConfig, partitionPublishedPages } from './cms-client'
 import { createPayloadClient } from './payload-client'
 import type { Page } from './cms-types'
 
@@ -9,6 +9,8 @@ vi.mock('./payload-client', () => ({
   createPayloadClient: vi.fn(),
   validateSDKResponse: (value: unknown) => value,
 }))
+// Silence the Sentry warning emitted on unresolved page references.
+vi.mock('@sentry/react', () => ({ captureMessage: vi.fn() }))
 vi.mock('./kv-cache', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./kv-cache')>()
 
@@ -39,6 +41,31 @@ describe('partitionPublishedPages', () => {
 
     expect(published).toHaveLength(2)
     expect(unresolved).toEqual([])
+  })
+})
+
+describe('getWebConfig featuredArticles', () => {
+  it('selects featuredArticles and drops unpublished (bare-id) refs', async () => {
+    const findGlobal = vi.fn().mockResolvedValue({
+      id: 1,
+      homePage: page(1, 'home'),
+      featuredPages: [page(2, 'about')],
+      // One published article + one unpublished page (returned as a bare id).
+      featuredArticles: [page(3, 'history-of-meditation'), 42],
+      classPages: [],
+      knowledgePages: [page(4, 'kundalini')],
+      infoPages: [],
+    })
+
+    vi.mocked(createPayloadClient).mockReturnValue({ findGlobal } as never)
+
+    const config = await getWebConfig({ locale: 'en' })
+    const args = findGlobal.mock.calls[0][0]
+
+    // The read must request featuredArticles (per .claude/rules/cms-api-reads.md).
+    expect(args.select.featuredArticles).toBe(true)
+    // The bare-id (unpublished) ref is dropped; only linkable articles remain.
+    expect(config.featuredArticles.map((p) => p.slug)).toEqual(['history-of-meditation'])
   })
 })
 

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -166,6 +166,7 @@ const PAGE_POPULATE = {
 const WEB_CONFIG_SELECT = {
   homePage: true,
   featuredPages: true,
+  featuredArticles: true,
   classPages: true,
   knowledgePages: true,
   infoPages: true,
@@ -501,6 +502,7 @@ export async function getWebConfig(options: { locale?: Locale } = {}): Promise<W
       // Drop unresolved (believed-unpublished) page references so the layout
       // never renders dead `/undefined` links — graceful fallback.
       const featured = partitionPublishedPages(validated.featuredPages)
+      const featuredArticles = partitionPublishedPages(validated.featuredArticles)
       const classPages = partitionPublishedPages(validated.classPages)
       const knowledgePages = partitionPublishedPages(validated.knowledgePages)
       const infoPages = partitionPublishedPages(validated.infoPages)
@@ -508,6 +510,7 @@ export async function getWebConfig(options: { locale?: Locale } = {}): Promise<W
       const unresolved = [
         ...(typeof validated.homePage === 'number' ? [`homePage id:${validated.homePage}`] : []),
         ...featured.unresolved.map((u) => `featuredPages ${u}`),
+        ...featuredArticles.unresolved.map((u) => `featuredArticles ${u}`),
         ...classPages.unresolved.map((u) => `classPages ${u}`),
         ...knowledgePages.unresolved.map((u) => `knowledgePages ${u}`),
         ...infoPages.unresolved.map((u) => `infoPages ${u}`),
@@ -529,6 +532,7 @@ export async function getWebConfig(options: { locale?: Locale } = {}): Promise<W
       return {
         ...validated,
         featuredPages: featured.published,
+        featuredArticles: featuredArticles.published,
         classPages: classPages.published,
         knowledgePages: knowledgePages.published,
         infoPages: infoPages.published,

--- a/server/cms-types.ts
+++ b/server/cms-types.ts
@@ -35,10 +35,11 @@ export type { ResolvedLecture, LectureMetadata, LectureSubtitleTrack } from '../
  */
 export interface WebConfig extends Omit<
   WmWebConfig,
-  'homePage' | 'featuredPages' | 'classPages' | 'knowledgePages' | 'infoPages'
+  'homePage' | 'featuredPages' | 'featuredArticles' | 'classPages' | 'knowledgePages' | 'infoPages'
 > {
   homePage: Page
   featuredPages: Page[]
+  featuredArticles: Page[]
   classPages: Page[]
   knowledgePages: Page[]
   infoPages: Page[]

--- a/server/payload-types.ts
+++ b/server/payload-types.ts
@@ -13,6 +13,7 @@
  * via the `definition` "supportedTimezones".
  */
 export type SupportedTimezones =
+  | 'UTC'
   | 'Pacific/Midway'
   | 'Pacific/Niue'
   | 'Pacific/Honolulu'
@@ -59,7 +60,540 @@ export type SupportedTimezones =
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
-  | 'Pacific/Fiji';
+  | 'Pacific/Fiji'
+  | 'Pacific/Pago_Pago'
+  | 'US/Samoa'
+  | 'Pacific/Samoa'
+  | 'US/Hawaii'
+  | 'Pacific/Johnston'
+  | 'HST'
+  | 'Pacific/Tahiti'
+  | 'Pacific/Marquesas'
+  | 'America/Adak'
+  | 'US/Aleutian'
+  | 'America/Atka'
+  | 'America/Juneau'
+  | 'America/Metlakatla'
+  | 'America/Nome'
+  | 'America/Sitka'
+  | 'America/Yakutat'
+  | 'US/Alaska'
+  | 'Pacific/Pitcairn'
+  | 'America/Hermosillo'
+  | 'America/Mazatlan'
+  | 'Mexico/BajaSur'
+  | 'MST'
+  | 'US/Arizona'
+  | 'America/Creston'
+  | 'US/Pacific'
+  | 'PST8PDT'
+  | 'Mexico/BajaNorte'
+  | 'America/Ensenada'
+  | 'America/Santa_Isabel'
+  | 'America/Vancouver'
+  | 'Canada/Pacific'
+  | 'America/Whitehorse'
+  | 'America/Dawson'
+  | 'America/Dawson_Creek'
+  | 'America/Fort_Nelson'
+  | 'Canada/Yukon'
+  | 'America/Belize'
+  | 'America/Managua'
+  | 'America/Mexico_City'
+  | 'America/Bahia_Banderas'
+  | 'America/Chihuahua'
+  | 'America/Merida'
+  | 'America/Monterrey'
+  | 'Mexico/General'
+  | 'America/Costa_Rica'
+  | 'America/El_Salvador'
+  | 'America/Regina'
+  | 'America/Swift_Current'
+  | 'Canada/Saskatchewan'
+  | 'America/Tegucigalpa'
+  | 'Pacific/Easter'
+  | 'Chile/EasterIsland'
+  | 'Pacific/Galapagos'
+  | 'America/Edmonton'
+  | 'America/Cambridge_Bay'
+  | 'America/Inuvik'
+  | 'Canada/Mountain'
+  | 'America/Yellowknife'
+  | 'America/Ciudad_Juarez'
+  | 'America/Boise'
+  | 'MST7MDT'
+  | 'Navajo'
+  | 'US/Mountain'
+  | 'America/Shiprock'
+  | 'America/Rio_Branco'
+  | 'America/Eirunepe'
+  | 'Brazil/Acre'
+  | 'America/Porto_Acre'
+  | 'America/Indiana/Knox'
+  | 'America/Indiana/Tell_City'
+  | 'America/Menominee'
+  | 'America/North_Dakota/Beulah'
+  | 'America/North_Dakota/Center'
+  | 'America/North_Dakota/New_Salem'
+  | 'CST6CDT'
+  | 'US/Central'
+  | 'US/Indiana-Starke'
+  | 'America/Knox_IN'
+  | 'America/Matamoros'
+  | 'America/Ojinaga'
+  | 'America/Winnipeg'
+  | 'America/Rankin_Inlet'
+  | 'America/Resolute'
+  | 'Canada/Central'
+  | 'America/Rainy_River'
+  | 'America/Atikokan'
+  | 'America/Cancun'
+  | 'America/Cayman'
+  | 'America/Jamaica'
+  | 'Jamaica'
+  | 'America/Panama'
+  | 'EST'
+  | 'America/Coral_Harbour'
+  | 'America/Guayaquil'
+  | 'America/Lima'
+  | 'America/Manaus'
+  | 'America/Boa_Vista'
+  | 'America/Campo_Grande'
+  | 'America/Cuiaba'
+  | 'America/Porto_Velho'
+  | 'Brazil/West'
+  | 'America/St_Kitts'
+  | 'America/Blanc-Sablon'
+  | 'America/Montserrat'
+  | 'America/Barbados'
+  | 'America/Port_of_Spain'
+  | 'America/Martinique'
+  | 'America/St_Lucia'
+  | 'America/St_Barthelemy'
+  | 'America/St_Vincent'
+  | 'America/Kralendijk'
+  | 'America/Guadeloupe'
+  | 'America/Marigot'
+  | 'America/Aruba'
+  | 'America/Lower_Princes'
+  | 'America/Tortola'
+  | 'America/Dominica'
+  | 'America/St_Thomas'
+  | 'America/Grenada'
+  | 'America/Antigua'
+  | 'America/Puerto_Rico'
+  | 'America/Virgin'
+  | 'America/Anguilla'
+  | 'America/Curacao'
+  | 'America/Santo_Domingo'
+  | 'America/La_Paz'
+  | 'Chile/Continental'
+  | 'America/Havana'
+  | 'Cuba'
+  | 'America/Nassau'
+  | 'America/Detroit'
+  | 'America/Indiana/Indianapolis'
+  | 'America/Indiana/Marengo'
+  | 'America/Indiana/Petersburg'
+  | 'America/Indiana/Vevay'
+  | 'America/Indiana/Vincennes'
+  | 'America/Indiana/Winamac'
+  | 'America/Kentucky/Louisville'
+  | 'America/Kentucky/Monticello'
+  | 'US/Michigan'
+  | 'US/East-Indiana'
+  | 'America/Indianapolis'
+  | 'America/Fort_Wayne'
+  | 'America/Louisville'
+  | 'EST5EDT'
+  | 'US/Eastern'
+  | 'America/Port-au-Prince'
+  | 'America/Grand_Turk'
+  | 'America/Toronto'
+  | 'America/Iqaluit'
+  | 'America/Pangnirtung'
+  | 'Canada/Eastern'
+  | 'America/Montreal'
+  | 'America/Nipigon'
+  | 'America/Thunder_Bay'
+  | 'America/Guyana'
+  | 'America/Argentina/Buenos_Aires'
+  | 'America/Argentina/Catamarca'
+  | 'America/Argentina/Cordoba'
+  | 'America/Argentina/Jujuy'
+  | 'America/Argentina/La_Rioja'
+  | 'America/Argentina/Mendoza'
+  | 'America/Argentina/Rio_Gallegos'
+  | 'America/Argentina/Salta'
+  | 'America/Argentina/San_Juan'
+  | 'America/Argentina/San_Luis'
+  | 'America/Argentina/Tucuman'
+  | 'America/Argentina/Ushuaia'
+  | 'America/Catamarca'
+  | 'America/Argentina/ComodRivadavia'
+  | 'America/Cordoba'
+  | 'America/Rosario'
+  | 'America/Jujuy'
+  | 'America/Mendoza'
+  | 'America/Halifax'
+  | 'America/Glace_Bay'
+  | 'America/Goose_Bay'
+  | 'America/Moncton'
+  | 'Canada/Atlantic'
+  | 'Atlantic/Bermuda'
+  | 'America/Thule'
+  | 'America/Araguaina'
+  | 'America/Bahia'
+  | 'America/Belem'
+  | 'America/Fortaleza'
+  | 'America/Maceio'
+  | 'America/Recife'
+  | 'America/Santarem'
+  | 'Brazil/East'
+  | 'Antarctica/Palmer'
+  | 'Antarctica/Rothera'
+  | 'America/Punta_Arenas'
+  | 'America/Coyhaique'
+  | 'Atlantic/Stanley'
+  | 'America/Cayenne'
+  | 'America/Asuncion'
+  | 'America/Paramaribo'
+  | 'America/Montevideo'
+  | 'America/St_Johns'
+  | 'Canada/Newfoundland'
+  | 'America/Noronha'
+  | 'Brazil/DeNoronha'
+  | 'America/Miquelon'
+  | 'America/Nuuk'
+  | 'America/Scoresbysund'
+  | 'America/Godthab'
+  | 'Africa/Abidjan'
+  | 'Iceland'
+  | 'Africa/Accra'
+  | 'Africa/Bamako'
+  | 'Africa/Banjul'
+  | 'Africa/Conakry'
+  | 'Africa/Dakar'
+  | 'Africa/Freetown'
+  | 'Africa/Lome'
+  | 'Africa/Nouakchott'
+  | 'Africa/Ouagadougou'
+  | 'Atlantic/Reykjavik'
+  | 'Atlantic/St_Helena'
+  | 'Africa/Timbuktu'
+  | 'Africa/Bissau'
+  | 'America/Danmarkshavn'
+  | 'Africa/Monrovia'
+  | 'Africa/Sao_Tome'
+  | 'Africa/Algiers'
+  | 'Africa/Tunis'
+  | 'Europe/Isle_of_Man'
+  | 'Europe/Dublin'
+  | 'Eire'
+  | 'GB'
+  | 'GB-Eire'
+  | 'Europe/Guernsey'
+  | 'Europe/Jersey'
+  | 'Europe/Belfast'
+  | 'Africa/Bangui'
+  | 'Africa/Malabo'
+  | 'Africa/Brazzaville'
+  | 'Africa/Porto-Novo'
+  | 'Africa/Douala'
+  | 'Africa/Kinshasa'
+  | 'Africa/Libreville'
+  | 'Africa/Luanda'
+  | 'Africa/Niamey'
+  | 'Africa/Ndjamena'
+  | 'Africa/Casablanca'
+  | 'Africa/El_Aaiun'
+  | 'Atlantic/Canary'
+  | 'Europe/Lisbon'
+  | 'Atlantic/Madeira'
+  | 'Portugal'
+  | 'WET'
+  | 'Atlantic/Faroe'
+  | 'Atlantic/Faeroe'
+  | 'Africa/Bujumbura'
+  | 'Africa/Gaborone'
+  | 'Africa/Harare'
+  | 'Africa/Juba'
+  | 'Africa/Khartoum'
+  | 'Africa/Kigali'
+  | 'Africa/Blantyre'
+  | 'Africa/Lubumbashi'
+  | 'Africa/Lusaka'
+  | 'Africa/Maputo'
+  | 'Africa/Windhoek'
+  | 'Europe/Andorra'
+  | 'Europe/Belgrade'
+  | 'Europe/Ljubljana'
+  | 'Europe/Podgorica'
+  | 'Europe/Sarajevo'
+  | 'Europe/Skopje'
+  | 'Europe/Zagreb'
+  | 'Europe/Busingen'
+  | 'Arctic/Longyearbyen'
+  | 'Europe/Copenhagen'
+  | 'Europe/Oslo'
+  | 'Europe/Stockholm'
+  | 'Atlantic/Jan_Mayen'
+  | 'Europe/Bratislava'
+  | 'Europe/Brussels'
+  | 'CET'
+  | 'MET'
+  | 'Europe/Amsterdam'
+  | 'Europe/Luxembourg'
+  | 'Europe/Budapest'
+  | 'Europe/Gibraltar'
+  | 'Europe/Madrid'
+  | 'Africa/Ceuta'
+  | 'Europe/Monaco'
+  | 'Europe/Paris'
+  | 'Europe/Prague'
+  | 'Europe/Rome'
+  | 'Europe/San_Marino'
+  | 'Europe/Vatican'
+  | 'Europe/Malta'
+  | 'Europe/Tirane'
+  | 'Europe/Vaduz'
+  | 'Europe/Vienna'
+  | 'Europe/Warsaw'
+  | 'Poland'
+  | 'Europe/Zurich'
+  | 'Europe/Kaliningrad'
+  | 'Africa/Tripoli'
+  | 'Libya'
+  | 'Antarctica/Troll'
+  | 'Africa/Johannesburg'
+  | 'Africa/Maseru'
+  | 'Africa/Mbabane'
+  | 'Asia/Kuwait'
+  | 'Asia/Bahrain'
+  | 'Asia/Baghdad'
+  | 'Asia/Qatar'
+  | 'Antarctica/Syowa'
+  | 'Asia/Aden'
+  | 'Asia/Amman'
+  | 'Asia/Damascus'
+  | 'Africa/Addis_Ababa'
+  | 'Indian/Antananarivo'
+  | 'Africa/Asmara'
+  | 'Africa/Dar_es_Salaam'
+  | 'Africa/Djibouti'
+  | 'Africa/Kampala'
+  | 'Indian/Mayotte'
+  | 'Africa/Mogadishu'
+  | 'Indian/Comoro'
+  | 'Africa/Nairobi'
+  | 'Africa/Asmera'
+  | 'EET'
+  | 'Asia/Beirut'
+  | 'Europe/Bucharest'
+  | 'Egypt'
+  | 'Europe/Chisinau'
+  | 'Europe/Tiraspol'
+  | 'Asia/Hebron'
+  | 'Asia/Gaza'
+  | 'Europe/Helsinki'
+  | 'Europe/Mariehamn'
+  | 'Europe/Kyiv'
+  | 'Europe/Uzhgorod'
+  | 'Europe/Zaporozhye'
+  | 'Europe/Kiev'
+  | 'Asia/Nicosia'
+  | 'Asia/Famagusta'
+  | 'Europe/Nicosia'
+  | 'Europe/Riga'
+  | 'Europe/Sofia'
+  | 'Europe/Tallinn'
+  | 'Europe/Vilnius'
+  | 'Asia/Jerusalem'
+  | 'Israel'
+  | 'Asia/Tel_Aviv'
+  | 'Europe/Minsk'
+  | 'Europe/Kirov'
+  | 'Europe/Volgograd'
+  | 'W-SU'
+  | 'Europe/Simferopol'
+  | 'Europe/Istanbul'
+  | 'Turkey'
+  | 'Asia/Istanbul'
+  | 'Asia/Tehran'
+  | 'Iran'
+  | 'Asia/Yerevan'
+  | 'Asia/Tbilisi'
+  | 'Asia/Muscat'
+  | 'Indian/Mahe'
+  | 'Indian/Reunion'
+  | 'Indian/Mauritius'
+  | 'Europe/Samara'
+  | 'Europe/Astrakhan'
+  | 'Europe/Saratov'
+  | 'Europe/Ulyanovsk'
+  | 'Asia/Kabul'
+  | 'Indian/Kerguelen'
+  | 'Asia/Aqtau'
+  | 'Asia/Aqtobe'
+  | 'Asia/Atyrau'
+  | 'Asia/Oral'
+  | 'Asia/Qostanay'
+  | 'Asia/Qyzylorda'
+  | 'Indian/Maldives'
+  | 'Antarctica/Mawson'
+  | 'Antarctica/Vostok'
+  | 'Asia/Dushanbe'
+  | 'Asia/Ashgabat'
+  | 'Asia/Ashkhabad'
+  | 'Asia/Samarkand'
+  | 'Asia/Yekaterinburg'
+  | 'Asia/Colombo'
+  | 'Asia/Kolkata'
+  | 'Asia/Kathmandu'
+  | 'Asia/Katmandu'
+  | 'Asia/Dacca'
+  | 'Asia/Thimphu'
+  | 'Asia/Thimbu'
+  | 'Asia/Urumqi'
+  | 'Asia/Kashgar'
+  | 'Indian/Chagos'
+  | 'Asia/Bishkek'
+  | 'Asia/Omsk'
+  | 'Indian/Cocos'
+  | 'Asia/Yangon'
+  | 'Asia/Rangoon'
+  | 'Indian/Christmas'
+  | 'Antarctica/Davis'
+  | 'Asia/Hovd'
+  | 'Asia/Phnom_Penh'
+  | 'Asia/Vientiane'
+  | 'Asia/Ho_Chi_Minh'
+  | 'Asia/Saigon'
+  | 'Asia/Novosibirsk'
+  | 'Asia/Barnaul'
+  | 'Asia/Krasnoyarsk'
+  | 'Asia/Novokuznetsk'
+  | 'Asia/Tomsk'
+  | 'Asia/Pontianak'
+  | 'Antarctica/Casey'
+  | 'Australia/Perth'
+  | 'Australia/West'
+  | 'Asia/Brunei'
+  | 'Asia/Makassar'
+  | 'Asia/Ujung_Pandang'
+  | 'Asia/Macau'
+  | 'Asia/Macao'
+  | 'PRC'
+  | 'Asia/Chongqing'
+  | 'Asia/Harbin'
+  | 'Asia/Chungking'
+  | 'Asia/Hong_Kong'
+  | 'Hongkong'
+  | 'Asia/Irkutsk'
+  | 'Asia/Kuala_Lumpur'
+  | 'Asia/Kuching'
+  | 'Asia/Manila'
+  | 'Singapore'
+  | 'Asia/Taipei'
+  | 'ROC'
+  | 'Asia/Ulaanbaatar'
+  | 'Asia/Choibalsan'
+  | 'Asia/Ulan_Bator'
+  | 'Australia/Eucla'
+  | 'Asia/Jayapura'
+  | 'Japan'
+  | 'Asia/Pyongyang'
+  | 'ROK'
+  | 'Pacific/Palau'
+  | 'Asia/Dili'
+  | 'Asia/Chita'
+  | 'Asia/Khandyga'
+  | 'Asia/Yakutsk'
+  | 'Australia/Adelaide'
+  | 'Australia/Broken_Hill'
+  | 'Australia/South'
+  | 'Australia/Yancowinna'
+  | 'Australia/Darwin'
+  | 'Australia/North'
+  | 'Australia/Lindeman'
+  | 'Australia/Queensland'
+  | 'Antarctica/Macquarie'
+  | 'Australia/Hobart'
+  | 'Australia/Melbourne'
+  | 'Australia/Tasmania'
+  | 'Australia/Currie'
+  | 'Australia/Victoria'
+  | 'Australia/ACT'
+  | 'Australia/NSW'
+  | 'Australia/Canberra'
+  | 'Pacific/Saipan'
+  | 'Pacific/Chuuk'
+  | 'Antarctica/DumontDUrville'
+  | 'Pacific/Port_Moresby'
+  | 'Pacific/Yap'
+  | 'Pacific/Truk'
+  | 'Asia/Vladivostok'
+  | 'Asia/Ust-Nera'
+  | 'Australia/Lord_Howe'
+  | 'Australia/LHI'
+  | 'Pacific/Bougainville'
+  | 'Pacific/Kosrae'
+  | 'Pacific/Pohnpei'
+  | 'Pacific/Norfolk'
+  | 'Asia/Sakhalin'
+  | 'Asia/Magadan'
+  | 'Asia/Srednekolymsk'
+  | 'Pacific/Guadalcanal'
+  | 'Pacific/Ponape'
+  | 'Pacific/Efate'
+  | 'Pacific/Tarawa'
+  | 'Pacific/Funafuti'
+  | 'Pacific/Majuro'
+  | 'Pacific/Wake'
+  | 'Pacific/Wallis'
+  | 'Asia/Kamchatka'
+  | 'Asia/Anadyr'
+  | 'Pacific/Kwajalein'
+  | 'Kwajalein'
+  | 'Pacific/Nauru'
+  | 'NZ'
+  | 'Antarctica/McMurdo'
+  | 'Antarctica/South_Pole'
+  | 'Pacific/Chatham'
+  | 'NZ-CHAT'
+  | 'Pacific/Kanton'
+  | 'Pacific/Enderbury'
+  | 'Pacific/Apia'
+  | 'Pacific/Fakaofo'
+  | 'Pacific/Tongatapu'
+  | 'Pacific/Kiritimati'
+  | 'Etc/GMT-14'
+  | 'Etc/GMT-13'
+  | 'Etc/GMT-12'
+  | 'Etc/GMT-11'
+  | 'Etc/GMT-10'
+  | 'Etc/GMT-9'
+  | 'Etc/GMT-8'
+  | 'Etc/GMT-7'
+  | 'Etc/GMT-6'
+  | 'Etc/GMT-5'
+  | 'Etc/GMT-4'
+  | 'Etc/GMT-3'
+  | 'Etc/GMT-2'
+  | 'Etc/GMT-1'
+  | 'Etc/GMT'
+  | 'Etc/GMT+1'
+  | 'Etc/GMT+2'
+  | 'Etc/GMT+3'
+  | 'Etc/GMT+4'
+  | 'Etc/GMT+5'
+  | 'Etc/GMT+6'
+  | 'Etc/GMT+7'
+  | 'Etc/GMT+8'
+  | 'Etc/GMT+9'
+  | 'Etc/GMT+10'
+  | 'Etc/GMT+11'
+  | 'Etc/GMT+12';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "ProjectSlug".
@@ -148,6 +682,9 @@ export interface Config {
     };
     regions: {
       events: 'events';
+      childrenRegions: 'regions';
+      childrenCities: 'regions';
+      childrenCenters: 'regions';
     };
     events: {
       registrations: 'registrations';
@@ -258,6 +795,7 @@ export interface Config {
   jobs: {
     tasks: {
       cleanupOrphanedMedia: TaskCleanupOrphanedMedia;
+      expireEvents: TaskExpireEvents;
       syncLectureMetadata: TaskSyncLectureMetadata;
       resetUsage: TaskResetUsage;
       schedulePublish: TaskSchedulePublish;
@@ -462,6 +1000,7 @@ export interface Author {
 export interface Video {
   id: number;
   hlsUrl?: string | null;
+  mp4Url?: string | null;
   previewUrl?: string | null;
   thumbnail?: (number | null) | Image;
   /**
@@ -542,7 +1081,7 @@ export interface Manager {
   /**
    * The manager's preferred language.
    */
-  languageCode?:
+  language?:
     | (
         | 'ab'
         | 'aa'
@@ -800,25 +1339,25 @@ export interface Region {
    * The geographic parent of this node (a higher level).
    */
   parent?: (number | null) | Region;
-  name: string;
   /**
-   * Text that appears below the region name in listings
+   * Managers responsible for this region.
    */
-  subtitle?: string | null;
+  managers?: (number | Manager)[] | null;
   /**
    * Search for this place (country, region, city, or venue) to set its geographic identity, or "Enter manually" to provide your own coordinates.
    */
   mapboxId: string;
+  name?: string | null;
+  /**
+   * Text that appears below the region name in listings
+   */
+  subtitle?: string | null;
   latitude?: number | null;
   longitude?: number | null;
   /**
    * Radius in meters.
    */
   radius?: number | null;
-  /**
-   * Managers responsible for this region.
-   */
-  managers?: (number | Manager)[] | null;
   /**
    * These fields will be used to set defaults for Events in this region
    */
@@ -1012,6 +1551,7 @@ export interface Region {
       | null;
     timeZone?:
       | (
+          | 'UTC'
           | 'Pacific/Midway'
           | 'Pacific/Niue'
           | 'Pacific/Honolulu'
@@ -1059,6 +1599,539 @@ export interface Region {
           | 'Pacific/Noumea'
           | 'Pacific/Auckland'
           | 'Pacific/Fiji'
+          | 'Pacific/Pago_Pago'
+          | 'US/Samoa'
+          | 'Pacific/Samoa'
+          | 'US/Hawaii'
+          | 'Pacific/Johnston'
+          | 'HST'
+          | 'Pacific/Tahiti'
+          | 'Pacific/Marquesas'
+          | 'America/Adak'
+          | 'US/Aleutian'
+          | 'America/Atka'
+          | 'America/Juneau'
+          | 'America/Metlakatla'
+          | 'America/Nome'
+          | 'America/Sitka'
+          | 'America/Yakutat'
+          | 'US/Alaska'
+          | 'Pacific/Pitcairn'
+          | 'America/Hermosillo'
+          | 'America/Mazatlan'
+          | 'Mexico/BajaSur'
+          | 'MST'
+          | 'US/Arizona'
+          | 'America/Creston'
+          | 'US/Pacific'
+          | 'PST8PDT'
+          | 'Mexico/BajaNorte'
+          | 'America/Ensenada'
+          | 'America/Santa_Isabel'
+          | 'America/Vancouver'
+          | 'Canada/Pacific'
+          | 'America/Whitehorse'
+          | 'America/Dawson'
+          | 'America/Dawson_Creek'
+          | 'America/Fort_Nelson'
+          | 'Canada/Yukon'
+          | 'America/Belize'
+          | 'America/Managua'
+          | 'America/Mexico_City'
+          | 'America/Bahia_Banderas'
+          | 'America/Chihuahua'
+          | 'America/Merida'
+          | 'America/Monterrey'
+          | 'Mexico/General'
+          | 'America/Costa_Rica'
+          | 'America/El_Salvador'
+          | 'America/Regina'
+          | 'America/Swift_Current'
+          | 'Canada/Saskatchewan'
+          | 'America/Tegucigalpa'
+          | 'Pacific/Easter'
+          | 'Chile/EasterIsland'
+          | 'Pacific/Galapagos'
+          | 'America/Edmonton'
+          | 'America/Cambridge_Bay'
+          | 'America/Inuvik'
+          | 'Canada/Mountain'
+          | 'America/Yellowknife'
+          | 'America/Ciudad_Juarez'
+          | 'America/Boise'
+          | 'MST7MDT'
+          | 'Navajo'
+          | 'US/Mountain'
+          | 'America/Shiprock'
+          | 'America/Rio_Branco'
+          | 'America/Eirunepe'
+          | 'Brazil/Acre'
+          | 'America/Porto_Acre'
+          | 'America/Indiana/Knox'
+          | 'America/Indiana/Tell_City'
+          | 'America/Menominee'
+          | 'America/North_Dakota/Beulah'
+          | 'America/North_Dakota/Center'
+          | 'America/North_Dakota/New_Salem'
+          | 'CST6CDT'
+          | 'US/Central'
+          | 'US/Indiana-Starke'
+          | 'America/Knox_IN'
+          | 'America/Matamoros'
+          | 'America/Ojinaga'
+          | 'America/Winnipeg'
+          | 'America/Rankin_Inlet'
+          | 'America/Resolute'
+          | 'Canada/Central'
+          | 'America/Rainy_River'
+          | 'America/Atikokan'
+          | 'America/Cancun'
+          | 'America/Cayman'
+          | 'America/Jamaica'
+          | 'Jamaica'
+          | 'America/Panama'
+          | 'EST'
+          | 'America/Coral_Harbour'
+          | 'America/Guayaquil'
+          | 'America/Lima'
+          | 'America/Manaus'
+          | 'America/Boa_Vista'
+          | 'America/Campo_Grande'
+          | 'America/Cuiaba'
+          | 'America/Porto_Velho'
+          | 'Brazil/West'
+          | 'America/St_Kitts'
+          | 'America/Blanc-Sablon'
+          | 'America/Montserrat'
+          | 'America/Barbados'
+          | 'America/Port_of_Spain'
+          | 'America/Martinique'
+          | 'America/St_Lucia'
+          | 'America/St_Barthelemy'
+          | 'America/St_Vincent'
+          | 'America/Kralendijk'
+          | 'America/Guadeloupe'
+          | 'America/Marigot'
+          | 'America/Aruba'
+          | 'America/Lower_Princes'
+          | 'America/Tortola'
+          | 'America/Dominica'
+          | 'America/St_Thomas'
+          | 'America/Grenada'
+          | 'America/Antigua'
+          | 'America/Puerto_Rico'
+          | 'America/Virgin'
+          | 'America/Anguilla'
+          | 'America/Curacao'
+          | 'America/Santo_Domingo'
+          | 'America/La_Paz'
+          | 'Chile/Continental'
+          | 'America/Havana'
+          | 'Cuba'
+          | 'America/Nassau'
+          | 'America/Detroit'
+          | 'America/Indiana/Indianapolis'
+          | 'America/Indiana/Marengo'
+          | 'America/Indiana/Petersburg'
+          | 'America/Indiana/Vevay'
+          | 'America/Indiana/Vincennes'
+          | 'America/Indiana/Winamac'
+          | 'America/Kentucky/Louisville'
+          | 'America/Kentucky/Monticello'
+          | 'US/Michigan'
+          | 'US/East-Indiana'
+          | 'America/Indianapolis'
+          | 'America/Fort_Wayne'
+          | 'America/Louisville'
+          | 'EST5EDT'
+          | 'US/Eastern'
+          | 'America/Port-au-Prince'
+          | 'America/Grand_Turk'
+          | 'America/Toronto'
+          | 'America/Iqaluit'
+          | 'America/Pangnirtung'
+          | 'Canada/Eastern'
+          | 'America/Montreal'
+          | 'America/Nipigon'
+          | 'America/Thunder_Bay'
+          | 'America/Guyana'
+          | 'America/Argentina/Buenos_Aires'
+          | 'America/Argentina/Catamarca'
+          | 'America/Argentina/Cordoba'
+          | 'America/Argentina/Jujuy'
+          | 'America/Argentina/La_Rioja'
+          | 'America/Argentina/Mendoza'
+          | 'America/Argentina/Rio_Gallegos'
+          | 'America/Argentina/Salta'
+          | 'America/Argentina/San_Juan'
+          | 'America/Argentina/San_Luis'
+          | 'America/Argentina/Tucuman'
+          | 'America/Argentina/Ushuaia'
+          | 'America/Catamarca'
+          | 'America/Argentina/ComodRivadavia'
+          | 'America/Cordoba'
+          | 'America/Rosario'
+          | 'America/Jujuy'
+          | 'America/Mendoza'
+          | 'America/Halifax'
+          | 'America/Glace_Bay'
+          | 'America/Goose_Bay'
+          | 'America/Moncton'
+          | 'Canada/Atlantic'
+          | 'Atlantic/Bermuda'
+          | 'America/Thule'
+          | 'America/Araguaina'
+          | 'America/Bahia'
+          | 'America/Belem'
+          | 'America/Fortaleza'
+          | 'America/Maceio'
+          | 'America/Recife'
+          | 'America/Santarem'
+          | 'Brazil/East'
+          | 'Antarctica/Palmer'
+          | 'Antarctica/Rothera'
+          | 'America/Punta_Arenas'
+          | 'America/Coyhaique'
+          | 'Atlantic/Stanley'
+          | 'America/Cayenne'
+          | 'America/Asuncion'
+          | 'America/Paramaribo'
+          | 'America/Montevideo'
+          | 'America/St_Johns'
+          | 'Canada/Newfoundland'
+          | 'America/Noronha'
+          | 'Brazil/DeNoronha'
+          | 'America/Miquelon'
+          | 'America/Nuuk'
+          | 'America/Scoresbysund'
+          | 'America/Godthab'
+          | 'Africa/Abidjan'
+          | 'Iceland'
+          | 'Africa/Accra'
+          | 'Africa/Bamako'
+          | 'Africa/Banjul'
+          | 'Africa/Conakry'
+          | 'Africa/Dakar'
+          | 'Africa/Freetown'
+          | 'Africa/Lome'
+          | 'Africa/Nouakchott'
+          | 'Africa/Ouagadougou'
+          | 'Atlantic/Reykjavik'
+          | 'Atlantic/St_Helena'
+          | 'Africa/Timbuktu'
+          | 'Africa/Bissau'
+          | 'America/Danmarkshavn'
+          | 'Africa/Monrovia'
+          | 'Africa/Sao_Tome'
+          | 'Africa/Algiers'
+          | 'Africa/Tunis'
+          | 'Europe/Isle_of_Man'
+          | 'Europe/Dublin'
+          | 'Eire'
+          | 'GB'
+          | 'GB-Eire'
+          | 'Europe/Guernsey'
+          | 'Europe/Jersey'
+          | 'Europe/Belfast'
+          | 'Africa/Bangui'
+          | 'Africa/Malabo'
+          | 'Africa/Brazzaville'
+          | 'Africa/Porto-Novo'
+          | 'Africa/Douala'
+          | 'Africa/Kinshasa'
+          | 'Africa/Libreville'
+          | 'Africa/Luanda'
+          | 'Africa/Niamey'
+          | 'Africa/Ndjamena'
+          | 'Africa/Casablanca'
+          | 'Africa/El_Aaiun'
+          | 'Atlantic/Canary'
+          | 'Europe/Lisbon'
+          | 'Atlantic/Madeira'
+          | 'Portugal'
+          | 'WET'
+          | 'Atlantic/Faroe'
+          | 'Atlantic/Faeroe'
+          | 'Africa/Bujumbura'
+          | 'Africa/Gaborone'
+          | 'Africa/Harare'
+          | 'Africa/Juba'
+          | 'Africa/Khartoum'
+          | 'Africa/Kigali'
+          | 'Africa/Blantyre'
+          | 'Africa/Lubumbashi'
+          | 'Africa/Lusaka'
+          | 'Africa/Maputo'
+          | 'Africa/Windhoek'
+          | 'Europe/Andorra'
+          | 'Europe/Belgrade'
+          | 'Europe/Ljubljana'
+          | 'Europe/Podgorica'
+          | 'Europe/Sarajevo'
+          | 'Europe/Skopje'
+          | 'Europe/Zagreb'
+          | 'Europe/Busingen'
+          | 'Arctic/Longyearbyen'
+          | 'Europe/Copenhagen'
+          | 'Europe/Oslo'
+          | 'Europe/Stockholm'
+          | 'Atlantic/Jan_Mayen'
+          | 'Europe/Bratislava'
+          | 'Europe/Brussels'
+          | 'CET'
+          | 'MET'
+          | 'Europe/Amsterdam'
+          | 'Europe/Luxembourg'
+          | 'Europe/Budapest'
+          | 'Europe/Gibraltar'
+          | 'Europe/Madrid'
+          | 'Africa/Ceuta'
+          | 'Europe/Monaco'
+          | 'Europe/Paris'
+          | 'Europe/Prague'
+          | 'Europe/Rome'
+          | 'Europe/San_Marino'
+          | 'Europe/Vatican'
+          | 'Europe/Malta'
+          | 'Europe/Tirane'
+          | 'Europe/Vaduz'
+          | 'Europe/Vienna'
+          | 'Europe/Warsaw'
+          | 'Poland'
+          | 'Europe/Zurich'
+          | 'Europe/Kaliningrad'
+          | 'Africa/Tripoli'
+          | 'Libya'
+          | 'Antarctica/Troll'
+          | 'Africa/Johannesburg'
+          | 'Africa/Maseru'
+          | 'Africa/Mbabane'
+          | 'Asia/Kuwait'
+          | 'Asia/Bahrain'
+          | 'Asia/Baghdad'
+          | 'Asia/Qatar'
+          | 'Antarctica/Syowa'
+          | 'Asia/Aden'
+          | 'Asia/Amman'
+          | 'Asia/Damascus'
+          | 'Africa/Addis_Ababa'
+          | 'Indian/Antananarivo'
+          | 'Africa/Asmara'
+          | 'Africa/Dar_es_Salaam'
+          | 'Africa/Djibouti'
+          | 'Africa/Kampala'
+          | 'Indian/Mayotte'
+          | 'Africa/Mogadishu'
+          | 'Indian/Comoro'
+          | 'Africa/Nairobi'
+          | 'Africa/Asmera'
+          | 'EET'
+          | 'Asia/Beirut'
+          | 'Europe/Bucharest'
+          | 'Egypt'
+          | 'Europe/Chisinau'
+          | 'Europe/Tiraspol'
+          | 'Asia/Hebron'
+          | 'Asia/Gaza'
+          | 'Europe/Helsinki'
+          | 'Europe/Mariehamn'
+          | 'Europe/Kyiv'
+          | 'Europe/Uzhgorod'
+          | 'Europe/Zaporozhye'
+          | 'Europe/Kiev'
+          | 'Asia/Nicosia'
+          | 'Asia/Famagusta'
+          | 'Europe/Nicosia'
+          | 'Europe/Riga'
+          | 'Europe/Sofia'
+          | 'Europe/Tallinn'
+          | 'Europe/Vilnius'
+          | 'Asia/Jerusalem'
+          | 'Israel'
+          | 'Asia/Tel_Aviv'
+          | 'Europe/Minsk'
+          | 'Europe/Kirov'
+          | 'Europe/Volgograd'
+          | 'W-SU'
+          | 'Europe/Simferopol'
+          | 'Europe/Istanbul'
+          | 'Turkey'
+          | 'Asia/Istanbul'
+          | 'Asia/Tehran'
+          | 'Iran'
+          | 'Asia/Yerevan'
+          | 'Asia/Tbilisi'
+          | 'Asia/Muscat'
+          | 'Indian/Mahe'
+          | 'Indian/Reunion'
+          | 'Indian/Mauritius'
+          | 'Europe/Samara'
+          | 'Europe/Astrakhan'
+          | 'Europe/Saratov'
+          | 'Europe/Ulyanovsk'
+          | 'Asia/Kabul'
+          | 'Indian/Kerguelen'
+          | 'Asia/Aqtau'
+          | 'Asia/Aqtobe'
+          | 'Asia/Atyrau'
+          | 'Asia/Oral'
+          | 'Asia/Qostanay'
+          | 'Asia/Qyzylorda'
+          | 'Indian/Maldives'
+          | 'Antarctica/Mawson'
+          | 'Antarctica/Vostok'
+          | 'Asia/Dushanbe'
+          | 'Asia/Ashgabat'
+          | 'Asia/Ashkhabad'
+          | 'Asia/Samarkand'
+          | 'Asia/Yekaterinburg'
+          | 'Asia/Colombo'
+          | 'Asia/Kolkata'
+          | 'Asia/Kathmandu'
+          | 'Asia/Katmandu'
+          | 'Asia/Dacca'
+          | 'Asia/Thimphu'
+          | 'Asia/Thimbu'
+          | 'Asia/Urumqi'
+          | 'Asia/Kashgar'
+          | 'Indian/Chagos'
+          | 'Asia/Bishkek'
+          | 'Asia/Omsk'
+          | 'Indian/Cocos'
+          | 'Asia/Yangon'
+          | 'Asia/Rangoon'
+          | 'Indian/Christmas'
+          | 'Antarctica/Davis'
+          | 'Asia/Hovd'
+          | 'Asia/Phnom_Penh'
+          | 'Asia/Vientiane'
+          | 'Asia/Ho_Chi_Minh'
+          | 'Asia/Saigon'
+          | 'Asia/Novosibirsk'
+          | 'Asia/Barnaul'
+          | 'Asia/Krasnoyarsk'
+          | 'Asia/Novokuznetsk'
+          | 'Asia/Tomsk'
+          | 'Asia/Pontianak'
+          | 'Antarctica/Casey'
+          | 'Australia/Perth'
+          | 'Australia/West'
+          | 'Asia/Brunei'
+          | 'Asia/Makassar'
+          | 'Asia/Ujung_Pandang'
+          | 'Asia/Macau'
+          | 'Asia/Macao'
+          | 'PRC'
+          | 'Asia/Chongqing'
+          | 'Asia/Harbin'
+          | 'Asia/Chungking'
+          | 'Asia/Hong_Kong'
+          | 'Hongkong'
+          | 'Asia/Irkutsk'
+          | 'Asia/Kuala_Lumpur'
+          | 'Asia/Kuching'
+          | 'Asia/Manila'
+          | 'Singapore'
+          | 'Asia/Taipei'
+          | 'ROC'
+          | 'Asia/Ulaanbaatar'
+          | 'Asia/Choibalsan'
+          | 'Asia/Ulan_Bator'
+          | 'Australia/Eucla'
+          | 'Asia/Jayapura'
+          | 'Japan'
+          | 'Asia/Pyongyang'
+          | 'ROK'
+          | 'Pacific/Palau'
+          | 'Asia/Dili'
+          | 'Asia/Chita'
+          | 'Asia/Khandyga'
+          | 'Asia/Yakutsk'
+          | 'Australia/Adelaide'
+          | 'Australia/Broken_Hill'
+          | 'Australia/South'
+          | 'Australia/Yancowinna'
+          | 'Australia/Darwin'
+          | 'Australia/North'
+          | 'Australia/Lindeman'
+          | 'Australia/Queensland'
+          | 'Antarctica/Macquarie'
+          | 'Australia/Hobart'
+          | 'Australia/Melbourne'
+          | 'Australia/Tasmania'
+          | 'Australia/Currie'
+          | 'Australia/Victoria'
+          | 'Australia/ACT'
+          | 'Australia/NSW'
+          | 'Australia/Canberra'
+          | 'Pacific/Saipan'
+          | 'Pacific/Chuuk'
+          | 'Antarctica/DumontDUrville'
+          | 'Pacific/Port_Moresby'
+          | 'Pacific/Yap'
+          | 'Pacific/Truk'
+          | 'Asia/Vladivostok'
+          | 'Asia/Ust-Nera'
+          | 'Australia/Lord_Howe'
+          | 'Australia/LHI'
+          | 'Pacific/Bougainville'
+          | 'Pacific/Kosrae'
+          | 'Pacific/Pohnpei'
+          | 'Pacific/Norfolk'
+          | 'Asia/Sakhalin'
+          | 'Asia/Magadan'
+          | 'Asia/Srednekolymsk'
+          | 'Pacific/Guadalcanal'
+          | 'Pacific/Ponape'
+          | 'Pacific/Efate'
+          | 'Pacific/Tarawa'
+          | 'Pacific/Funafuti'
+          | 'Pacific/Majuro'
+          | 'Pacific/Wake'
+          | 'Pacific/Wallis'
+          | 'Asia/Kamchatka'
+          | 'Asia/Anadyr'
+          | 'Pacific/Kwajalein'
+          | 'Kwajalein'
+          | 'Pacific/Nauru'
+          | 'NZ'
+          | 'Antarctica/McMurdo'
+          | 'Antarctica/South_Pole'
+          | 'Pacific/Chatham'
+          | 'NZ-CHAT'
+          | 'Pacific/Kanton'
+          | 'Pacific/Enderbury'
+          | 'Pacific/Apia'
+          | 'Pacific/Fakaofo'
+          | 'Pacific/Tongatapu'
+          | 'Pacific/Kiritimati'
+          | 'Etc/GMT-14'
+          | 'Etc/GMT-13'
+          | 'Etc/GMT-12'
+          | 'Etc/GMT-11'
+          | 'Etc/GMT-10'
+          | 'Etc/GMT-9'
+          | 'Etc/GMT-8'
+          | 'Etc/GMT-7'
+          | 'Etc/GMT-6'
+          | 'Etc/GMT-5'
+          | 'Etc/GMT-4'
+          | 'Etc/GMT-3'
+          | 'Etc/GMT-2'
+          | 'Etc/GMT-1'
+          | 'Etc/GMT'
+          | 'Etc/GMT+1'
+          | 'Etc/GMT+2'
+          | 'Etc/GMT+3'
+          | 'Etc/GMT+4'
+          | 'Etc/GMT+5'
+          | 'Etc/GMT+6'
+          | 'Etc/GMT+7'
+          | 'Etc/GMT+8'
+          | 'Etc/GMT+9'
+          | 'Etc/GMT+10'
+          | 'Etc/GMT+11'
+          | 'Etc/GMT+12'
         )[]
       | null;
   };
@@ -1067,6 +2140,38 @@ export interface Region {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * Region-level nodes nested directly beneath this one.
+   */
+  childrenRegions?: {
+    docs?: (number | Region)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  /**
+   * Cities nested directly beneath this one.
+   */
+  childrenCities?: {
+    docs?: (number | Region)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  /**
+   * SY Centers nested directly beneath this one.
+   */
+  childrenCenters?: {
+    docs?: (number | Region)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  breadcrumbs?:
+    | {
+        doc?: (number | null) | Region;
+        url?: string | null;
+        label?: string | null;
+        id?: string | null;
+      }[]
+    | null;
   legacyId?: number | null;
   legacyData?:
     | {
@@ -1076,14 +2181,6 @@ export interface Region {
     | string
     | number
     | boolean
-    | null;
-  breadcrumbs?:
-    | {
-        doc?: (number | null) | Region;
-        url?: string | null;
-        label?: string | null;
-        id?: string | null;
-      }[]
     | null;
   updatedAt: string;
   createdAt: string;
@@ -1099,9 +2196,9 @@ export interface Event {
    */
   title: string;
   /**
-   * Language this event is conducted in.
+   * Language(s) this event is conducted in.
    */
-  language:
+  languages: (
     | 'ab'
     | 'aa'
     | 'af'
@@ -1284,8 +2381,15 @@ export interface Event {
     | 'yi'
     | 'yo'
     | 'za'
-    | 'zu';
+    | 'zu'
+  )[];
+  /**
+   * A phone number that seekers can call to learn more about the program.
+   */
   contactPhone?: string | null;
+  /**
+   * The name of the person they are calling
+   */
   contactName?: string | null;
   description?: {
     root: {
@@ -1307,9 +2411,13 @@ export interface Event {
    */
   images?: (number | Image)[] | null;
   /**
+   * Mark this event dormant — it has no active schedule. With no schedule to show, you must provide contact info (phone + name) so seekers can reach out and find out more. Inactive events still need verification but never auto-finish.
+   */
+  inactive?: boolean | null;
+  /**
    * Configure when this event occurs and repeats
    */
-  schedule: {
+  schedule?: {
     firstDate: string;
     firstDate_tz: SupportedTimezones;
     /**
@@ -1357,7 +2465,7 @@ export interface Event {
   /**
    * The city or center this event belongs to.
    */
-  region?: (number | null) | Region;
+  region: number | Region;
   eventType: 'offline' | 'online';
   /**
    * Link attendees join the online event through.
@@ -1366,9 +2474,6 @@ export interface Event {
   address?: {
     mapboxId?: string | null;
     street?: string | null;
-    /**
-     * Room or floor within the venue, if any.
-     */
     room?: string | null;
     postCode?: string | null;
     country?: string | null;
@@ -1402,11 +2507,21 @@ export interface Event {
    * Manager responsible for verifying this event.
    */
   manager: number | Manager;
-  status: 'active' | 'expired' | 'inactive';
+  verificationStage: 'verified' | 'reminded' | 'escalated' | 'urgent' | 'expired' | 'finished';
+  nextCheckAt?: string | null;
   /**
-   * Consecutive successful verifications.
+   * Current verification cycle — the verification that opened it plus each reminder sent. Reset on every verification.
    */
-  verificationStreak?: number | null;
+  notificationLog?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  webUrl?: string | null;
   legacyId?: number | null;
   legacyData?:
     | {
@@ -1419,6 +2534,7 @@ export interface Event {
     | null;
   updatedAt: string;
   createdAt: string;
+  deletedAt?: string | null;
   _status?: ('draft' | 'published') | null;
 }
 /**
@@ -1802,6 +2918,7 @@ export interface File {
   id: number;
   createdAt: string;
   hlsUrl?: string | null;
+  mp4Url?: string | null;
   previewUrl?: string | null;
   updatedAt: string;
   deletedAt?: string | null;
@@ -2573,6 +3690,7 @@ export interface SubtleSystemNode {
 export interface Frame {
   id: number;
   hlsUrl?: string | null;
+  mp4Url?: string | null;
   previewUrl?: string | null;
   imageSet: 'male' | 'female';
   /**
@@ -3215,7 +4333,13 @@ export interface PayloadJob {
     | {
         executedAt: string;
         completedAt: string;
-        taskSlug: 'inline' | 'cleanupOrphanedMedia' | 'syncLectureMetadata' | 'resetUsage' | 'schedulePublish';
+        taskSlug:
+          | 'inline'
+          | 'cleanupOrphanedMedia'
+          | 'expireEvents'
+          | 'syncLectureMetadata'
+          | 'resetUsage'
+          | 'schedulePublish';
         taskID: string;
         input?:
           | {
@@ -3248,7 +4372,9 @@ export interface PayloadJob {
         id?: string | null;
       }[]
     | null;
-  taskSlug?: ('inline' | 'cleanupOrphanedMedia' | 'syncLectureMetadata' | 'resetUsage' | 'schedulePublish') | null;
+  taskSlug?:
+    | ('inline' | 'cleanupOrphanedMedia' | 'expireEvents' | 'syncLectureMetadata' | 'resetUsage' | 'schedulePublish')
+    | null;
   queue?: string | null;
   waitUntil?: string | null;
   processing?: boolean | null;
@@ -3531,6 +4657,7 @@ export interface AlbumsSelect<T extends boolean = true> {
  */
 export interface VideosSelect<T extends boolean = true> {
   hlsUrl?: T;
+  mp4Url?: T;
   previewUrl?: T;
   thumbnail?: T;
   title?: T;
@@ -3610,6 +4737,7 @@ export interface LecturesSelect<T extends boolean = true> {
  */
 export interface FramesSelect<T extends boolean = true> {
   hlsUrl?: T;
+  mp4Url?: T;
   previewUrl?: T;
   imageSet?: T;
   subtleSystemNode?: T;
@@ -3685,6 +4813,7 @@ export interface ImagesSelect<T extends boolean = true> {
 export interface FilesSelect<T extends boolean = true> {
   createdAt?: T;
   hlsUrl?: T;
+  mp4Url?: T;
   previewUrl?: T;
   updatedAt?: T;
   deletedAt?: T;
@@ -3817,7 +4946,7 @@ export interface ManagersSelect<T extends boolean = true> {
   managedPages?: T;
   managedRegions?: T;
   managedEvents?: T;
-  languageCode?: T;
+  language?: T;
   contactDetails?:
     | T
     | {
@@ -3993,13 +5122,13 @@ export interface AppCardsSelect<T extends boolean = true> {
 export interface RegionsSelect<T extends boolean = true> {
   level?: T;
   parent?: T;
+  managers?: T;
+  mapboxId?: T;
   name?: T;
   subtitle?: T;
-  mapboxId?: T;
   latitude?: T;
   longitude?: T;
   radius?: T;
-  managers?: T;
   eventDefaults?:
     | T
     | {
@@ -4007,8 +5136,9 @@ export interface RegionsSelect<T extends boolean = true> {
         timeZone?: T;
       };
   events?: T;
-  legacyId?: T;
-  legacyData?: T;
+  childrenRegions?: T;
+  childrenCities?: T;
+  childrenCenters?: T;
   breadcrumbs?:
     | T
     | {
@@ -4017,6 +5147,8 @@ export interface RegionsSelect<T extends boolean = true> {
         label?: T;
         id?: T;
       };
+  legacyId?: T;
+  legacyData?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -4026,11 +5158,12 @@ export interface RegionsSelect<T extends boolean = true> {
  */
 export interface EventsSelect<T extends boolean = true> {
   title?: T;
-  language?: T;
+  languages?: T;
   contactPhone?: T;
   contactName?: T;
   description?: T;
   images?: T;
+  inactive?: T;
   schedule?:
     | T
     | {
@@ -4088,12 +5221,15 @@ export interface EventsSelect<T extends boolean = true> {
       };
   registrations?: T;
   manager?: T;
-  status?: T;
-  verificationStreak?: T;
+  verificationStage?: T;
+  nextCheckAt?: T;
+  notificationLog?: T;
+  webUrl?: T;
   legacyId?: T;
   legacyData?: T;
   updatedAt?: T;
   createdAt?: T;
+  deletedAt?: T;
   _status?: T;
 }
 /**
@@ -4358,6 +5494,10 @@ export interface WmWebConfig {
    * Select 2-3 pages to feature in the website header and footer.
    */
   featuredPages: (number | Page)[];
+  /**
+   * Select 2 or more article pages to feature in the website header dropdown.
+   */
+  featuredArticles: (number | Page)[];
   /**
    * Select up to 5 pages for seekers to start meditating. The first one will be featured in the header. (eg. Classes Near Me, Online Meditations, Recorded Meditations, WeMeditate App
    */
@@ -5501,6 +6641,7 @@ export interface PayloadJobsStat {
 export interface WmWebConfigSelect<T extends boolean = true> {
   homePage?: T;
   featuredPages?: T;
+  featuredArticles?: T;
   classPages?: T;
   knowledgePages?: T;
   infoPages?: T;
@@ -5735,6 +6876,21 @@ export interface TaskCleanupOrphanedMedia {
     trashedImages: number;
     skippedImages: number;
     errors: number;
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskExpireEvents".
+ */
+export interface TaskExpireEvents {
+  input?: unknown;
+  output: {
+    processed: number;
+    finished: number;
+    advanced: number;
+    trashed: number;
+    remindersSent: number;
+    failed: number;
   };
 }
 /**


### PR DESCRIPTION
## Summary

Adds the header mega-menu described in #45. The nav now carries a dedicated **link-less "About Meditation" item** (appended after the featured-page links) that opens a `HeaderDropdown` panel on **hover or click**, listing every `knowledgePages` entry plus **2 article thumbnails** picked at random from the CMS-curated `WebConfig.featuredArticles` list (falling back to `knowledgePages` when that field is empty).

Positioning is driven directly by `@floating-ui/react` (the same pattern as `Tooltip`); the shared `Dropdown` atom is intentionally untouched.

Closes #45

## What changed

1. **CMS types resync** (`pnpm types:cms`) — brings `featuredArticles` into the generated `WmWebConfig` (the upstream copy had drifted; the regen is large but type-only and `tsc` passes).
2. **Read path** (`server/cms-client.ts`, `server/cms-types.ts`) — `featuredArticles` added to `WEB_CONFIG_SELECT` and the `WebConfig` type, and run through `partitionPublishedPages` in `getWebConfig` (unpublished/bare-ID refs dropped with the existing Sentry warning). `WEB_CONFIG_POPULATE`'s `pages: PAGE_SELECT` already populates each page's `meta.image`.
3. **`HeaderNavDropdown`** (new organism + Ladle story) — wires `@floating-ui/react` directly: `useHover` + `safePolygon`, `useClick`, `useDismiss` (Escape + outside click), `useRole({ role: 'dialog' })`, `offset/flip/shift` + `autoUpdate`. The panel renders in a `FloatingPortal` with no extra chrome. The trigger is a real `Button` carrying the popup ARIA + interaction handlers (keyboard-focusable; opens on Enter/Space).
4. **`Header`** — `navItems` items gain an optional `dropdown` and an optional `href`. An item with a `dropdown` renders as the **link-less** `HeaderNavDropdown` trigger (sticky-aware theme); plain link items render the existing flat `Button`.
5. **`LayoutChrome`** — featured pages render as plain links; a separate "About Meditation" dropdown item is **appended** (only when knowledge pages exist) with links = all knowledge pages and 2 random featured articles. Pure, unit-tested helpers live in `layouts/headerDropdown.ts`. The random pick is computed once via `useState`; the panel is closed during SSR so the picks never enter server HTML → **no hydration mismatch**.

### Label source (interim)

The link-less item's label (and panel heading) currently use the knowledge group's **first page title** — localized, and consistent with how the footer already labels that group. There's a `// TODO` to source it from `WmWebTranslations.navigation` once that global is configured in the CMS (it isn't yet).

## Tests

- `getWebConfig` selects `featuredArticles` and drops unpublished (bare-id) refs.
- `headerDropdown` helpers: link/article mapping, `meta.image` resolution + graceful fallback, fallback-to-knowledge-pages, count ≤ 2, no input mutation.
- `HeaderNavDropdown` markup contract: focusable trigger with dialog popup semantics; panel absent until opened.
- `LayoutChrome`: a separate link-less dropdown item is appended (featured links stay plain); omitted entirely when there are no knowledge pages.
- Full local gate green: `pnpm lint`, `tsc --noEmit`, `pnpm test:run` (268), and `pnpm build`.

## Review process

- `/simplify` over the full branch diff — already clean; no changes.
- `/code-review high` over the full branch diff — one **a11y finding fixed**: popup ARIA/interaction props moved onto the focusable `Button` (from the wrapper span). Refuted: empty-`featuredPages` (`lastIndex` map never runs), required-`featuredArticles` (tsc passes), hydration-mismatch (picks never reach SSR HTML).

## Verify manually (interactive — not unit-testable here, no jsdom)

- In Ladle (`pnpm ladle` → Organisms → "Header Nav Dropdown" / "Header"): hover **and** click open the panel; cursor can travel onto it (safePolygon); Escape / outside-click close it; Tab to the trigger + Enter/Space opens it; the "About Meditation" item does not navigate.
- Confirm positioning under both the static and scroll-sticky nav states.

## Deferred / notes

- **`Button` `forwardRef`**: would let the trigger drop its wrapper span; deferred since it touches a shared atom + the `Link` ref path.
- **Label → `WmWebTranslations`**: switch the interim first-knowledge-page-title label to the configured translation once available.
- **Missing article image**: renders the `Image` atom's placeholder (graceful); only reachable via the `knowledgePages` fallback.
- **Nav width**: items keep the existing `basis-1/4` sizing; `featuredPages` (CMS: "2–3") + 1 dropdown item stays within that.
- Branched from clean `main`; does not include the unrelated splash-hero WIP stashed locally — expect a small `LayoutChrome.tsx` conflict when that stash is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
