### PR TITLE
feat(preview): block link navigation in live-preview routes

### DIFF
--- a/pages/preview/_components/Preview.tsx
+++ b/pages/preview/_components/Preview.tsx
@@ -12,6 +12,7 @@ import { PreviewBanner } from './PreviewBanner'
 import { PagePreview } from './PagePreview'
 import { MeditationPreview } from './MeditationPreview'
 import { LecturePreview } from './LecturePreview'
+import { usePreviewLinkGuard } from './previewNavigation'
 
 export interface PreviewProps {
   /**
@@ -33,6 +34,10 @@ export interface PreviewProps {
 }
 
 export function Preview({ data, showEmbedButton = true }: PreviewProps) {
+  // Make every link in the preview inert so editors don't navigate the
+  // live-preview iframe away from the document being edited.
+  usePreviewLinkGuard()
+
   switch (data.collection) {
     case 'pages':
       return <PagePreview initialData={data.initialData} />

--- a/pages/preview/_components/previewNavigation.test.ts
+++ b/pages/preview/_components/previewNavigation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBlockPreviewLink } from './previewNavigation'
+
+describe('shouldBlockPreviewLink', () => {
+  it('blocks internal route links so the iframe stays on the previewed document', () => {
+    expect(shouldBlockPreviewLink('/about')).toBe(true)
+    expect(shouldBlockPreviewLink('/es/meditations')).toBe(true)
+    expect(shouldBlockPreviewLink('/')).toBe(true)
+  })
+
+  it('blocks external and other-protocol links', () => {
+    expect(shouldBlockPreviewLink('https://wemeditate.com')).toBe(true)
+    expect(shouldBlockPreviewLink('http://example.com')).toBe(true)
+    expect(shouldBlockPreviewLink('mailto:hello@example.com')).toBe(true)
+    expect(shouldBlockPreviewLink('tel:+1234567890')).toBe(true)
+  })
+
+  it('allows same-page hash links so table-of-contents jumps still scroll', () => {
+    expect(shouldBlockPreviewLink('#section-1')).toBe(false)
+    expect(shouldBlockPreviewLink('#')).toBe(false)
+  })
+
+  it('ignores anchors without a navigable href', () => {
+    expect(shouldBlockPreviewLink(null)).toBe(false)
+    expect(shouldBlockPreviewLink(undefined)).toBe(false)
+    expect(shouldBlockPreviewLink('')).toBe(false)
+  })
+})

--- a/pages/preview/_components/previewNavigation.ts
+++ b/pages/preview/_components/previewNavigation.ts
@@ -1,0 +1,85 @@
+/**
+ * Live-preview navigation guard
+ *
+ * Preview routes (/preview and /preview/embed) render the real site components,
+ * so every link on screen is genuine navigation. When an editor clicks one
+ * inside the SahajCloud live-preview iframe, the iframe leaves the document
+ * being edited and the live-preview session breaks. This guard makes links
+ * inert WITHOUT threading a "disabled" prop through every component (Link atom,
+ * Button-as-link, Breadcrumbs, cards, nav, footer): a single capture-phase
+ * click interceptor blocks anchor navigation across the whole preview tree —
+ * including the Header/Footer chrome that LayoutChrome renders OUTSIDE
+ * <Preview>.
+ */
+
+import { useEffect } from 'react'
+
+/**
+ * Whether a click on an in-preview anchor should be blocked.
+ *
+ * Same-page hash links (`#heading`) are table-of-contents jumps editors use to
+ * scroll within the document being edited — keep them working. Everything else
+ * (internal route, external, `mailto:`, `tel:`, …) navigates away and is made
+ * inert.
+ *
+ * Pass the anchor's href *attribute* (`getAttribute('href')`), not the resolved
+ * `.href` DOM property, so a bare `#heading` stays detectable instead of being
+ * expanded to an absolute URL.
+ */
+export function shouldBlockPreviewLink(rawHref: string | null | undefined): boolean {
+  // <a> without an href doesn't navigate — nothing to block.
+  if (!rawHref) return false
+  // Same-page anchor (table-of-contents jump): leave it alone so it scrolls.
+  if (rawHref.startsWith('#')) return false
+
+  // Internal route, external, mailto, tel, … → inert in preview.
+  return true
+}
+
+/**
+ * Make every link in the live-preview routes inert so editors can read and
+ * scroll without the iframe navigating away from the document being edited.
+ *
+ * Mechanism: a capture-phase listener on `window`, which fires before Vike's
+ * client-router click handler (a bubble-phase listener on `document` that does
+ * NOT check `defaultPrevented`). For a blocked anchor we therefore call BOTH:
+ *   - `preventDefault()` — stops native navigation / open-in-new-tab, and
+ *   - `stopPropagation()` — keeps the event from reaching Vike's client router.
+ *
+ * `auxclick` is covered too, since that is where browsers fire middle-click
+ * "open in new tab". Only `<a>` is touched, so `<button>` and media controls
+ * (play/pause, captions, the embed dropdown) keep working, and the
+ * `message`-based live-preview content updates and seek sync are untouched. The
+ * listener is mounted only while a preview route renders <Preview>, so the
+ * normal site navigates exactly as before.
+ */
+export function usePreviewLinkGuard(): void {
+  useEffect(() => {
+    const blockAnchorNavigation = (event: MouseEvent) => {
+      const target = event.target
+
+      if (!(target instanceof Element)) return
+
+      const anchor = target.closest('a')
+
+      if (!anchor) return // not a link — let buttons / media controls work
+
+      if (!shouldBlockPreviewLink(anchor.getAttribute('href'))) return // #hash: allow
+
+      // Block native navigation AND stop the event before Vike's document-level
+      // client-router handler can run its client-side navigation.
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    // Capture phase on `window` runs before any document-level handler.
+    window.addEventListener('click', blockAnchorNavigation, true)
+    // `auxclick` is where browsers fire middle-click "open in new tab".
+    window.addEventListener('auxclick', blockAnchorNavigation, true)
+
+    return () => {
+      window.removeEventListener('click', blockAnchorNavigation, true)
+      window.removeEventListener('auxclick', blockAnchorNavigation, true)
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

- Makes every link in the live-preview routes (`/preview` and `/preview/embed`) inert so editors don't navigate the SahajCloud preview iframe away from the document they're editing.
- Same-page anchor jumps (`#heading`) still scroll; `<button>` and media controls (play/pause, captions, embed dropdown) and the message-based live-preview/seek sync are untouched.
- Zero impact on the normal site — the guard is mounted only while `<Preview>` renders.

## Changes

- `pages/preview/_components/previewNavigation.ts` (new) — `shouldBlockPreviewLink(href)` predicate (block everything except `#hash`/href-less anchors) + `usePreviewLinkGuard()` hook that installs **capture-phase** `click`/`auxclick` listeners on `window` and calls `preventDefault()` + `stopPropagation()` on blocked anchors.
- `pages/preview/_components/Preview.tsx` — calls `usePreviewLinkGuard()` once at the top of the shared `Preview` component (rendered by both preview routes).
- `pages/preview/_components/previewNavigation.test.ts` (new) — unit tests for the decision logic.

### Why a `window`-capture listener + `stopPropagation()`

Vike's client router listens for link clicks on `document` in the **bubble** phase and does **not** check `event.defaultPrevented` ([initOnLinkClick.js](https://github.com/vikejs/vike)). So `preventDefault()` alone wouldn't stop Vike's client-side navigation. A capture-phase listener on `window` is the first node in the event path, so `stopPropagation()` there halts all further propagation and the event never reaches Vike's `document` handler; `preventDefault()` additionally blocks native navigation and middle-click/modifier "open in new tab" (via `auxclick`). A single document-level interceptor also covers the Header/Footer nav that `LayoutChrome` renders **outside** `<Preview>`, without threading a `disabled` prop through every link-rendering component.

## Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 272 passed, incl. 4 new (`pnpm test:run`)
- Build: ✓ Success (`pnpm build`)

## Manual verification

Open the SahajCloud live preview for a page, a meditation, and a lecture, in both `/preview` and `/preview/embed`:

1. Click a rich-text link, a nav/header link, a card, and a breadcrumb → URL/iframe stays put, no navigation.
2. Cmd/Ctrl-click and middle-click a navigating link → no new tab opens.
3. Click a table-of-contents `#heading` link → still scrolls within the document.
4. Use play/pause, the captions menu, and the Embed dropdown (open + copy) → all still work.
5. Confirm live edits in the admin still update the preview and frame-thumbnail seek sync still works.

## Notes for reviewer

- Tests cover the pure `shouldBlockPreviewLink` decision logic. The DOM wiring (capture phase, `auxclick`, Vike interaction) isn't unit-tested because the project runs Vitest in `node` with no jsdom — it's covered by the manual steps above.
- **Considered and deferred — altitude:** a `/simplify` pass suggested moving the hook into a dedicated preview layout. Kept it inline in `Preview` because this repo's layouts are config-driven (`Layout:` in `+config.ts`) with a deliberate `(full)` vs `embed` chrome split; a guard layout would add routing machinery/risk for a one-line effect, and `Preview` is the single shared mount point both routes already render.
- **Known minor limitation:** because the guard calls `stopPropagation()`, clicking an `<a>` *inside* an open dropdown won't auto-close that dropdown in preview (Floating UI's outside-press dismiss never sees the click). Navigation is still correctly blocked, the EmbedButton dropdown has no anchors so it's unaffected, and clicking elsewhere still closes it. Not worth complicating the guard.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
