### PR TITLE
feat(layout): full-bleed blocks, splash header overlay, mobile images

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -14,8 +14,15 @@ import '../layouts/tailwind.css'
 // pageContext and a Suspense boundary here, mirroring what Vike provides at runtime.
 const ladlePageContext = { isClientSide: true, locale: 'en' } as unknown as PageContext
 
+// The inline-size container makes `full-bleed` blocks (which size with `cqi`)
+// resolve to the Ladle story area instead of the whole window — so they don't
+// overflow under the sidebar. `overflowX: clip` contains decorative horizontal
+// bleed (e.g. OrnateTextBox's floral graphic) without creating a scroll container.
+// Inline styles (not Tailwind classes) because Tailwind doesn't scan `.ladle/`.
 export const Provider: GlobalProvider = ({ children }) => (
   <VikeReactProviderPageContext pageContext={ladlePageContext}>
-    <Suspense fallback={null}>{children}</Suspense>
+    <div style={{ containerType: 'inline-size', overflowX: 'clip' }}>
+      <Suspense fallback={null}>{children}</Suspense>
+    </div>
   </VikeReactProviderPageContext>
 )

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -5,6 +5,7 @@ import type { PageContext } from 'vike/types'
 import '../layouts/fonts.css'
 import '../layouts/style.css'
 import '../layouts/tailwind.css'
+import './story-overrides.css'
 
 // Ladle isn't a Vike app, so vike-react's runtime `pageContext` and the app-root
 // <Suspense> boundary don't exist. Components that read `usePageContext()` or use

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -16,12 +16,12 @@ const ladlePageContext = { isClientSide: true, locale: 'en' } as unknown as Page
 
 // The inline-size container makes `full-bleed` blocks (which size with `cqi`)
 // resolve to the Ladle story area instead of the whole window — so they don't
-// overflow under the sidebar. `overflowX: clip` contains decorative horizontal
-// bleed (e.g. OrnateTextBox's floral graphic) without creating a scroll container.
-// Inline styles (not Tailwind classes) because Tailwind doesn't scan `.ladle/`.
+// overflow under the sidebar. Inline style (not a Tailwind class) because Tailwind
+// doesn't scan `.ladle/`. No `overflowX: clip` here — it would clip ContentTextBox's
+// desktop overlap; blocks that bleed horizontally (OrnateTextBox) clip themselves.
 export const Provider: GlobalProvider = ({ children }) => (
   <VikeReactProviderPageContext pageContext={ladlePageContext}>
-    <div style={{ containerType: 'inline-size', overflowX: 'clip' }}>
+    <div style={{ containerType: 'inline-size' }}>
       <Suspense fallback={null}>{children}</Suspense>
     </div>
   </VikeReactProviderPageContext>

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { Suspense, type CSSProperties } from 'react'
 import type { GlobalProvider } from '@ladle/react'
 import { VikeReactProviderPageContext } from 'vike-react/usePageContext'
 import type { PageContext } from 'vike/types'
@@ -15,15 +15,19 @@ import './story-overrides.css'
 // pageContext and a Suspense boundary here, mirroring what Vike provides at runtime.
 const ladlePageContext = { isClientSide: true, locale: 'en' } as unknown as PageContext
 
-// The inline-size container makes `full-bleed` blocks (which size with `cqi`)
-// resolve to the Ladle story area instead of the whole window — so they don't
-// overflow under the sidebar. Inline style (not a Tailwind class) because Tailwind
-// doesn't scan `.ladle/`. No `overflowX: clip` here — it would clip ContentTextBox's
+// The inline-size container makes `full-bleed` blocks resolve to the Ladle story
+// area instead of the whole window — so they don't overflow under the sidebar. The
+// inner wrapper captures that area's width into `--page-width` (`100cqi`), mirroring
+// the page-content wrapper in LayoutChrome, so full-bleed reads the same captured
+// length here as on real pages. Inline styles (not Tailwind classes) because Tailwind
+// doesn't scan `.ladle/`. No `overflowX: clip` — it would clip ContentTextBox's
 // desktop overlap; blocks that bleed horizontally (OrnateTextBox) clip themselves.
 export const Provider: GlobalProvider = ({ children }) => (
   <VikeReactProviderPageContext pageContext={ladlePageContext}>
     <div style={{ containerType: 'inline-size' }}>
-      <Suspense fallback={null}>{children}</Suspense>
+      <div style={{ '--page-width': '100cqi' } as CSSProperties}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </div>
     </div>
   </VikeReactProviderPageContext>
 )

--- a/.ladle/config.mjs
+++ b/.ladle/config.mjs
@@ -17,4 +17,12 @@ export default {
 
   // Use Vite config from the project
   viteConfig: ".ladle/vite.config.ts",
+
+  // Disable the dark-mode toggle — the component library is light-theme only
+  addons: {
+    theme: {
+      enabled: false, // removes the dark/light toggle from the toolbar
+      defaultState: "light", // force light theme
+    },
+  },
 };

--- a/.ladle/story-overrides.css
+++ b/.ladle/story-overrides.css
@@ -1,0 +1,14 @@
+/**
+ * Remove Ladle's default horizontal story padding so the inline-size container in
+ * the global Provider (.ladle/components.tsx) spans the full story canvas. This
+ * lets `full-bleed` blocks reach the canvas edges in Ladle — matching how they
+ * fill the window on real pages — instead of stopping at Ladle's 48px gutter.
+ *
+ * Per-story breathing room moves onto StoryWrapper (components/ladle/StoryWrapper),
+ * which lives inside the container and is therefore escaped by `full-bleed`,
+ * mirroring the page model (gutter on the content wrapper inside `<main>`).
+ */
+.ladle-main {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}

--- a/components/atoms/Container/Container.stories.tsx
+++ b/components/atoms/Container/Container.stories.tsx
@@ -43,6 +43,24 @@ export const Default: Story = () => (
           </Container>
         </div>
         <div>
+          <p className="text-sm text-gray-600 mb-2">XL (max-w-6xl)</p>
+          <Container maxWidth="xl">
+            <div className="bg-gray-100 p-4 rounded">
+              <p className="text-gray-700">XL container - wide feature sections</p>
+            </div>
+          </Container>
+        </div>
+        <div>
+          <p className="text-sm text-gray-600 mb-2">2XL / Default (max-w-7xl)</p>
+          <Container maxWidth="2xl">
+            <div className="bg-gray-100 p-4 rounded">
+              <p className="text-gray-700">
+                2XL container - the default; spans the full page content area
+              </p>
+            </div>
+          </Container>
+        </div>
+        <div>
           <p className="text-sm text-gray-600 mb-2">Full (no max-width)</p>
           <Container maxWidth="full">
             <div className="bg-gray-100 p-4 rounded">

--- a/components/atoms/Container/Container.stories.tsx
+++ b/components/atoms/Container/Container.stories.tsx
@@ -8,7 +8,7 @@ export default {
 
 /**
  * Container component showcasing all max widths and usage in context.
- * Padding is automatically responsive (small on mobile, medium on tablet, large on desktop).
+ * Horizontal gutter is a flat px-4 at all breakpoints.
  */
 export const Default: Story = () => (
   <StoryWrapper>

--- a/components/atoms/Container/Container.stories.tsx
+++ b/components/atoms/Container/Container.stories.tsx
@@ -1,11 +1,10 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { Container } from "./Container";
-import { StoryWrapper, StorySection,
-   } from '../../ladle';
+import type { Story, StoryDefault } from '@ladle/react'
+import { Container } from './Container'
+import { StoryWrapper, StorySection } from '../../ladle'
 
 export default {
-  title: "Atoms"
-} satisfies StoryDefault;
+  title: 'Atoms',
+} satisfies StoryDefault
 
 /**
  * Container component showcasing all max widths and usage in context.
@@ -19,20 +18,24 @@ export const Default: Story = () => (
           <p className="text-sm text-gray-600 mb-2">Small (max-w-3xl)</p>
           <Container maxWidth="sm">
             <div className="bg-gray-100 p-4 rounded">
-              <p className="text-gray-700">Small container - ideal for focused content like forms</p>
+              <p className="text-gray-700">
+                Small container - ideal for focused content like forms
+              </p>
             </div>
           </Container>
         </div>
         <div>
-          <p className="text-sm text-gray-600 mb-2">Medium (max-w-5xl)</p>
+          <p className="text-sm text-gray-600 mb-2">Medium (max-w-4xl)</p>
           <Container maxWidth="md">
             <div className="bg-gray-100 p-4 rounded">
-              <p className="text-gray-700">Medium container - perfect for articles and blog posts</p>
+              <p className="text-gray-700">
+                Medium container - perfect for articles and blog posts
+              </p>
             </div>
           </Container>
         </div>
         <div>
-          <p className="text-sm text-gray-600 mb-2">Large (max-w-7xl)</p>
+          <p className="text-sm text-gray-600 mb-2">Large (max-w-5xl)</p>
           <Container maxWidth="lg">
             <div className="bg-gray-100 p-4 rounded">
               <p className="text-gray-700">Large container - great for dashboards and grids</p>
@@ -50,7 +53,7 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection title="Examples" inContext={true}>
+    <StorySection inContext={true} title="Examples">
       <StorySection title="Article" variant="subsection">
         <div className="bg-gray-50 py-8">
           <Container maxWidth="md">
@@ -59,19 +62,19 @@ export const Default: Story = () => (
                 The Benefits of Daily Meditation
               </h1>
               <p className="text-gray-700 mb-4">
-                Meditation is a powerful practice that can transform your life in many ways.
-                Regular practice has been shown to reduce stress, improve focus, and enhance
-                overall well-being.
+                Meditation is a powerful practice that can transform your life in many ways. Regular
+                practice has been shown to reduce stress, improve focus, and enhance overall
+                well-being.
               </p>
               <p className="text-gray-700 mb-4">
-                Starting a meditation practice doesn't have to be complicated. Just a few
-                minutes each day can make a significant difference in how you feel and how
-                you respond to life's challenges.
+                Starting a meditation practice doesn't have to be complicated. Just a few minutes
+                each day can make a significant difference in how you feel and how you respond to
+                life's challenges.
               </p>
               <p className="text-gray-700">
-                The key is consistency. Find a quiet time and place, sit comfortably, and
-                simply focus on your breath. Over time, you'll discover the profound benefits
-                that meditation can bring.
+                The key is consistency. Find a quiet time and place, sit comfortably, and simply
+                focus on your breath. Over time, you'll discover the profound benefits that
+                meditation can bring.
               </p>
             </article>
           </Container>
@@ -82,24 +85,22 @@ export const Default: Story = () => (
         <div className="bg-gray-50 py-8">
           <Container maxWidth="sm">
             <div className="bg-white rounded-lg shadow-md p-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-6">
-                Sign Up for Free
-              </h2>
+              <h2 className="text-2xl font-semibold text-gray-900 mb-6">Sign Up for Free</h2>
               <form className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium mb-1 text-gray-900">Name</label>
                   <input
-                    type="text"
                     className="w-full px-3 py-2 border border-gray-300 rounded focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
                     placeholder="Your name"
+                    type="text"
                   />
                 </div>
                 <div>
                   <label className="block text-sm font-medium mb-1 text-gray-900">Email</label>
                   <input
-                    type="email"
                     className="w-full px-3 py-2 border border-gray-300 rounded focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
                     placeholder="you@example.com"
+                    type="email"
                   />
                 </div>
                 <button className="w-full bg-teal-500 text-white py-2 px-4 rounded hover:bg-teal-600">
@@ -117,9 +118,9 @@ export const Default: Story = () => (
             <h2 className="text-2xl font-semibold text-gray-900 mb-6">Your Meditation Journey</h2>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
               {[
-                { title: "Sessions", value: "127", subtitle: "Total meditations" },
-                { title: "Streak", value: "15", subtitle: "Days in a row" },
-                { title: "Minutes", value: "1,840", subtitle: "Time practiced" },
+                { title: 'Sessions', value: '127', subtitle: 'Total meditations' },
+                { title: 'Streak', value: '15', subtitle: 'Days in a row' },
+                { title: 'Minutes', value: '1,840', subtitle: 'Time practiced' },
               ].map((stat) => (
                 <div key={stat.title} className="bg-white rounded-lg shadow p-6">
                   <h3 className="text-sm font-medium text-gray-600 mb-2">{stat.title}</h3>
@@ -133,6 +134,6 @@ export const Default: Story = () => (
       </StorySection>
     </StorySection>
   </StoryWrapper>
-);
+)
 
-Default.storyName = "Container"
+Default.storyName = 'Container'

--- a/components/atoms/Container/Container.tsx
+++ b/components/atoms/Container/Container.tsx
@@ -35,9 +35,8 @@ export interface ContainerProps {
 /**
  * Container component for consistent content width and spacing.
  *
- * Provides responsive container with max-width constraints and horizontal padding.
- * Padding is automatically responsive: small on mobile, medium on tablet, large on desktop.
- * Centers content by default for standard page layouts.
+ * Provides a max-width constraint and a flat horizontal gutter (px-4 at all
+ * breakpoints). Centers content by default for standard page layouts.
  *
  * @example
  * <Container>Content here</Container>
@@ -65,8 +64,8 @@ export function Container({
     default: 'max-w-7xl', // Default max width (1280px)
   }
 
-  // Responsive padding: small (mobile), medium (tablet), large (desktop)
-  const paddingStyles = 'px-4 sm:px-8 lg:px-16'
+  // Horizontal gutter — a flat px-4 at all breakpoints
+  const paddingStyles = 'px-4'
 
   const centerStyles = center ? 'mx-auto' : ''
 

--- a/components/atoms/Container/Container.tsx
+++ b/components/atoms/Container/Container.tsx
@@ -9,9 +9,10 @@ export interface ContainerProps {
 
   /**
    * Maximum width variant
+   * - `prose`: readable article column (max-w-4xl, ~896px)
    * @default 'default'
    */
-  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full' | 'default'
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full' | 'default' | 'prose'
 
   /**
    * Center the container
@@ -60,6 +61,7 @@ export function Container({
     xl: 'max-w-screen-xl',
     '2xl': 'max-w-screen-2xl',
     full: 'max-w-full',
+    prose: 'max-w-4xl', // Readable article column (~896px)
     default: 'max-w-7xl', // Default max width (1280px)
   }
 

--- a/components/atoms/Container/Container.tsx
+++ b/components/atoms/Container/Container.tsx
@@ -8,11 +8,12 @@ export interface ContainerProps {
   as?: ElementType
 
   /**
-   * Maximum width variant
-   * - `prose`: readable article column (max-w-4xl, ~896px)
+   * Maximum width variant — a content-width scale (max-w-3xl → max-w-7xl):
+   * `sm`=3xl (768px), `md`=4xl (896px, readable body), `lg`=5xl (1024px),
+   * `xl`=6xl (1152px), `2xl`=7xl (1280px). `full` removes the constraint.
    * @default 'default'
    */
-  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full' | 'default' | 'prose'
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full' | 'default'
 
   /**
    * Center the container
@@ -55,13 +56,12 @@ export function Container({
   const Component = as
 
   const maxWidthStyles = {
-    sm: 'max-w-screen-sm',
-    md: 'max-w-screen-md',
-    lg: 'max-w-screen-lg',
-    xl: 'max-w-screen-xl',
-    '2xl': 'max-w-screen-2xl',
+    sm: 'max-w-3xl', // 768px
+    md: 'max-w-4xl', // 896px — readable article/body column
+    lg: 'max-w-5xl', // 1024px
+    xl: 'max-w-6xl', // 1152px
+    '2xl': 'max-w-7xl', // 1280px
     full: 'max-w-full',
-    prose: 'max-w-4xl', // Readable article column (~896px)
     default: 'max-w-7xl', // Default max width (1280px)
   }
 

--- a/components/atoms/Icon/Icon.stories.tsx
+++ b/components/atoms/Icon/Icon.stories.tsx
@@ -1,5 +1,5 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { Icon } from "./Icon";
+import type { Story, StoryDefault } from '@ladle/react'
+import { Icon } from './Icon'
 import {
   HeartIcon,
   StarIcon,
@@ -37,12 +37,12 @@ import {
   StoryGridBody,
   StoryGridRow,
   StoryGridCell,
-  StoryWrapper
-} from '../../ladle';
+  StoryWrapper,
+} from '../../ladle'
 
 export default {
-  title: "Atoms"
-} satisfies StoryDefault;
+  title: 'Atoms / Graphics',
+} satisfies StoryDefault
 
 /**
  * Icon component showcasing all sizes, colors, common icons, and usage in context.
@@ -93,17 +93,17 @@ export const Default: Story = () => (
           <StoryGridRow>
             <StoryGridCell isLabel>Outline</StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="primary" />
+              <Icon color="primary" icon={StarIcon} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="secondary" />
+              <Icon color="secondary" icon={StarIcon} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="neutral" />
+              <Icon color="neutral" icon={StarIcon} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
               <div className="text-blue-600">
-                <Icon icon={StarIcon} size="lg" color="currentColor" />
+                <Icon color="currentColor" icon={StarIcon} size="lg" />
               </div>
             </StoryGridCell>
           </StoryGridRow>
@@ -111,17 +111,17 @@ export const Default: Story = () => (
           <StoryGridRow>
             <StoryGridCell isLabel>Solid</StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="primary" />
+              <Icon color="primary" icon={StarIconSolid} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="secondary" />
+              <Icon color="secondary" icon={StarIconSolid} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="neutral" />
+              <Icon color="neutral" icon={StarIconSolid} size="lg" />
             </StoryGridCell>
             <StoryGridCell>
               <div className="text-blue-600">
-                <Icon icon={StarIconSolid} size="lg" color="currentColor" />
+                <Icon color="currentColor" icon={StarIconSolid} size="lg" />
               </div>
             </StoryGridCell>
           </StoryGridRow>
@@ -130,10 +130,10 @@ export const Default: Story = () => (
     </StorySection>
 
     <StorySection
-      title="Dark Theme"
-      theme="dark"
       background="neutral"
       description="Lightened colors (teal-300, coral-300, white) for contrast on dark backgrounds"
+      theme="dark"
+      title="Dark Theme"
     >
       <StoryGrid>
         <StoryGridHeader>
@@ -149,17 +149,17 @@ export const Default: Story = () => (
           <StoryGridRow>
             <StoryGridCell isLabel>Outline</StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="primary" theme="dark" />
+              <Icon color="primary" icon={StarIcon} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="secondary" theme="dark" />
+              <Icon color="secondary" icon={StarIcon} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIcon} size="lg" color="neutral" theme="dark" />
+              <Icon color="neutral" icon={StarIcon} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
               <div className="text-blue-600">
-                <Icon icon={StarIcon} size="lg" color="currentColor" theme="dark" />
+                <Icon color="currentColor" icon={StarIcon} size="lg" theme="dark" />
               </div>
             </StoryGridCell>
           </StoryGridRow>
@@ -167,17 +167,17 @@ export const Default: Story = () => (
           <StoryGridRow>
             <StoryGridCell isLabel>Solid</StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="primary" theme="dark" />
+              <Icon color="primary" icon={StarIconSolid} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="secondary" theme="dark" />
+              <Icon color="secondary" icon={StarIconSolid} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
-              <Icon icon={StarIconSolid} size="lg" color="neutral" theme="dark" />
+              <Icon color="neutral" icon={StarIconSolid} size="lg" theme="dark" />
             </StoryGridCell>
             <StoryGridCell>
               <div className="text-blue-600">
-                <Icon icon={StarIconSolid} size="lg" color="currentColor" theme="dark" />
+                <Icon color="currentColor" icon={StarIconSolid} size="lg" theme="dark" />
               </div>
             </StoryGridCell>
           </StoryGridRow>
@@ -291,7 +291,7 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection title="Examples" inContext={true}>
+    <StorySection inContext={true} title="Examples">
       <div className="flex flex-col gap-6">
         <StorySection title="Button with Icons" variant="subsection">
           <div className="flex flex-wrap gap-3">
@@ -313,19 +313,19 @@ export const Default: Story = () => (
         <StorySection title="List Items with Icons" variant="subsection">
           <ul className="space-y-3">
             <li className="flex items-center gap-3">
-              <Icon icon={CheckIcon} size="md" color="primary" />
+              <Icon color="primary" icon={CheckIcon} size="md" />
               <span className="text-gray-700">Reduce stress and anxiety</span>
             </li>
             <li className="flex items-center gap-3">
-              <Icon icon={CheckIcon} size="md" color="primary" />
+              <Icon color="primary" icon={CheckIcon} size="md" />
               <span className="text-gray-700">Improve focus and concentration</span>
             </li>
             <li className="flex items-center gap-3">
-              <Icon icon={CheckIcon} size="md" color="primary" />
+              <Icon color="primary" icon={CheckIcon} size="md" />
               <span className="text-gray-700">Enhance emotional well-being</span>
             </li>
             <li className="flex items-center gap-3">
-              <Icon icon={CheckIcon} size="md" color="primary" />
+              <Icon color="primary" icon={CheckIcon} size="md" />
               <span className="text-gray-700">Better sleep quality</span>
             </li>
           </ul>
@@ -334,14 +334,14 @@ export const Default: Story = () => (
         <StorySection title="Information Cards" variant="subsection">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="border border-teal-200 bg-teal-50 rounded-lg p-4 flex gap-3">
-              <Icon icon={InformationCircleIcon} size="lg" color="primary" />
+              <Icon color="primary" icon={InformationCircleIcon} size="lg" />
               <div>
                 <h4 className="font-medium text-gray-900 mb-1">Beginner Friendly</h4>
                 <p className="text-sm text-gray-700">Perfect for those new to meditation</p>
               </div>
             </div>
             <div className="border border-coral-200 bg-coral-50 rounded-lg p-4 flex gap-3">
-              <Icon icon={ClockIcon} size="lg" color="secondary" />
+              <Icon color="secondary" icon={ClockIcon} size="lg" />
               <div>
                 <h4 className="font-medium text-gray-900 mb-1">Quick Session</h4>
                 <p className="text-sm text-gray-700">Just 10 minutes a day</p>
@@ -353,15 +353,15 @@ export const Default: Story = () => (
         <StorySection title="Current Color on Dark Background" variant="subsection">
           <div className="bg-gray-800 rounded-lg p-6 space-y-4">
             <div className="flex items-center gap-3 text-white">
-              <Icon icon={HeartIcon} size="lg" color="currentColor" />
+              <Icon color="currentColor" icon={HeartIcon} size="lg" />
               <span>White icon inherits from parent text color</span>
             </div>
             <div className="flex items-center gap-3 text-teal-300">
-              <Icon icon={StarIcon} size="lg" color="currentColor" />
+              <Icon color="currentColor" icon={StarIcon} size="lg" />
               <span>Teal icon inherits custom color</span>
             </div>
             <div className="flex items-center gap-3 text-coral-300">
-              <Icon icon={PlayIcon} size="lg" color="currentColor" />
+              <Icon color="currentColor" icon={PlayIcon} size="lg" />
               <span>Coral icon inherits custom color</span>
             </div>
           </div>
@@ -371,5 +371,5 @@ export const Default: Story = () => (
 
     <div />
   </StoryWrapper>
-);
-Default.storyName = "Icon"
+)
+Default.storyName = 'Icon'

--- a/components/atoms/Image/Image.test.tsx
+++ b/components/atoms/Image/Image.test.tsx
@@ -46,6 +46,28 @@ describe('<Image> Cloudflare Images integration', () => {
   })
 })
 
+describe('<Image> forceAspectRatio', () => {
+  it('constrains to a fixed-ratio box by default (aspect class on container, img fills it)', () => {
+    const html = renderToStaticMarkup(<Image alt="test" aspectRatio="video" src={CF_URL} />)
+
+    expect(html).toContain('aspect-video')
+    expect(html).toContain('w-full h-full') // <img> fills the box
+  })
+
+  it('renders natural flow when false, but still fetches the optimized variant + srcset', () => {
+    const html = renderToStaticMarkup(
+      <Image alt="test" aspectRatio="video" forceAspectRatio={false} src={CF_URL} />,
+    )
+
+    // The optimized variant + responsive srcSet are still emitted...
+    expect(html).toContain(`src="${CF_URL}video-800"`)
+    expect(html).toContain('video-1536 1536w')
+    // ...but no fixed-ratio box, and the <img> is not absolutely positioned to fill one.
+    expect(html).not.toContain('aspect-video')
+    expect(html).not.toContain('w-full h-full')
+  })
+})
+
 describe('buildLightboxSlide', () => {
   it('requests the largest Cloudflare variant and mirrors alt into the caption', () => {
     const slide = buildLightboxSlide(CF_URL, 'A sunrise', 'video')

--- a/components/atoms/Image/Image.tsx
+++ b/components/atoms/Image/Image.tsx
@@ -215,6 +215,20 @@ export function Image({
     }
   }, [src, aspectRatio, size, responsive])
 
+  // Reset loading/error state when the resolved src changes in place (a
+  // persistent <Image> whose `src` prop mutates, e.g. the AudioPlayer now-playing
+  // thumbnail on track switch). React's "adjust state during render" pattern runs
+  // before paint, so the new image shows its placeholder instead of briefly
+  // flashing the previous (or a stuck error) state; the effect below then clears
+  // `isLoading` immediately if the new src is already cached.
+  const [loadedSrc, setLoadedSrc] = useState(imageSrc)
+
+  if (imageSrc !== loadedSrc) {
+    setLoadedSrc(imageSrc)
+    setIsLoading(true)
+    setHasError(false)
+  }
+
   // A cached image can already be `complete` before React attaches `onLoad`, so
   // the load event never reaches our handler and `isLoading` stays stuck `true`
   // (placeholder lingers, image held at opacity-0). Effects don't run during SSR,

--- a/components/atoms/Image/Image.tsx
+++ b/components/atoms/Image/Image.tsx
@@ -271,9 +271,8 @@ export function Image({
     onError?.(e)
   }
 
-  const containerClasses = boxed
-    ? `relative ${aspectRatioStyles} ${roundedStyles} overflow-hidden`
-    : `relative ${roundedStyles} overflow-hidden`
+  // `aspectRatioStyles` is '' unless boxed, so one literal covers both cases.
+  const containerClasses = `relative ${aspectRatioStyles} ${roundedStyles} overflow-hidden`
 
   const imageClasses = `${objectFitStyles} ${
     boxed ? 'absolute inset-0 w-full h-full' : ''

--- a/components/atoms/Image/Image.tsx
+++ b/components/atoms/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useEffect, useMemo, useState } from 'react'
+import { ComponentProps, useEffect, useMemo, useRef, useState } from 'react'
 import { Placeholder } from '../Placeholder'
 import { Icon } from '../Icon'
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
@@ -44,6 +44,17 @@ export interface ImageProps extends ComponentProps<'img'> {
    * @default undefined (intrinsic aspect ratio)
    */
   aspectRatio?: AspectRatio
+
+  /**
+   * When an `aspectRatio` is set, also crop the layout to a fixed box of that
+   * ratio (the `<img>` fills it via `absolute inset-0` + `object-fit`). The
+   * aspect ratio is still used to pick an optimized Cloudflare variant + srcset
+   * either way. Set `false` to keep the `<img>` in natural document flow (sized
+   * by its intrinsic `width`/`height`) while still fetching an optimized
+   * variant — used by feature blocks that render at the image's own ratio.
+   * @default true
+   */
+  forceAspectRatio?: boolean
 
   /**
    * Size tier used to pick a Cloudflare Images variant and generate srcset.
@@ -153,6 +164,7 @@ export function Image({
   width,
   height,
   aspectRatio,
+  forceAspectRatio = true,
   size = 'medium',
   responsive = true,
   objectFit = 'cover',
@@ -169,6 +181,7 @@ export function Image({
 }: ImageProps) {
   const [isLoading, setIsLoading] = useState(true)
   const [hasError, setHasError] = useState(false)
+  const imgRef = useRef<HTMLImageElement>(null)
 
   const lightbox = useLightbox()
 
@@ -202,15 +215,36 @@ export function Image({
     }
   }, [src, aspectRatio, size, responsive])
 
-  const aspectRatioStyles = aspectRatio
-    ? {
-        square: 'aspect-square',
-        video: 'aspect-video',
-        '4-3': 'aspect-[4/3]',
-        '3-2': 'aspect-[3/2]',
-        ultrawide: 'aspect-[21/9]',
-      }[aspectRatio]
-    : ''
+  // A cached image can already be `complete` before React attaches `onLoad`, so
+  // the load event never reaches our handler and `isLoading` stays stuck `true`
+  // (placeholder lingers, image held at opacity-0). Effects don't run during SSR,
+  // so on mount — and whenever the resolved src changes — re-check `complete` and
+  // clear the loading state for an already-decoded image. `naturalWidth > 0`
+  // excludes broken images so `onError` still owns the error path.
+  useEffect(() => {
+    const img = imgRef.current
+
+    if (img?.complete && img.naturalWidth > 0) {
+      setIsLoading(false)
+    }
+  }, [imageSrc, imageSrcSet])
+
+  // `aspectRatio` always drives Cloudflare variant/srcset selection (above), but
+  // only constrains the layout to a fixed-ratio box when `forceAspectRatio`
+  // is set (the default). Natural-flow callers pass `forceAspectRatio=false`
+  // to render the image at its own ratio while still fetching an optimized variant.
+  const boxed = Boolean(aspectRatio) && forceAspectRatio
+
+  const aspectRatioStyles =
+    boxed && aspectRatio
+      ? {
+          square: 'aspect-square',
+          video: 'aspect-video',
+          '4-3': 'aspect-[4/3]',
+          '3-2': 'aspect-[3/2]',
+          ultrawide: 'aspect-[21/9]',
+        }[aspectRatio]
+      : ''
 
   const objectFitStyles = {
     cover: 'object-cover',
@@ -237,25 +271,24 @@ export function Image({
     onError?.(e)
   }
 
-  const containerClasses = aspectRatio
+  const containerClasses = boxed
     ? `relative ${aspectRatioStyles} ${roundedStyles} overflow-hidden`
     : `relative ${roundedStyles} overflow-hidden`
 
   const imageClasses = `${objectFitStyles} ${
-    aspectRatio ? 'absolute inset-0 w-full h-full' : ''
+    boxed ? 'absolute inset-0 w-full h-full' : ''
   } transition-opacity duration-300 ${isLoading ? 'opacity-0' : 'opacity-100'} ${className}`
 
   const content = (
     <>
-      {/* Always show Placeholder when loading or error */}
+      {/* Loading/error overlay. It's always positioned `absolute inset-0` to fill
+          the container the image occupies, so it must NOT take explicit pixel
+          dimensions — passing the intrinsic width/height here would size the
+          overlay to the raw image and anchor it top-left, overflowing/clipping
+          instead of matching the rendered image box. The <img>'s own width/height
+          attributes reserve layout space and prevent shift. */}
       {showLoading && (isLoading || hasError) && (
-        <Placeholder
-          animate={!hasError}
-          className="absolute inset-0"
-          height={height}
-          variant={placeholderVariant}
-          width={width}
-        >
+        <Placeholder animate={!hasError} className="absolute inset-0" variant={placeholderVariant}>
           {hasError && <Icon icon={ExclamationCircleIcon} size="lg" />}
         </Placeholder>
       )}
@@ -263,6 +296,7 @@ export function Image({
       {/* Image element (hidden until loaded, not rendered on error) */}
       {!hasError && (
         <img
+          ref={imgRef}
           alt={alt}
           className={imageClasses}
           height={height}

--- a/components/atoms/Image/Image.tsx
+++ b/components/atoms/Image/Image.tsx
@@ -74,7 +74,7 @@ export interface ImageProps extends ComponentProps<'img'> {
    * Border radius style
    * @default 'square'
    */
-  rounded?: 'square' | 'rounded' | 'circle'
+  rounded?: 'none' | 'square' | 'rounded' | 'circle'
 
   /**
    * Show loading state
@@ -220,6 +220,7 @@ export function Image({
   }[objectFit]
 
   const roundedStyles = {
+    none: '',
     square: 'rounded-xs',
     rounded: 'rounded-lg',
     circle: 'rounded-full',

--- a/components/ladle/StorySection.tsx
+++ b/components/ladle/StorySection.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode } from 'react'
 
 /**
  * Unified StorySection component for consistent story structure in Ladle.
@@ -15,13 +15,13 @@ import type { ReactNode } from 'react';
  * @param inContext - When true, adds "In Context" prefix to title and bold top border
  */
 export interface StorySectionProps {
-  title: string;
-  description?: string;
-  children: ReactNode;
-  theme?: 'light' | 'dark';
-  background?: 'none' | 'neutral' | 'gradient';
-  variant?: 'section' | 'subsection' | 'scrollable';
-  inContext?: boolean;
+  title: string
+  description?: string
+  children: ReactNode
+  theme?: 'light' | 'dark'
+  background?: 'none' | 'neutral' | 'gradient'
+  variant?: 'section' | 'subsection' | 'scrollable'
+  inContext?: boolean
 }
 
 export const StorySection = ({
@@ -31,41 +31,40 @@ export const StorySection = ({
   theme = 'light',
   background = 'none',
   variant = 'section',
-  inContext = false
+  inContext = false,
 }: StorySectionProps) => {
   // Background styles based on theme and background type
   const getBackgroundStyles = () => {
-    if (background === 'none') return '';
+    if (background === 'none') return ''
 
-    const baseStyles = 'p-6 rounded-lg';
+    const baseStyles = 'p-6 rounded-lg'
 
     if (background === 'neutral') {
-      return theme === 'dark'
-        ? `bg-gray-800 ${baseStyles}`
-        : `bg-gray-50 ${baseStyles}`;
+      return theme === 'dark' ? `bg-gray-800 ${baseStyles}` : `bg-gray-50 ${baseStyles}`
     }
 
     if (background === 'gradient') {
       return theme === 'dark'
         ? `bg-linear-to-b from-teal-600 to-teal-700 ${baseStyles}`
-        : `bg-linear-to-b from-teal-50 to-teal-100 ${baseStyles}`;
+        : `bg-linear-to-b from-teal-50 to-teal-100 ${baseStyles}`
     }
 
-    return '';
-  };
+    return ''
+  }
 
   // Text colors based on theme
   // For non-subsection dark sections with background, title/description appear on light wrapper background
   const getTitleColor = () => {
     if (variant === 'subsection') {
-      return theme === 'dark' ? 'text-gray-100' : 'text-gray-700';
+      return theme === 'dark' ? 'text-gray-100' : 'text-gray-700'
     }
+
     // Non-subsection dark theme sections have title/description on light background wrapper
     // So they should use light theme colors
-    return 'text-gray-900';
-  };
+    return 'text-gray-900'
+  }
 
-  const descriptionColor = 'text-gray-600'; // Always on light background for non-subsections
+  const descriptionColor = 'text-gray-600' // Always on light background for non-subsections
 
   // Variant-specific configuration
   const variantConfig = {
@@ -74,79 +73,72 @@ export const StorySection = ({
       titleClass: 'text-lg font-semibold mb-4',
       showDivider: true,
       wrapperClass: '',
-      isScrollable: false
+      isScrollable: false,
     },
     subsection: {
       tag: 'p' as const,
       titleClass: 'text-sm font-medium mb-3',
       showDivider: false,
       wrapperClass: 'mt-5',
-      isScrollable: false
+      isScrollable: false,
     },
     scrollable: {
       tag: 'h2' as const,
       titleClass: 'text-lg font-semibold mb-4',
       showDivider: true,
       wrapperClass: '',
-      isScrollable: true
-    }
-  };
+      isScrollable: true,
+    },
+  }
 
-  const config = variantConfig[variant];
-  const TitleTag = config.tag;
-  const titleColor = getTitleColor();
-  const backgroundStyles = getBackgroundStyles();
+  const config = variantConfig[variant]
+  const TitleTag = config.tag
+  const titleColor = getTitleColor()
+  const backgroundStyles = getBackgroundStyles()
 
   // Add "In Context - " prefix when inContext is true
-  const displayTitle = inContext && title
-    ? `In Context - ${title}`
-    : inContext
-      ? 'In Context'
-      : title;
+  const displayTitle =
+    inContext && title ? `In Context - ${title}` : inContext ? 'In Context' : title
 
   // Get text color for children based on theme
-  const childrenTextColor = theme === 'dark' ? 'text-white' : '';
+  const childrenTextColor = theme === 'dark' ? 'text-white' : ''
 
   // For scrollable variant, wrap content in scrollable container
   const renderContent = () => {
     if (config.isScrollable) {
       // Determine border and background for scrollable container
-      const borderColor = theme === 'dark' ? 'border-gray-700' : 'border-gray-200';
-      const scrollBackground = backgroundStyles || (theme === 'dark' ? 'bg-linear-to-b from-teal-600 to-teal-700' : 'bg-white');
+      const borderColor = theme === 'dark' ? 'border-gray-700' : 'border-gray-200'
+      const scrollBackground =
+        backgroundStyles ||
+        (theme === 'dark' ? 'bg-linear-to-b from-teal-600 to-teal-700' : 'bg-white')
 
       return (
-        <div className={`h-[600px] overflow-y-auto border-4 ${borderColor} -m-6`}>
+        <div className={`h-[600px] overflow-y-auto border-4 ${borderColor}`}>
           <div className={`min-h-full px-6 ${scrollBackground} ${childrenTextColor}`}>
             {children}
           </div>
         </div>
-      );
+      )
     }
 
     // Regular content with optional background and text color
     if (backgroundStyles) {
-      return <div className={`${backgroundStyles} ${childrenTextColor}`}>{children}</div>;
+      return <div className={`${backgroundStyles} ${childrenTextColor}`}>{children}</div>
     }
 
-    return <div className={childrenTextColor}>{children}</div>;
-  };
+    return <div className={childrenTextColor}>{children}</div>
+  }
 
   return (
     <>
       <div className={config.wrapperClass}>
         {/* Bold top border for "In Context" sections */}
-        {inContext && (
-          <div className="border-t-4 border-gray-900 mb-6 pt-8" />
-        )}
-        <TitleTag className={`${config.titleClass} ${titleColor}`}>
-          {displayTitle}
-        </TitleTag>
-        {description && (
-          <p className={`text-sm ${descriptionColor} mb-4`}>{description}</p>
-        )}
+        {inContext && <div className="border-t-4 border-gray-900 mb-6 pt-8" />}
+        <TitleTag className={`${config.titleClass} ${titleColor}`}>{displayTitle}</TitleTag>
+        {description && <p className={`text-sm ${descriptionColor} mb-4`}>{description}</p>}
         {renderContent()}
       </div>
       {config.showDivider && <hr className="border-gray-200" />}
     </>
-  );
-};
+  )
+}

--- a/components/ladle/StoryWrapper.tsx
+++ b/components/ladle/StoryWrapper.tsx
@@ -1,10 +1,10 @@
-import type { ReactNode } from 'react';
+import type { ReactNode } from 'react'
 
 export interface StoryWrapperProps {
   /**
    * Story content to wrap
    */
-  children: ReactNode;
+  children: ReactNode
 }
 
 /**
@@ -23,9 +23,9 @@ export interface StoryWrapperProps {
  * ```
  */
 export function StoryWrapper({ children }: StoryWrapperProps) {
-  return (
-    <div className="flex flex-col gap-8 p-2">
-      {children}
-    </div>
-  );
+  // Horizontal gutter lives here (inside the Provider's inline-size container) so
+  // `full-bleed` blocks escape it and reach the story-canvas edges, matching the
+  // page model where the content gutter sits inside `<main>`. Ladle's own
+  // `.ladle-main` horizontal padding is removed in .ladle/story-overrides.css.
+  return <div className="flex flex-col gap-8 px-12 py-2">{children}</div>
 }

--- a/components/organisms/ContentOverlay/ContentOverlay.stories.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.stories.tsx
@@ -16,6 +16,7 @@ export const Default: Story = () => (
         <StorySection title="Left Aligned" variant="subsection">
           <ContentOverlay
             align="left"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Get Inspired"
             imageAlt="Meditation practice"
@@ -32,6 +33,7 @@ export const Default: Story = () => (
         <StorySection title="Right Aligned" variant="subsection">
           <ContentOverlay
             align="right"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Start Your Journey"
             imageAlt="Inner peace"
@@ -48,6 +50,7 @@ export const Default: Story = () => (
         <StorySection title="Center Aligned" variant="subsection">
           <ContentOverlay
             align="center"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Learn More"
             imageAlt="Life transformation"
@@ -71,6 +74,7 @@ export const Default: Story = () => (
         <StorySection title="Dark Theme" variant="subsection">
           <ContentOverlay
             align="left"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Get Inspired"
             imageAlt="Meditation at dusk"
@@ -85,6 +89,7 @@ export const Default: Story = () => (
         <StorySection title="Light Theme" variant="subsection">
           <ContentOverlay
             align="right"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Begin Today"
             imageAlt="Bright morning meditation"
@@ -103,6 +108,7 @@ export const Default: Story = () => (
         <StorySection title="Left Aligned" variant="subsection">
           <ContentOverlay
             align="left"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Explore Techniques"
             imageAlt="Unlock potential"
@@ -119,6 +125,7 @@ export const Default: Story = () => (
         <StorySection title="Right Aligned" variant="subsection">
           <ContentOverlay
             align="right"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Begin Today"
             imageAlt="Mental clarity"
@@ -135,6 +142,7 @@ export const Default: Story = () => (
         <StorySection title="Center Aligned" variant="subsection">
           <ContentOverlay
             align="center"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Join Now"
             imageAlt="Meditation community"
@@ -155,6 +163,7 @@ export const Default: Story = () => (
         <StorySection title="Dark Theme with High Contrast" variant="subsection">
           <ContentOverlay
             align="left"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Learn More"
             imageAlt="High contrast dark theme"
@@ -172,6 +181,7 @@ export const Default: Story = () => (
         <StorySection title="Light Theme with High Contrast" variant="subsection">
           <ContentOverlay
             align="right"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Get Started"
             imageAlt="High contrast light theme"
@@ -193,6 +203,7 @@ export const Default: Story = () => (
         <StorySection title="Dark Theme with Box" variant="subsection">
           <ContentOverlay
             align="center"
+            className="full-bleed"
             ctaHref="#"
             ctaText="Explore Features"
             imageAlt="Box variant dark theme"
@@ -210,6 +221,7 @@ export const Default: Story = () => (
         <StorySection title="Light Theme with Box" variant="subsection">
           <ContentOverlay
             align="right"
+            className="full-bleed"
             ctaHref="#"
             ctaText="View Details"
             imageAlt="Box variant light theme"

--- a/components/organisms/ContentOverlay/ContentOverlay.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.tsx
@@ -129,7 +129,7 @@ export function ContentOverlay({
   const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[50%]'
 
   return (
-    <div className={`w-full ${className}`} {...props}>
+    <div className={className} {...props}>
       {/* Mobile: Stacked layout - no variant or theme styling */}
       <div className="flex flex-col gap-6 md:hidden">
         {/* Image on top */}

--- a/components/organisms/ContentOverlay/ContentOverlay.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.tsx
@@ -126,8 +126,8 @@ export function ContentOverlay({
   }
 
   // Outer positioning zone — up to 50% of the overlay on lg+ for non-box. The
-  // readable text width inside is capped by a Container (md) below.
-  const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[50%]'
+  // readable text width inside is capped by a Container (lg) below.
+  const maxWidthClasses = variant === 'box' ? 'max-w-lg lg:max-w-lg' : 'max-w-lg lg:max-w-[50%]'
 
   // Position the readable Container within the zone to match the alignment.
   const innerAlign = { left: '', right: 'md:ml-auto', center: 'md:mx-auto' }[align]
@@ -227,7 +227,7 @@ export function ContentOverlay({
             {variant === 'box' ? (
               desktopContent
             ) : (
-              <Container center={false} className={innerAlign} maxWidth="md">
+              <Container center={false} className={innerAlign} maxWidth="lg">
                 {desktopContent}
               </Container>
             )}

--- a/components/organisms/ContentOverlay/ContentOverlay.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.tsx
@@ -125,8 +125,8 @@ export function ContentOverlay({
     center: 'md:mx-auto md:text-center',
   }
 
-  // Max width classes - 50% on lg+ for non-box variants
-  const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[50%]'
+  // Max width classes - 40% on lg+ for non-box variants (narrower text column)
+  const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[40%]'
 
   return (
     <div className={className} {...props}>

--- a/components/organisms/ContentOverlay/ContentOverlay.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.tsx
@@ -127,7 +127,7 @@ export function ContentOverlay({
 
   // Outer positioning zone — up to 50% of the overlay on lg+ for non-box. The
   // readable text width inside is capped by a Container (lg) below.
-  const maxWidthClasses = variant === 'box' ? 'max-w-lg lg:max-w-lg' : 'max-w-lg lg:max-w-[50%]'
+  const maxWidthClasses = variant === 'box' ? 'max-w-lg' : 'max-w-lg lg:max-w-[50%]'
 
   // Position the readable Container within the zone to match the alignment.
   const innerAlign = { left: '', right: 'md:ml-auto', center: 'md:mx-auto' }[align]

--- a/components/organisms/ContentOverlay/ContentOverlay.tsx
+++ b/components/organisms/ContentOverlay/ContentOverlay.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react'
-import { Button, Image } from '../../atoms'
+import { Button, Container, Image } from '../../atoms'
 
 export interface ContentOverlayProps extends Omit<ComponentProps<'div'>, 'children'> {
   /**
@@ -125,8 +125,55 @@ export function ContentOverlay({
     center: 'md:mx-auto md:text-center',
   }
 
-  // Max width classes - 40% on lg+ for non-box variants (narrower text column)
-  const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[40%]'
+  // Outer positioning zone — up to 50% of the overlay on lg+ for non-box. The
+  // readable text width inside is capped by a Container (md) below.
+  const maxWidthClasses = variant === 'box' ? 'max-w-md lg:max-w-lg' : 'max-w-md lg:max-w-[50%]'
+
+  // Position the readable Container within the zone to match the alignment.
+  const innerAlign = { left: '', right: 'md:ml-auto', center: 'md:mx-auto' }[align]
+
+  // Desktop overlay content (header + body + CTA). Reused inside the readable
+  // Container for non-box variants, or directly for `box` (already a card).
+  const desktopContent = (
+    <>
+      <div className="mb-7 flex flex-col gap-1.5">
+        <h2
+          className={`text-xl md:text-2xl font-semibold tracking-wide ${textColorClass} ${textShadowClass}`}
+        >
+          {title}
+        </h2>
+        {subtitle && (
+          <p className={`text-base md:text-lg font-light ${textColorClass} ${textShadowClass}`}>
+            {subtitle}
+          </p>
+        )}
+      </div>
+
+      <div
+        className={`text-base md:text-lg font-medium leading-relaxed ${textColorClass} ${textShadowClass}`}
+      >
+        {textParagraphs.map((paragraph, index) => (
+          <p key={index} className={index < textParagraphs.length - 1 ? 'mb-4' : ''}>
+            {paragraph}
+          </p>
+        ))}
+      </div>
+
+      {ctaText && ctaHref && (
+        <div className="mt-6">
+          <Button
+            className={buttonClassName}
+            href={ctaHref}
+            size="md"
+            theme={theme}
+            variant={buttonVariant}
+          >
+            {ctaText}
+          </Button>
+        </div>
+      )}
+    </>
+  )
 
   return (
     <div className={className} {...props}>
@@ -174,45 +221,15 @@ export function ContentOverlay({
 
         {/* Content Overlay */}
         <div className="relative h-full flex items-center md:px-8 lg:px-24">
-          {/* Content Box - 50% max-width on lg+ for non-box variants */}
+          {/* Positioning zone (up to 50%); the readable text is capped by the
+              Container inside (non-box). The box variant is already a constrained card. */}
           <div className={`${maxWidthClasses} ${alignmentClasses[align]} ${boxClasses}`}>
-            <div className="mb-7 flex flex-col gap-1.5">
-              <h2
-                className={`text-xl md:text-2xl font-semibold tracking-wide ${textColorClass} ${textShadowClass}`}
-              >
-                {title}
-              </h2>
-              {subtitle && (
-                <p
-                  className={`text-base md:text-lg font-light ${textColorClass} ${textShadowClass}`}
-                >
-                  {subtitle}
-                </p>
-              )}
-            </div>
-
-            <div
-              className={`text-base md:text-lg font-medium leading-relaxed ${textColorClass} ${textShadowClass}`}
-            >
-              {textParagraphs.map((paragraph, index) => (
-                <p key={index} className={index < textParagraphs.length - 1 ? 'mb-4' : ''}>
-                  {paragraph}
-                </p>
-              ))}
-            </div>
-
-            {ctaText && ctaHref && (
-              <div className="mt-6">
-                <Button
-                  className={buttonClassName}
-                  href={ctaHref}
-                  size="md"
-                  theme={theme}
-                  variant={buttonVariant}
-                >
-                  {ctaText}
-                </Button>
-              </div>
+            {variant === 'box' ? (
+              desktopContent
+            ) : (
+              <Container center={false} className={innerAlign} maxWidth="md">
+                {desktopContent}
+              </Container>
             )}
           </div>
         </div>

--- a/components/organisms/ContentTextBox/ContentTextBox.tsx
+++ b/components/organisms/ContentTextBox/ContentTextBox.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from 'react'
 import { Button, Image } from '../../atoms'
+import type { AspectRatio } from '../../../lib/cloudflare-images'
 
 export interface ContentTextBoxProps extends Omit<ComponentProps<'div'>, 'title'> {
   /**
@@ -51,6 +52,14 @@ export interface ContentTextBoxProps extends Omit<ComponentProps<'div'>, 'title'
   imageHeight?: number
 
   /**
+   * Nearest configured Cloudflare aspect ratio for the image. When set (and the
+   * `imageSrc` is a Cloudflare URL), an optimized variant + srcset is fetched
+   * instead of the full-resolution original. The image still renders at its
+   * natural ratio (the ratio only selects the variant, not a cropping box).
+   */
+  imageAspectRatio?: AspectRatio
+
+  /**
    * Text box position relative to image
    * - left: Text box on left, image on right (max 50% width on desktop)
    * - right: Text box on right, image on left (max 50% width on desktop)
@@ -91,6 +100,7 @@ export function ContentTextBox({
   imageAlt,
   imageWidth,
   imageHeight,
+  imageAspectRatio,
   align = 'left',
   className = '',
   ...props
@@ -102,6 +112,7 @@ export function ContentTextBox({
     <div
       className={`
         relative
+        my-24 lg:my-32
         lg:max-h-[700px]
         gap-6 lg:gap-0
         flex flex-col items-center ${wrapperClasses}
@@ -117,9 +128,12 @@ export function ContentTextBox({
           tall. Desktop (lg): the original contained, container-height behavior. */}
       <Image
         alt={imageAlt}
+        aspectRatio={imageAspectRatio}
         className="w-full max-h-[calc(100cqi-5rem)] lg:h-full lg:max-h-[85vh] lg:object-contain"
+        forceAspectRatio={false}
         height={imageHeight}
         objectFit="cover"
+        sizes="(max-width: 1024px) 100vw, 600px"
         src={imageSrc}
         width={imageWidth}
       />

--- a/components/organisms/ContentTextBox/ContentTextBox.tsx
+++ b/components/organisms/ContentTextBox/ContentTextBox.tsx
@@ -110,12 +110,16 @@ export function ContentTextBox({
       `}
       {...props}
     >
-      {/* Image - natural flow on mobile, positioned on desktop */}
+      {/* Image - natural flow on mobile, positioned on desktop.
+          Mobile: fill the column width, capped to a 1:1 aspect (height ≤ width, via
+          the local content-container width `100cqi` minus the page gutters) and
+          `object-cover` so portrait images crop to ≤ square rather than running
+          tall. Desktop (lg): the original contained, container-height behavior. */}
       <Image
         alt={imageAlt}
-        className="w-full max-h-[min(70vh,100vw)] lg:h-full lg:max-h-[85vh]"
+        className="w-full max-h-[calc(100cqi-5rem)] lg:h-full lg:max-h-[85vh] lg:object-contain"
         height={imageHeight}
-        objectFit="contain"
+        objectFit="cover"
         src={imageSrc}
         width={imageWidth}
       />

--- a/components/organisms/ContentTextBox/ContentTextBox.tsx
+++ b/components/organisms/ContentTextBox/ContentTextBox.tsx
@@ -123,13 +123,13 @@ export function ContentTextBox({
     >
       {/* Image - natural flow on mobile, positioned on desktop.
           Mobile: fill the column width, capped to a 1:1 aspect (height ≤ width, via
-          the local content-container width `100cqi` minus the page gutters) and
+          the captured page width `--page-width` minus the page gutters) and
           `object-cover` so portrait images crop to ≤ square rather than running
           tall. Desktop (lg): the original contained, container-height behavior. */}
       <Image
         alt={imageAlt}
         aspectRatio={imageAspectRatio}
-        className="w-full max-h-[calc(100cqi-5rem)] lg:h-full lg:max-h-[85vh] lg:object-contain"
+        className="w-full max-h-[calc(var(--page-width)-5rem)] lg:h-full lg:max-h-[85vh] lg:object-contain"
         forceAspectRatio={false}
         height={imageHeight}
         objectFit="cover"

--- a/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
+++ b/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
@@ -1,6 +1,11 @@
 import { ComponentProps } from 'react'
 import { Link } from '../../atoms'
-import { PlayCircleIcon, ComputerDesktopIcon, UserGroupIcon, MapPinIcon } from '@heroicons/react/24/outline'
+import {
+  PlayCircleIcon,
+  ComputerDesktopIcon,
+  UserGroupIcon,
+  MapPinIcon,
+} from '@heroicons/react/24/outline'
 
 export interface DiscoverMeditationProps extends ComponentProps<'section'> {
   /**
@@ -27,7 +32,7 @@ export interface DiscoverMeditationProps extends ComponentProps<'section'> {
  * live meditations, and in-person classes.
  */
 export function DiscoverMeditation({
-  title = "Discover it for yourself!",
+  title = 'Discover it for yourself!',
   subtitle = "Don't just take our word for it. Try meditating and see how you feel!",
   locale,
   className = '',
@@ -36,10 +41,10 @@ export function DiscoverMeditation({
   return (
     <section
       className={`
-        relative h-screen min-h-screen
+        relative min-h-screen
         flex items-center justify-center
         text-center text-gray-700
-        pb-48
+        py-24 lg:pb-48
         ${className}
       `}
       {...props}
@@ -47,10 +52,10 @@ export function DiscoverMeditation({
       {/* Background Image */}
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+        role="presentation"
         style={{
           backgroundImage: 'url(/images/backgrounds/discover-meditation-background.webp)',
         }}
-        role="presentation"
       />
 
       {/* Gradient Overlay - left side, extends 65px below component */}
@@ -63,38 +68,36 @@ export function DiscoverMeditation({
       <div className="relative z-10 p-6">
         {/* Header Section */}
         <div className="mb-16">
-          <h2 className="text-3xl md:text-4xl font-normal text-gray-700 mb-8">
-            {title}
-          </h2>
+          <h2 className="text-3xl md:text-4xl font-normal text-gray-700 mb-8">{title}</h2>
           <p className="text-xl md:text-2xl font-light text-gray-700 max-w-lg mx-auto">
             {subtitle}
           </p>
         </div>
 
         {/* Action Items */}
-        <div className="flex flex-col lg:flex-row gap-12 lg:gap-16 xl:gap-24 items-center justify-center mt-24">
+        <div className="flex flex-wrap gap-8 sm:gap-12 lg:gap-16 xl:gap-24 items-center justify-center mt-12 lg:mt-24">
           <ActionItem
             href="/meditations"
-            locale={locale}
             icon={PlayCircleIcon}
-            title="Meditate Now"
+            locale={locale}
             subtitle="Watch guided meditations"
+            title="Meditate Now"
           />
 
           <ActionItem
             href="/live"
-            locale={locale}
             icon={ComputerDesktopIcon}
-            title="Live Guidance"
+            locale={locale}
             subtitle="Free online meditations"
+            title="Live Guidance"
           />
 
           <ActionItem
             href="/classes"
-            locale={locale}
             icon={MapPinIcon}
-            title="Classes Near Me"
+            locale={locale}
             subtitle="Free in-person classes"
+            title="Classes Near Me"
           />
         </div>
       </div>
@@ -116,10 +119,10 @@ interface ActionItemProps {
 function ActionItem({ href, locale, icon: Icon, title, subtitle }: ActionItemProps) {
   return (
     <Link
+      className="flex flex-col items-center gap-3 group"
       href={href}
       locale={locale}
       variant="neutral"
-      className="flex flex-col items-center gap-3 group"
     >
       <div className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 group-hover:scale-105 transition-transform">
         <Icon className="w-full h-full stroke-current stroke-[0.5]" />
@@ -135,4 +138,3 @@ function ActionItem({ href, locale, icon: Icon, title, subtitle }: ActionItemPro
     </Link>
   )
 }
-

--- a/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
+++ b/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
@@ -1,11 +1,6 @@
 import { ComponentProps } from 'react'
 import { Link } from '../../atoms'
-import {
-  PlayCircleIcon,
-  ComputerDesktopIcon,
-  UserGroupIcon,
-  MapPinIcon,
-} from '@heroicons/react/24/outline'
+import { PlayCircleIcon, ComputerDesktopIcon, MapPinIcon } from '@heroicons/react/24/outline'
 
 export interface DiscoverMeditationProps extends ComponentProps<'section'> {
   /**
@@ -124,14 +119,14 @@ function ActionItem({ href, locale, icon: Icon, title, subtitle }: ActionItemPro
       locale={locale}
       variant="neutral"
     >
-      <div className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 group-hover:scale-105 transition-transform">
+      <div className="w-16 h-16 group-hover:scale-105 transition-transform">
         <Icon className="w-full h-full stroke-current stroke-[0.5]" />
       </div>
-      <div className="flex flex-col items-center gap-1 px-4 py-2 rounded-lg bg-white/40 backdrop-blur-xs lg:bg-transparent lg:backdrop-blur-none">
-        <span className="text-lg md:text-xl lg:text-2xl font-medium text-gray-900 lg:text-gray-700 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)]">
+      <div className="flex flex-col items-center gap-1 px-4 py-2 rounded-lg bg-white/40 backdrop-blur-xs">
+        <span className="text-lg font-medium text-gray-900 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)]">
           {title}
         </span>
-        <span className="text-sm md:text-base lg:text-lg font-light text-gray-900 lg:text-gray-700 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)]">
+        <span className="text-sm font-light text-gray-900 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)]">
           {subtitle}
         </span>
       </div>

--- a/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
+++ b/components/organisms/DiscoverMeditation/DiscoverMeditation.tsx
@@ -122,7 +122,7 @@ function ActionItem({ href, locale, icon: Icon, title, subtitle }: ActionItemPro
       <div className="w-16 h-16 group-hover:scale-105 transition-transform">
         <Icon className="w-full h-full stroke-current stroke-[0.5]" />
       </div>
-      <div className="flex flex-col items-center gap-1 px-4 py-2 rounded-lg bg-white/40 backdrop-blur-xs">
+      <div className="flex flex-col items-center gap-1 px-4 py-2 rounded-lg bg-white/40 backdrop-blur-xs transition-colors duration-200 group-hover:bg-white/60">
         <span className="text-lg font-medium text-gray-900 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)]">
           {title}
         </span>

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -118,14 +118,9 @@ export function Header({
         <nav
           className={`sticky top-0 z-50 border-t border-b transition-colors duration-200 ${
             isSticky
-              ? 'bg-white border-gray-200 text-gray-700'
+              ? 'full-bleed bg-white border-gray-200 text-gray-700'
               : `${textColorClass} ${borderColorClass}`
           }`}
-          style={{
-            width: isSticky ? '100vw' : 'auto',
-            marginLeft: isSticky ? 'calc(-50vw + 50%)' : '0',
-            marginRight: isSticky ? 'calc(-50vw + 50%)' : '0',
-          }}
         >
           {/* Centered content container */}
           <div className="flex items-center justify-between gap-2 max-w-5xl mx-auto px-6">

--- a/components/organisms/Header/HeaderNavDropdown.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.tsx
@@ -100,11 +100,14 @@ export function HeaderNavDropdown({
         <FloatingPortal>
           <div
             ref={refs.setFloating}
+            // `left:0; right:0` (not `width:100vw`) spans the viewport content area
+            // excluding the scrollbar, so the open panel never adds a horizontal
+            // scrollbar; the inner max-w-7xl box still centers to the content area.
             style={{
               position: floatingStyles.position,
               top: floatingStyles.top,
               left: 0,
-              width: '100vw',
+              right: 0,
             }}
             {...getFloatingProps()}
             className="z-50"

--- a/components/organisms/Header/HeaderNavDropdown.tsx
+++ b/components/organisms/Header/HeaderNavDropdown.tsx
@@ -3,8 +3,6 @@ import {
   useFloating,
   autoUpdate,
   offset,
-  flip,
-  shift,
   useHover,
   useClick,
   useDismiss,
@@ -62,10 +60,13 @@ export function HeaderNavDropdown({
     open: isOpen,
     onOpenChange: setIsOpen,
     placement: 'bottom',
+    // Fixed + no transform so we can keep Floating UI's vertical placement (below
+    // the nav, tracking the sticky state) while pinning the panel to the viewport
+    // horizontally — its inner max-w-7xl box then centers to the page content area.
+    strategy: 'fixed',
+    transform: false,
     whileElementsMounted: autoUpdate,
-    // Open flush below the nav; flip/shift keep the wide panel on-screen in both
-    // the static and the scroll-sticky nav states.
-    middleware: [offset(0), flip({ padding: 8 }), shift({ padding: 8 })],
+    middleware: [offset(0)],
   })
 
   const hover = useHover(context, { handleClose: safePolygon() })
@@ -99,7 +100,12 @@ export function HeaderNavDropdown({
         <FloatingPortal>
           <div
             ref={refs.setFloating}
-            style={floatingStyles}
+            style={{
+              position: floatingStyles.position,
+              top: floatingStyles.top,
+              left: 0,
+              width: '100vw',
+            }}
             {...getFloatingProps()}
             className="z-50"
           >

--- a/components/organisms/HeaderDropdown/HeaderDropdown.tsx
+++ b/components/organisms/HeaderDropdown/HeaderDropdown.tsx
@@ -46,7 +46,7 @@ export function HeaderDropdown({
   useEffect(() => {
     if (featuredArticles.length > 2) {
       console.warn(
-        `HeaderDropdown: Only 2 featured articles are allowed. Received ${featuredArticles.length}. Extra articles will be truncated.`
+        `HeaderDropdown: Only 2 featured articles are allowed. Received ${featuredArticles.length}. Extra articles will be truncated.`,
       )
     }
   }, [featuredArticles.length])
@@ -55,7 +55,7 @@ export function HeaderDropdown({
 
   return (
     <div
-      className={`bg-gray-100 max-w-7xl mx-auto relative px-16 pb-12 overflow-hidden ${className}`}
+      className={`bg-gray-100 max-w-7xl mx-auto relative px-6 pb-12 overflow-hidden ${className}`}
       {...props}
     >
       {/* Background Logo - scaled 2x, top-left quadrant visible */}
@@ -72,9 +72,7 @@ export function HeaderDropdown({
         <div className="flex flex-col">
           {/* Title - Fixed Height */}
           <div className="h-20 py-4 flex items-center">
-            <h3 className="text-xl font-semibold text-gray-700 line-clamp-2">
-              {title}
-            </h3>
+            <h3 className="text-xl font-semibold text-gray-700 line-clamp-2">{title}</h3>
           </div>
 
           {/* Links Section */}
@@ -83,10 +81,10 @@ export function HeaderDropdown({
               {links.map((link, index) => (
                 <li key={index}>
                   <Link
-                    href={link.href}
-                    variant="neutral"
-                    size="base"
                     className="hover:text-teal-600 transition-colors"
+                    href={link.href}
+                    size="base"
+                    variant="neutral"
                   >
                     {link.label}
                   </Link>
@@ -125,9 +123,9 @@ function FeaturedArticleColumn({ article, className = '' }: FeaturedArticleColum
       {/* Article Title - Fixed Height */}
       <div className="h-20 py-4 flex items-center">
         <Link
+          className="hover:text-teal-600 transition-colors line-clamp-3 text-sm"
           href={article.href}
           variant="neutral"
-          className="hover:text-teal-600 transition-colors line-clamp-3 text-sm"
         >
           {article.title}
         </Link>
@@ -136,18 +134,18 @@ function FeaturedArticleColumn({ article, className = '' }: FeaturedArticleColum
       {/* Article Thumbnail with Hover Overlay */}
       <div>
         <Link
+          className="relative block aspect-square overflow-hidden"
           href={article.href}
           variant="unstyled"
-          className="relative block aspect-square overflow-hidden"
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
           <Image
-            src={article.image}
             alt={article.imageAlt}
             aspectRatio="square"
-            objectFit="cover"
             className="w-full h-full"
+            objectFit="cover"
+            src={article.image}
           />
 
           {/* Hover Overlay */}

--- a/components/organisms/MusicLibrary/MusicLibrary.tsx
+++ b/components/organisms/MusicLibrary/MusicLibrary.tsx
@@ -45,6 +45,7 @@ export function MusicLibrary({
 
   const handleFilterClick = (filterId: string) => {
     const newFilter = selectedFilter === filterId ? null : filterId
+
     setSelectedFilter(newFilter)
     onFilterChange?.(newFilter)
   }
@@ -56,10 +57,7 @@ export function MusicLibrary({
   const currentTrack = tracks[currentTrackIndex]
 
   return (
-    <div
-      className={`w-full max-w-7xl mx-auto p-4 sm:p-6 ${className}`}
-      {...props}
-    >
+    <div className={`w-full max-w-7xl mx-auto p-4 sm:p-6 ${className}`} {...props}>
       {/* Mobile-First: 2-Column Layout (stacks on mobile) */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Left Column: Current Track Art + Player */}
@@ -67,11 +65,11 @@ export function MusicLibrary({
           {/* Current Track Thumbnail with Overlay */}
           <div className="relative w-full aspect-square rounded-lg overflow-hidden shadow-lg">
             <Image
-              src={currentTrack.thumbnailURL}
               alt={currentTrack.title}
-              className="w-full h-full"
               aspectRatio="square"
+              className="w-full h-full"
               placeholderVariant="primary"
+              src={currentTrack.thumbnailURL}
             />
             {/* Gradient Overlay */}
             <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-transparent" />
@@ -81,10 +79,10 @@ export function MusicLibrary({
                 {currentTrack.title}
               </h3>
               <a
-                href={currentTrack.creditURL}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="text-sm text-white/90 hover:text-white truncate block mt-1"
+                href={currentTrack.creditURL}
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 {currentTrack.credit}
               </a>
@@ -93,11 +91,11 @@ export function MusicLibrary({
 
           {/* Audio Player */}
           <AudioPlayer
-            tracks={tracks}
-            initialTrackIndex={currentTrackIndex}
-            onTrackChange={setCurrentTrackIndex}
-            shuffle={true}
             disabledControls={['trackInfo']}
+            initialTrackIndex={currentTrackIndex}
+            shuffle={true}
+            tracks={tracks}
+            onTrackChange={setCurrentTrackIndex}
           />
         </div>
 
@@ -106,16 +104,16 @@ export function MusicLibrary({
           {/* Gradient background - extended above, below, and horizontally */}
           <div className="absolute -inset-6 bg-linear-to-r from-teal-100/50 to-transparent pointer-events-none -z-10" />
 
-          <div className="relative h-full p-6 sm:p-6 z-10">
+          <div className="relative h-full p-6 md:pr-10 z-10">
             <Playlist
-              title="Playlist"
-              tracks={tracks}
+              className="min-w-xs"
               currentTrackIndex={currentTrackIndex}
-              onTrackClick={handleTrackClick}
               filters={filters}
               selectedFilter={selectedFilter}
+              title="Playlist"
+              tracks={tracks}
               onFilterChange={handleFilterClick}
-              className="min-w-xs"
+              onTrackClick={handleTrackClick}
             />
           </div>
         </div>

--- a/components/organisms/OrnateTextBox/OrnateTextBox.stories.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.stories.tsx
@@ -16,6 +16,7 @@ export const Default: Story = () => (
   <StoryWrapper>
     <StorySection title="Default">
       <OrnateTextBox
+        className="full-bleed"
         description={
           "In every culture and religion, one can find great tales of the immense power of a mother's love and the lengths that she will go to in order to protect her children. It is this deep sense of love which gives a child security in their heart and removes their fears.\n\n" +
           'In Hinduism, the goddess Durga is the great warrior mother who defeats all the enemies of her children. A fearsome, yet extremely compassionate figure who rides on a tiger yielding great weapons with her many arms, she fights tirelessly to free her children from the evils of ego, fears and desires.\n\n' +
@@ -35,6 +36,7 @@ export const Default: Story = () => (
       title="With Subtitle & CTA"
     >
       <OrnateTextBox
+        className="full-bleed"
         ctaHref="#"
         ctaText="Read more"
         description="For thousands of years, seekers have turned inward to discover a deeper truth. This knowledge, passed down through generations, remains as relevant today as it ever was."
@@ -49,6 +51,7 @@ export const Default: Story = () => (
 
     <StorySection inContext={true} title="Without CTA or Subtitle">
       <OrnateTextBox
+        className="full-bleed"
         description="While the stories recounted in sacred texts do not resemble the modern world, we all still fight our own battles daily. With the motherly love of our Kundalini we are empowered to overcome our inner demons."
         imageAlt="Meditative scene"
         imageHeight={900}

--- a/components/organisms/OrnateTextBox/OrnateTextBox.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.tsx
@@ -102,7 +102,7 @@ export function OrnateTextBox({
 
   return (
     <div
-      className={`relative isolate flex min-h-[80vh] w-full items-center bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)] text-white ${className}`}
+      className={`relative isolate flex min-h-[80vh] items-center bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)] text-white ${className}`}
       {...props}
     >
       {/* Large faded floral graphic, offset ~45% to the right, behind content */}

--- a/components/organisms/OrnateTextBox/OrnateTextBox.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.tsx
@@ -102,22 +102,33 @@ export function OrnateTextBox({
 
   return (
     <div
-      className={`relative isolate flex min-h-[80vh] items-center overflow-x-clip bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)] text-white ${className}`}
+      className={`relative flex min-h-[80vh] items-center overflow-x-clip text-white ${className}`}
       {...props}
     >
+      {/* Brown ground — the OrnateTextBox background, furthest back (-z-20). A
+          separate layer (not the root's bg) so the gradient below can sit ABOVE it
+          while still being negative-z. NB: no `isolate` on the root, so the
+          negative-z layers participate in the page stacking context and render
+          behind other blocks' text where the gradient bleeds above this block. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-20 bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)]"
+      />
+
       {/* Large faded floral graphic, offset ~45% to the right, behind content */}
       <img
         alt=""
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-0 left-[45%] z-0 h-full w-[80%] object-cover object-left opacity-40"
+        className="pointer-events-none absolute inset-y-0 left-[45%] -z-10 h-full w-[80%] object-cover object-left opacity-40"
         src={ornateBackground}
       />
 
-      {/* Soft warm gradient lightening the left edge — extends above the block
-          (the gradient--ornate ::before). */}
+      {/* Soft warm gradient lightening the left edge — extends above the block (the
+          gradient--ornate ::before). Negative z so it sits over the brown ground
+          but behind text from the block above. */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute -top-24 bottom-0 left-0 z-0 w-1/3 bg-[linear-gradient(90deg,rgba(255,255,255,0.02)_0%,rgba(255,255,255,0.18)_25%,rgba(255,196,175,0.6)_100%)]"
+        className="pointer-events-none absolute -top-24 bottom-0 left-0 -z-10 w-1/3 bg-[linear-gradient(90deg,rgba(255,255,255,0.02)_0%,rgba(255,255,255,0.18)_25%,rgba(255,196,175,0.6)_100%)]"
       />
 
       {/* Decorative vertical sidetext label (desktop only, single line) */}
@@ -130,9 +141,10 @@ export function OrnateTextBox({
         </span>
       )}
 
-      {/* Content. Asymmetric desktop padding insets the column and reserves the
-          sidetext side. */}
-      <div className="relative z-10 mx-auto w-full max-w-[2000px] px-8 py-12 lg:py-20 lg:pl-[11%] lg:pr-[16%]">
+      {/* Content. Capped to a reasonable max (the content-area width) and centered
+          so the interior doesn't sprawl on ultra-wide screens; asymmetric desktop
+          padding insets the column and reserves the sidetext side. */}
+      <div className="relative z-10 mx-auto w-full max-w-7xl px-8 py-12 lg:py-20 lg:pl-[11%] lg:pr-[16%]">
         {/* Title + subtitle header, above the body */}
         <div className="mb-8 lg:mb-6">
           <h2 className="text-2xl font-light lg:text-3xl">{title}</h2>

--- a/components/organisms/OrnateTextBox/OrnateTextBox.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.tsx
@@ -102,7 +102,7 @@ export function OrnateTextBox({
 
   return (
     <div
-      className={`relative isolate flex min-h-[80vh] items-center bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)] text-white ${className}`}
+      className={`relative isolate flex min-h-[80vh] items-center overflow-x-clip bg-[linear-gradient(110deg,#8a6f56_0%,#6b5340_45%,#473729_100%)] text-white ${className}`}
       {...props}
     >
       {/* Large faded floral graphic, offset ~45% to the right, behind content */}

--- a/components/organisms/OrnateTextBox/OrnateTextBox.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from 'react'
 import { Button, Container, Image } from '../../atoms'
+import type { AspectRatio } from '../../../lib/cloudflare-images'
 import ornateBackground from '../../../assets/ornate.svg'
 
 export interface OrnateTextBoxProps extends Omit<ComponentProps<'div'>, 'title'> {
@@ -50,6 +51,14 @@ export interface OrnateTextBoxProps extends Omit<ComponentProps<'div'>, 'title'>
   imageHeight?: number
 
   /**
+   * Nearest configured Cloudflare aspect ratio for the image. When set (and the
+   * `imageSrc` is a Cloudflare URL), an optimized variant + srcset is fetched
+   * instead of the full-resolution original. The image still renders at its
+   * natural ratio (the ratio only selects the variant, not a cropping box).
+   */
+  imageAspectRatio?: AspectRatio
+
+  /**
    * Decorative vertical label along the outer edge (desktop only). Purely
    * ornamental. @default 'Ancient Wisdom'
    */
@@ -94,6 +103,7 @@ export function OrnateTextBox({
   imageAlt,
   imageWidth,
   imageHeight,
+  imageAspectRatio,
   sidetext = 'Ancient Wisdom',
   className = '',
   ...props
@@ -142,10 +152,10 @@ export function OrnateTextBox({
       )}
 
       {/* Content — capped to a readable width via a Container (the brown ground,
-          floral graphic and gradient stay full-bleed behind it). Since the content
-          is always narrower than where the sidetext appears (lg+), the sidetext
-          sits clear in the margin without needing asymmetric padding. */}
-      <Container className="relative z-10 py-12 lg:py-20" maxWidth="md">
+          floral graphic and gradient stay full-bleed behind it). On lg+ the
+          centered container's right margin can shrink to where the sidetext sits,
+          so reserve a right gutter (lg:pr-24) to keep the body clear of it. */}
+      <Container className="relative z-10 py-12 lg:py-20 lg:pr-24" maxWidth="md">
         {/* Title + subtitle header, above the body */}
         <div className="mb-8 lg:mb-6">
           <h2 className="text-2xl font-light lg:text-3xl">{title}</h2>
@@ -156,9 +166,12 @@ export function OrnateTextBox({
         <div className="mb-6 w-full lg:float-left lg:mr-12 lg:mb-4 lg:w-[44%]">
           <Image
             alt={imageAlt}
+            aspectRatio={imageAspectRatio}
             className="w-full"
+            forceAspectRatio={false}
             height={imageHeight}
             objectFit="cover"
+            sizes="(max-width: 1024px) 100vw, 400px"
             src={imageSrc}
             width={imageWidth}
           />

--- a/components/organisms/OrnateTextBox/OrnateTextBox.tsx
+++ b/components/organisms/OrnateTextBox/OrnateTextBox.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react'
-import { Button, Image } from '../../atoms'
+import { Button, Container, Image } from '../../atoms'
 import ornateBackground from '../../../assets/ornate.svg'
 
 export interface OrnateTextBoxProps extends Omit<ComponentProps<'div'>, 'title'> {
@@ -141,10 +141,11 @@ export function OrnateTextBox({
         </span>
       )}
 
-      {/* Content. Capped to a reasonable max (the content-area width) and centered
-          so the interior doesn't sprawl on ultra-wide screens; asymmetric desktop
-          padding insets the column and reserves the sidetext side. */}
-      <div className="relative z-10 mx-auto w-full max-w-7xl px-8 py-12 lg:py-20 lg:pl-[11%] lg:pr-[16%]">
+      {/* Content — capped to a readable width via a Container (the brown ground,
+          floral graphic and gradient stay full-bleed behind it). Since the content
+          is always narrower than where the sidetext appears (lg+), the sidetext
+          sits clear in the margin without needing asymmetric padding. */}
+      <Container className="relative z-10 py-12 lg:py-20" maxWidth="md">
         {/* Title + subtitle header, above the body */}
         <div className="mb-8 lg:mb-6">
           <h2 className="text-2xl font-light lg:text-3xl">{title}</h2>
@@ -182,7 +183,7 @@ export function OrnateTextBox({
             </Button>
           )}
         </div>
-      </div>
+      </Container>
     </div>
   )
 }

--- a/components/organisms/RichText/RichText.stories.tsx
+++ b/components/organisms/RichText/RichText.stories.tsx
@@ -525,8 +525,9 @@ const pageContent = editorState(
 
 /**
  * Full-page simulation of every RichText node and custom block at maximal
- * configuration. Rendered full-bleed (no padding/max-width) so it fills the
- * available space.
+ * configuration. RichText constrains non-full-bleed content to a readable column
+ * via its own Container; full-bleed blocks (Splash, OrnateTextBox, SubtleSystem,
+ * ContentOverlay, wide uploads) break out to the story-canvas edges.
  */
 export const Default: Story = () => <RichText debug content={pageContent} />
 

--- a/components/organisms/RichText/RichText.tsx
+++ b/components/organisms/RichText/RichText.tsx
@@ -332,8 +332,9 @@ export function RichText({ content, className, debug = false }: RichTextProps) {
   // (max-w-4xl) with responsive gutters — owned here so it's consistent whether
   // RichText is rendered inside a page template or standalone (e.g. a story).
   // Full-bleed blocks (Splash, OrnateTextBox, SubtleSystem, ContentOverlay, wide
-  // uploads) escape it via the `full-bleed` cqi break-out, which resolves against
-  // the `@container` on <main> (the window) regardless of this Container.
+  // uploads) escape it via the `full-bleed` break-out, which spans `--page-width`
+  // (the content-area width captured on <main>'s wrapper) regardless of this
+  // Container or any nested `@container`.
   return (
     <LightboxProvider>
       <Container maxWidth="md">

--- a/components/organisms/RichText/RichText.tsx
+++ b/components/organisms/RichText/RichText.tsx
@@ -11,7 +11,7 @@ import {
   defaultJSXConverters,
 } from '@payloadcms/richtext-lexical/react'
 import type { JSXConverter, JSXConverters } from '@payloadcms/richtext-lexical/react'
-import { Blockquote, Image, Link } from '../../atoms'
+import { Blockquote, Container, Image, Link } from '../../atoms'
 import { Alert } from '../../molecules/Alert'
 import { LightboxProvider } from '../../molecules/Lightbox/LightboxProvider'
 import { cmsHref, type RelationValue } from '../../../lib/cms-routes'
@@ -327,13 +327,22 @@ export function RichText({ content, className, debug = false }: RichTextProps) {
 
   // One provider per document: every gallery/upload image below shares a single
   // client-only lightbox overlay (the provider renders no DOM until one opens).
+  //
+  // The Container constrains non-full-bleed content to a readable column
+  // (max-w-4xl) with responsive gutters — owned here so it's consistent whether
+  // RichText is rendered inside a page template or standalone (e.g. a story).
+  // Full-bleed blocks (Splash, OrnateTextBox, SubtleSystem, ContentOverlay, wide
+  // uploads) escape it via the `full-bleed` cqi break-out, which resolves against
+  // the `@container` on <main> (the window) regardless of this Container.
   return (
     <LightboxProvider>
-      <LexicalRichText
-        className={className ?? ARTICLE_CLASS}
-        converters={converters}
-        data={content as unknown as LexicalEditorState}
-      />
+      <Container maxWidth="prose">
+        <LexicalRichText
+          className={className ?? ARTICLE_CLASS}
+          converters={converters}
+          data={content as unknown as LexicalEditorState}
+        />
+      </Container>
     </LightboxProvider>
   )
 }

--- a/components/organisms/RichText/RichText.tsx
+++ b/components/organisms/RichText/RichText.tsx
@@ -336,7 +336,7 @@ export function RichText({ content, className, debug = false }: RichTextProps) {
   // the `@container` on <main> (the window) regardless of this Container.
   return (
     <LightboxProvider>
-      <Container maxWidth="prose">
+      <Container maxWidth="md">
         <LexicalRichText
           className={className ?? ARTICLE_CLASS}
           converters={converters}

--- a/components/organisms/RichText/RichText.tsx
+++ b/components/organisms/RichText/RichText.tsx
@@ -183,6 +183,9 @@ const CONVERTERS: JSXConverters = {
       | { caption?: unknown; align?: string | null; alt?: string | null }
       | undefined
     const caption = renderCaption(fields?.caption)
+    // `wide` images break out to the full content width: no rounding (they meet the
+    // edges) and a full-width `sizes` hint so the browser fetches a large variant.
+    const isWide = fields?.align === 'wide'
 
     return (
       <figure className={uploadFigureClass(fields?.align)}>
@@ -191,8 +194,8 @@ const CONVERTERS: JSXConverters = {
           aspectRatio={nearestAspectRatio(image.width, image.height)}
           height={image.height ?? undefined}
           lightboxGroup={`upload-${image.url}`}
-          rounded="rounded"
-          sizes={ARTICLE_IMAGE_SIZES}
+          rounded={isWide ? 'none' : 'rounded'}
+          sizes={isWide ? '100vw' : ARTICLE_IMAGE_SIZES}
           src={image.url}
           width={image.width ?? undefined}
         />

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -112,6 +112,7 @@ export const blockConverters: BlockConverters = {
       ctaText,
       description,
       imageAlt: img.alt,
+      imageAspectRatio: img.aspectRatio,
       imageHeight: img.height,
       imageSrc: img.url,
       imageWidth: img.width,

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -27,6 +27,7 @@ import {
   galleryImages,
   populatedImage,
   showcaseItems,
+  splashTheme,
   subtleSystemItems,
   type ButtonBlockFields,
   type ContentIndexBlockFields,
@@ -52,6 +53,15 @@ export type BlockConverters = NonNullable<JSXConverters['blocks']>
  * intentionally omit it.
  */
 export const BLOCK_SPACING = 'mx-auto my-6 clear-both'
+
+/**
+ * Width-escaping blocks (OrnateTextBox, SubtleSystem) break out of the article
+ * column to span the full content container via the `full-bleed` utility (see
+ * layouts/tailwind.css). `clear-both` keeps them clear of floated blockquotes; no
+ * `mx-auto` (full-bleed owns the horizontal margins). Splash uses a no-top-margin
+ * variant so a lead splash sits flush under the overlaid header.
+ */
+export const FULL_BLEED_BLOCK = 'full-bleed my-6 clear-both'
 
 export const blockConverters: BlockConverters = {
   // textbox → one of three organisms by the block's mode:
@@ -107,7 +117,9 @@ export const blockConverters: BlockConverters = {
     }
 
     return fields.wisdomStyle ? (
-      <OrnateTextBox {...sideProps} />
+      // OrnateTextBox breaks out to full content width (later className wins over
+      // the spread BLOCK_SPACING).
+      <OrnateTextBox {...sideProps} className={FULL_BLEED_BLOCK} />
     ) : (
       <ContentTextBox {...sideProps} align={fields.imagePosition} />
     )
@@ -163,7 +175,7 @@ export const blockConverters: BlockConverters = {
     const group = `gallery-${String(blockId ?? images[0].url)}`
 
     return (
-      <div className={`${BLOCK_SPACING} columns-2 gap-3 sm:columns-3 *:mb-3`}>
+      <div className={`${BLOCK_SPACING} columns-2 gap-3 lg:columns-3 *:mb-3`}>
         {images.map((img, index) => (
           <Image
             key={`${img.url}-${index}`}
@@ -173,7 +185,7 @@ export const blockConverters: BlockConverters = {
             lightboxGroup={group}
             lightboxIndex={index}
             rounded="rounded"
-            sizes="(max-width: 640px) 50vw, 33vw"
+            sizes="(max-width: 1024px) 50vw, 33vw"
             src={img.url}
           />
         ))}
@@ -236,7 +248,7 @@ export const blockConverters: BlockConverters = {
       return null
     }
 
-    return <SubtleSystem className={BLOCK_SPACING} items={items} />
+    return <SubtleSystem className={FULL_BLEED_BLOCK} items={items} />
   },
 
   // splash → full-bleed Splash. The block's countdown/app/map-search layouts
@@ -254,11 +266,13 @@ export const blockConverters: BlockConverters = {
     return (
       <Splash
         backgroundImage={bg.url}
-        className={BLOCK_SPACING}
+        // Full-bleed and flush (no top margin): a lead splash sits at the top of
+        // the page under the overlaid header (see LayoutChrome / getLeadSplash).
+        className="full-bleed clear-both"
         ctaHref={fields.actionURL ?? undefined}
         ctaText={fields.actionText ?? undefined}
         subtitle={fields.subtitle ?? undefined}
-        theme="dark"
+        theme={splashTheme(fields.textColor)}
         title={fields.title ?? undefined}
       />
     )
@@ -276,7 +290,7 @@ export const blockConverters: BlockConverters = {
     }
 
     return (
-      <div className={`${BLOCK_SPACING} grid grid-cols-2 gap-4 sm:grid-cols-3`}>
+      <div className={`${BLOCK_SPACING} grid grid-cols-2 gap-4 lg:grid-cols-3`}>
         {items.map(({ id, ...card }) => (
           <ContentCard key={id} {...card} />
         ))}

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -126,10 +126,10 @@ export const blockConverters: BlockConverters = {
     ) : (
       // ContentTextBox is wider than the readable body but capped (not full
       // window): break out of the prose Container with full-bleed, then constrain
-      // to the large Container width (lg / 5xl) with gutters. `className=""` drops
-      // the spread BLOCK_SPACING since the wrapper owns spacing/centering.
+      // to the Container `xl` width (6xl) with gutters. `className=""` drops the
+      // spread BLOCK_SPACING since the wrapper owns spacing/centering.
       <div className={FULL_BLEED_BLOCK}>
-        <Container maxWidth="lg">
+        <Container maxWidth="xl">
           <ContentTextBox {...sideProps} align={fields.imagePosition} className="" />
         </Container>
       </div>

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -29,6 +29,7 @@ import {
   showcaseItems,
   splashTheme,
   subtleSystemItems,
+  textColorToTheme,
   type ButtonBlockFields,
   type ContentIndexBlockFields,
   type ImageGalleryBlockFields,
@@ -98,7 +99,7 @@ export const blockConverters: BlockConverters = {
           imageSrc={img.url}
           subtitle={subtitle}
           text={description}
-          theme={fields.textColor === 'light' ? 'dark' : 'light'}
+          theme={textColorToTheme(fields.textColor, 'light')}
           title={title}
         />
       )

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -10,7 +10,7 @@
  */
 
 import type { JSXConverters } from '@payloadcms/richtext-lexical/react'
-import { Button, Image } from '../../atoms'
+import { Button, Container, Image } from '../../atoms'
 import {
   ContentCard,
   ContentCarousel,
@@ -124,7 +124,15 @@ export const blockConverters: BlockConverters = {
       // the spread BLOCK_SPACING).
       <OrnateTextBox {...sideProps} className={FULL_BLEED_BLOCK} />
     ) : (
-      <ContentTextBox {...sideProps} align={fields.imagePosition} />
+      // ContentTextBox is wider than the readable body but capped (not full
+      // window): break out of the prose Container with full-bleed, then constrain
+      // to the large Container width (lg / 5xl) with gutters. `className=""` drops
+      // the spread BLOCK_SPACING since the wrapper owns spacing/centering.
+      <div className={FULL_BLEED_BLOCK}>
+        <Container maxWidth="lg">
+          <ContentTextBox {...sideProps} align={fields.imagePosition} className="" />
+        </Container>
+      </div>
     )
   },
 

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -91,7 +91,7 @@ export const blockConverters: BlockConverters = {
       return (
         <ContentOverlay
           align={fields.textPosition ?? 'center'}
-          className={BLOCK_SPACING}
+          className={FULL_BLEED_BLOCK}
           ctaHref={ctaHref}
           ctaText={ctaText}
           imageAlt={img.alt}

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -55,13 +55,16 @@ export type BlockConverters = NonNullable<JSXConverters['blocks']>
 export const BLOCK_SPACING = 'mx-auto my-6 clear-both'
 
 /**
- * Width-escaping blocks (OrnateTextBox, SubtleSystem) break out of the article
- * column to span the full content container via the `full-bleed` utility (see
- * layouts/tailwind.css). `clear-both` keeps them clear of floated blockquotes; no
- * `mx-auto` (full-bleed owns the horizontal margins). Splash uses a no-top-margin
- * variant so a lead splash sits flush under the overlaid header.
+ * Width-escaping blocks break out of the article column to span the full content
+ * container via the `full-bleed` utility (see layouts/tailwind.css). `clear-both`
+ * keeps them clear of floated blockquotes; no `mx-auto` (full-bleed owns the
+ * horizontal margins).
+ *
+ * `FULL_BLEED_BLOCK` (OrnateTextBox, SubtleSystem) keeps vertical block spacing;
+ * `FULL_BLEED_SPLASH` drops it so a lead splash sits flush under the overlaid header.
  */
 export const FULL_BLEED_BLOCK = 'full-bleed my-6 clear-both'
+export const FULL_BLEED_SPLASH = 'full-bleed clear-both'
 
 export const blockConverters: BlockConverters = {
   // textbox → one of three organisms by the block's mode:
@@ -266,9 +269,9 @@ export const blockConverters: BlockConverters = {
     return (
       <Splash
         backgroundImage={bg.url}
-        // Full-bleed and flush (no top margin): a lead splash sits at the top of
-        // the page under the overlaid header (see LayoutChrome / getLeadSplash).
-        className="full-bleed clear-both"
+        // Full-bleed and flush: a lead splash sits at the top of the page under
+        // the overlaid header (see LayoutChrome / getLeadSplash).
+        className={FULL_BLEED_SPLASH}
         ctaHref={fields.actionURL ?? undefined}
         ctaText={fields.actionText ?? undefined}
         subtitle={fields.subtitle ?? undefined}

--- a/components/organisms/RichText/lexical-helpers.ts
+++ b/components/organisms/RichText/lexical-helpers.ts
@@ -57,13 +57,14 @@ export function relationshipLabel(value: unknown): string | null {
 /**
  * Tailwind classes for an upload `<figure>` given its CMS alignment. Aligned
  * images take 40% of the column width (left/right float so text wraps, center
- * is a centered block); `wide` spans the full width. Full width on mobile so
- * small screens stay readable.
+ * is a centered block); `wide` breaks out of the article column to span the full
+ * content container via the `full-bleed` utility. Full width on mobile so small
+ * screens stay readable.
  */
 export function uploadFigureClass(align?: string | null): string {
   switch (align) {
     case 'wide':
-      return 'my-6 w-full text-center'
+      return 'my-6 full-bleed text-center'
     case 'left':
       return 'my-6 w-full text-left sm:float-left sm:mr-6 sm:w-1/2'
     case 'right':

--- a/components/organisms/Splash/Splash.stories.tsx
+++ b/components/organisms/Splash/Splash.stories.tsx
@@ -1,12 +1,12 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { Splash } from "./Splash";
-import { Header } from "../Header";
-import { Countdown, Button, Input } from "../../atoms";
-import { StoryWrapper, StorySection } from '../../ladle';
+import type { Story, StoryDefault } from '@ladle/react'
+import { Splash } from './Splash'
+import { Header } from '../Header'
+import { Countdown, Button, Input } from '../../atoms'
+import { StoryWrapper, StorySection } from '../../ladle'
 
 export default {
-  title: "Organisms"
-} satisfies StoryDefault;
+  title: 'Organisms',
+} satisfies StoryDefault
 
 /**
  * Splash component - Full-screen hero section with background image, centered content,
@@ -15,6 +15,7 @@ export default {
 export const Default: Story = () => {
   // Create a countdown target 24 hours from now
   const tomorrow = new Date()
+
   tomorrow.setHours(tomorrow.getHours() + 24)
 
   return (
@@ -23,39 +24,40 @@ export const Default: Story = () => {
       <div className="mb-16">
         <h2 className="text-2xl font-semibold mb-4 px-4">Basic Splash</h2>
         <Splash
-          backgroundImage="https://picsum.photos/id/1018/1920/1080"
-          title="Meditate for Better Mental Health"
-          subtitle="Making a start is easier than you think."
-          ctaText="Try it now"
-          ctaHref="/start"
-          theme="dark"
           pulsate
+          backgroundImage="https://picsum.photos/id/1018/1920/1080"
+          className="full-bleed"
+          ctaHref="/start"
+          ctaText="Try it now"
+          subtitle="Making a start is easier than you think."
+          theme="dark"
+          title="Meditate for Better Mental Health"
         />
       </div>
 
       {/* Splash with Header Overlay (Dark Theme) */}
       <div className="mb-16">
         <h2 className="text-2xl font-semibold mb-4 px-4">With Header Overlay (Dark Theme)</h2>
-        <div className="relative">
+        <div className="relative full-bleed">
           <Splash
-            backgroundImage="https://picsum.photos/id/1018/1920/1080"
-            title="Meditate for Better Mental Health"
-            subtitle="Making a start is easier than you think."
-            ctaText="Try it now"
-            ctaHref="/start"
-            theme="dark"
             pulsate
+            backgroundImage="https://picsum.photos/id/1018/1920/1080"
+            ctaHref="/start"
+            ctaText="Try it now"
+            subtitle="Making a start is easier than you think."
+            theme="dark"
+            title="Meditate for Better Mental Health"
           />
           <div className="absolute top-0 left-0 right-0 z-20 p-4">
             <Header
-              logoHref="/"
-              actionLinkText="Classes near me"
               actionLinkHref="/classes"
+              actionLinkText="Classes near me"
+              logoHref="/"
               navItems={[
-                { label: "Meditate Now", href: "/meditate" },
-                { label: "Music for Meditation", href: "/music" },
-                { label: "Inspiration", href: "/inspiration" },
-                { label: "About Meditation", href: "/about" }
+                { label: 'Meditate Now', href: '/meditate' },
+                { label: 'Music for Meditation', href: '/music' },
+                { label: 'Inspiration', href: '/inspiration' },
+                { label: 'About Meditation', href: '/about' },
               ]}
             />
           </div>
@@ -64,73 +66,67 @@ export const Default: Story = () => {
 
       {/* Splash with Header Overlay (Light Theme Background) */}
       <div className="mb-16">
-        <h2 className="text-2xl font-semibold mb-4 px-4">With Header Overlay (Light Theme Background)</h2>
-        <div className="relative">
+        <h2 className="text-2xl font-semibold mb-4 px-4">
+          With Header Overlay (Light Theme Background)
+        </h2>
+        <div className="relative full-bleed">
           <Splash
-            backgroundImage="https://picsum.photos/id/1015/1920/1080"
-            title="Discover Inner Peace"
-            subtitle="Your journey to mindfulness starts here."
-            ctaText="Begin now"
-            ctaHref="/start"
-            theme="light"
             pulsate
+            backgroundImage="https://picsum.photos/id/1015/1920/1080"
+            ctaHref="/start"
+            ctaText="Begin now"
+            subtitle="Your journey to mindfulness starts here."
+            theme="light"
+            title="Discover Inner Peace"
           />
           <div className="absolute top-0 left-0 right-0 z-20 p-4">
             <Header
-              logoHref="/"
-              actionLinkText="Classes near me"
               actionLinkHref="/classes"
+              actionLinkText="Classes near me"
+              logoHref="/"
               navItems={[
-                { label: "Meditate Now", href: "/meditate" },
-                { label: "Music for Meditation", href: "/music" },
-                { label: "Inspiration", href: "/inspiration" },
-                { label: "About Meditation", href: "/about" }
+                { label: 'Meditate Now', href: '/meditate' },
+                { label: 'Music for Meditation', href: '/music' },
+                { label: 'Inspiration', href: '/inspiration' },
+                { label: 'About Meditation', href: '/about' },
               ]}
             />
           </div>
         </div>
       </div>
 
-      <StorySection title="Countdown Timer" inContext={true}>
-        <div className="relative">
+      <StorySection inContext={true} title="Countdown Timer">
+        <div className="relative full-bleed">
           <Splash
-            backgroundImage="https://picsum.photos/id/1015/1920/1080"
-            title="Join Free Zoom Meditations!"
-            subtitle="Every Tuesday and Thursday at 7 pm London / 8 pm CET"
-            ctaText="Sign up"
-            ctaHref="/live"
-            theme="dark"
             pulsate
+            backgroundImage="https://picsum.photos/id/1015/1920/1080"
+            ctaHref="/live"
+            ctaText="Sign up"
+            subtitle="Every Tuesday and Thursday at 7 pm London / 8 pm CET"
+            theme="dark"
+            title="Join Free Zoom Meditations!"
           >
             <Countdown targetDate={tomorrow} theme="dark" />
           </Splash>
         </div>
       </StorySection>
 
-      <StorySection title="App Download Buttons" inContext={true}>
-        <div className="relative">
+      <StorySection inContext={true} title="App Download Buttons">
+        <div className="relative full-bleed">
           <Splash
-            backgroundImage="https://picsum.photos/id/1018/1920/1080"
-            title="Download Our App"
-            subtitle="Meditate anytime, anywhere."
-            ctaText="Learn more"
-            ctaHref="/app"
-            theme="dark"
             pulsate
+            backgroundImage="https://picsum.photos/id/1018/1920/1080"
+            ctaHref="/app"
+            ctaText="Learn more"
+            subtitle="Meditate anytime, anywhere."
+            theme="dark"
+            title="Download Our App"
           >
             <div className="flex flex-col sm:flex-row gap-4 items-center justify-center">
-              <Button
-                href="https://apps.apple.com"
-                variant="primary"
-                size="lg"
-              >
+              <Button href="https://apps.apple.com" size="lg" variant="primary">
                 Download for iOS
               </Button>
-              <Button
-                href="https://play.google.com"
-                variant="secondary"
-                size="lg"
-              >
+              <Button href="https://play.google.com" size="lg" variant="secondary">
                 Download for Android
               </Button>
             </div>
@@ -138,32 +134,29 @@ export const Default: Story = () => {
         </div>
       </StorySection>
 
-      <StorySection title="Search Input with Header Overlay" inContext={true}>
-        <div className="relative max-h-96 md:max-h-160 overflow-hidden">
-          <Splash
-            backgroundImage="https://picsum.photos/id/1019/1920/1080"
-            theme="dark"
-          >
+      <StorySection inContext={true} title="Search Input with Header Overlay">
+        <div className="relative max-h-96 md:max-h-160 overflow-hidden full-bleed">
+          <Splash backgroundImage="https://picsum.photos/id/1019/1920/1080" theme="dark">
             <div className="max-w-md mx-auto shadow-md">
               <Input
-                type="search"
-                placeholder="Search meditations, articles, music..."
                 className="text-lg py-4 w-full"
+                placeholder="Search meditations, articles, music..."
+                type="search"
               />
             </div>
           </Splash>
           <div className="absolute top-0 left-0 right-0 z-20 p-4">
             <Header
-              logoHref="/"
-              actionLinkText="Classes near me"
               actionLinkHref="/classes"
-              theme="dark"
+              actionLinkText="Classes near me"
+              logoHref="/"
               navItems={[
-                { label: "Meditate Now", href: "/meditate" },
-                { label: "Music for Meditation", href: "/music" },
-                { label: "Inspiration", href: "/inspiration" },
-                { label: "About Meditation", href: "/about" }
+                { label: 'Meditate Now', href: '/meditate' },
+                { label: 'Music for Meditation', href: '/music' },
+                { label: 'Inspiration', href: '/inspiration' },
+                { label: 'About Meditation', href: '/about' },
               ]}
+              theme="dark"
             />
           </div>
         </div>
@@ -171,7 +164,7 @@ export const Default: Story = () => {
 
       <div />
     </StoryWrapper>
-  );
-};
+  )
+}
 
-Default.storyName = "Splash"
+Default.storyName = 'Splash'

--- a/components/organisms/Splash/Splash.tsx
+++ b/components/organisms/Splash/Splash.tsx
@@ -49,7 +49,7 @@ export interface SplashProps extends Omit<ComponentProps<'div'>, 'children'> {
 
 /**
  * Full-screen splash section with background image, centered content, and decorative leaves.
- * Reserves 234px at top for Header overlay.
+ * Reserves 240px (pt-60) at top for the overlaid Header.
  *
  * @example
  * <Splash
@@ -89,9 +89,9 @@ export function Splash({
     >
       {/* Background Image */}
       <div
+        aria-hidden="true"
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
         style={{ backgroundImage: `url(${resolvedBackgroundImage})` }}
-        aria-hidden="true"
       />
 
       {/* Content Container */}
@@ -108,7 +108,9 @@ export function Splash({
 
           {/* Subtitle */}
           {subtitle && (
-            <p className={`text-lg md:text-xl font-light ${children ? 'mb-8' : 'mb-12'} ${textColor}`}>
+            <p
+              className={`text-lg md:text-xl font-light ${children ? 'mb-8' : 'mb-12'} ${textColor}`}
+            >
               {subtitle}
             </p>
           )}
@@ -119,25 +121,19 @@ export function Splash({
           {/* Call-to-Action with Decorative Leaves */}
           {ctaText && ctaHref && (
             <a
-              href={ctaHref}
               className={`inline-flex items-center justify-center gap-4 text-xl md:text-2xl font-light ${textColor} transition-transform hover:scale-105 ${
                 pulsate ? 'animate-pulse-scale' : ''
               }`}
+              href={ctaHref}
             >
               {/* Left Leaf (rotated outward) */}
-              <LeafSvg
-                className="w-16 h-16 -rotate-90"
-                aria-hidden="true"
-              />
+              <LeafSvg aria-hidden="true" className="w-16 h-16 -rotate-90" />
 
               {/* CTA Text */}
               <span>{ctaText}</span>
 
               {/* Right Leaf (rotated outward) */}
-              <LeafSvg
-                className="w-16 h-16 rotate-90"
-                aria-hidden="true"
-              />
+              <LeafSvg aria-hidden="true" className="w-16 h-16 rotate-90" />
             </a>
           )}
         </div>

--- a/components/organisms/SubtleSystem/SubtleSystem.tsx
+++ b/components/organisms/SubtleSystem/SubtleSystem.tsx
@@ -70,7 +70,10 @@ export function SubtleSystem({
    */
   const isNested = useCallback((current: string | null, target: string) => {
     if (!current) return false
-    const nestedGroup = NESTED_CHAKRAS[target as keyof typeof NESTED_CHAKRAS] as readonly string[] | undefined
+    const nestedGroup = NESTED_CHAKRAS[target as keyof typeof NESTED_CHAKRAS] as
+      | readonly string[]
+      | undefined
+
     return nestedGroup?.includes(current) ?? false
   }, [])
 
@@ -90,23 +93,26 @@ export function SubtleSystem({
   /**
    * Handle node hover with timing delay for nested elements
    */
-  const handleNodeHover = useCallback((nodeId: string) => {
-    if (nodeId === activeNode) return
+  const handleNodeHover = useCallback(
+    (nodeId: string) => {
+      if (nodeId === activeNode) return
 
-    // Clear any existing timeout
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current)
-    }
+      // Clear any existing timeout
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+      }
 
-    // Determine delay time for nested chakras
-    const delay = isNested(activeNode, nodeId) ? NESTED_HOVER_DELAY : 0
+      // Determine delay time for nested chakras
+      const delay = isNested(activeNode, nodeId) ? NESTED_HOVER_DELAY : 0
 
-    hoverTimeoutRef.current = setTimeout(() => {
-      setIsAnimated(false)
-      setActiveNode(nodeId)
-      onNodeSelect?.(nodeId)
-    }, delay)
-  }, [activeNode, onNodeSelect, isNested])
+      hoverTimeoutRef.current = setTimeout(() => {
+        setIsAnimated(false)
+        setActiveNode(nodeId)
+        onNodeSelect?.(nodeId)
+      }, delay)
+    },
+    [activeNode, onNodeSelect, isNested],
+  )
 
   /**
    * Handle node hover end
@@ -121,37 +127,50 @@ export function SubtleSystem({
   /**
    * Handle node click
    */
-  const handleNodeClick = useCallback((nodeId: string) => {
-    setActiveNode(nodeId)
-    onNodeSelect?.(nodeId)
-    scrollToPreview(nodeId)
-  }, [onNodeSelect, scrollToPreview])
+  const handleNodeClick = useCallback(
+    (nodeId: string) => {
+      setActiveNode(nodeId)
+      onNodeSelect?.(nodeId)
+      scrollToPreview(nodeId)
+    },
+    [onNodeSelect, scrollToPreview],
+  )
 
   /**
    * Handle view toggle
    */
-  const handleViewToggle = useCallback((view: 'chakras' | 'channels') => {
-    if (view === activeView) return
+  const handleViewToggle = useCallback(
+    (view: 'chakras' | 'channels') => {
+      if (view === activeView) return
 
-    setActiveView(view)
-    setIsAnimated(true)
-    setActiveNode(null)
-    onNodeSelect?.(null)
-  }, [activeView, onNodeSelect])
+      setActiveView(view)
+      setIsAnimated(true)
+      setActiveNode(null)
+      onNodeSelect?.(null)
+    },
+    [activeView, onNodeSelect],
+  )
 
   /**
    * Handle fullscreen toggle
    */
   const handleFullscreenToggle = useCallback(async () => {
-    if (!containerRef.current) return
+    // Support the WebKit-prefixed Fullscreen API (Safari < 16.4) alongside the
+    // standard one; without the fallback the request throws and is swallowed by
+    // the catch, so the button silently does nothing in those browsers.
+    const el = containerRef.current as
+      | (HTMLDivElement & { webkitRequestFullscreen?: () => Promise<void> })
+      | null
+
+    if (!el) return
+    const doc = document as Document & { webkitExitFullscreen?: () => Promise<void> }
 
     try {
       if (!isFullscreen) {
-        await containerRef.current.requestFullscreen()
-        // State will be updated by fullscreenchange event listener
+        // State will be updated by the fullscreenchange event listener
+        await (el.requestFullscreen?.() ?? el.webkitRequestFullscreen?.())
       } else {
-        await document.exitFullscreen()
-        // State will be updated by fullscreenchange event listener
+        await (doc.exitFullscreen?.() ?? doc.webkitExitFullscreen?.())
       }
     } catch (error) {
       console.error('Fullscreen error:', error)
@@ -159,16 +178,20 @@ export function SubtleSystem({
   }, [isFullscreen])
 
   /**
-   * Listen for fullscreen change events
+   * Listen for fullscreen change events (standard + WebKit-prefixed)
    */
   useEffect(() => {
+    const doc = document as Document & { webkitFullscreenElement?: Element | null }
     const handleFullscreenChange = () => {
-      setIsFullscreen(!!document.fullscreenElement)
+      setIsFullscreen(Boolean(document.fullscreenElement || doc.webkitFullscreenElement))
     }
 
     document.addEventListener('fullscreenchange', handleFullscreenChange)
+    document.addEventListener('webkitfullscreenchange', handleFullscreenChange)
+
     return () => {
       document.removeEventListener('fullscreenchange', handleFullscreenChange)
+      document.removeEventListener('webkitfullscreenchange', handleFullscreenChange)
     }
   }, [])
 
@@ -179,16 +202,18 @@ export function SubtleSystem({
     if (!svgRef.current) return
 
     const svg = svgRef.current.querySelector('svg')
+
     if (!svg) return
 
     const containerSelector = activeView === 'chakras' ? '#hover_chakras' : '#hover_channels'
     const hoverContainer = svg.querySelector(containerSelector)
+
     if (!hoverContainer) return
 
     const nodes = Array.from(hoverContainer.children) as SVGElement[]
 
     // Update active classes
-    nodes.forEach(node => {
+    nodes.forEach((node) => {
       if (node.id === activeNode) {
         node.classList.add('active')
       } else {
@@ -199,6 +224,7 @@ export function SubtleSystem({
     // Setup event listeners
     const handleMouseOver = (event: Event) => {
       const target = event.currentTarget as SVGElement
+
       handleNodeHover(target.id)
     }
 
@@ -208,10 +234,11 @@ export function SubtleSystem({
 
     const handleClick = (event: Event) => {
       const target = event.currentTarget as SVGElement
+
       handleNodeClick(target.id)
     }
 
-    nodes.forEach(node => {
+    nodes.forEach((node) => {
       node.addEventListener('mouseover', handleMouseOver)
       node.addEventListener('mouseout', handleMouseOut)
       node.addEventListener('click', handleClick)
@@ -219,7 +246,7 @@ export function SubtleSystem({
 
     // Cleanup
     return () => {
-      nodes.forEach(node => {
+      nodes.forEach((node) => {
         node.removeEventListener('mouseover', handleMouseOver)
         node.removeEventListener('mouseout', handleMouseOut)
         node.removeEventListener('click', handleClick)
@@ -230,29 +257,29 @@ export function SubtleSystem({
   return (
     <div
       ref={containerRef}
-      data-view={activeView}
-      data-animated={isAnimated}
       className={`${isFullscreen ? 'bg-white' : ''} ${className}`}
+      data-animated={isAnimated}
+      data-view={activeView}
       {...props}
     >
       {/* Toggle */}
       <div className="text-center mb-7 text-base sm:text-lg leading-[25px]">
         <button
+          aria-pressed={activeView === 'chakras'}
           className={`px-2 cursor-pointer transition-colors ${
             activeView === 'chakras' ? 'font-bold text-teal-600' : 'hover:text-teal-600'
           }`}
           onClick={() => handleViewToggle('chakras')}
-          aria-pressed={activeView === 'chakras'}
         >
           Chakras
         </button>
         <span className="px-1">|</span>
         <button
+          aria-pressed={activeView === 'channels'}
           className={`px-2 cursor-pointer transition-colors ${
             activeView === 'channels' ? 'font-bold text-teal-600' : 'hover:text-teal-600'
           }`}
           onClick={() => handleViewToggle('channels')}
-          aria-pressed={activeView === 'channels'}
         >
           Channels
         </button>
@@ -262,19 +289,19 @@ export function SubtleSystem({
       <div className="relative max-w-[1200px] mx-auto mb-[100px]">
         {/* SVG Chart */}
         <div
+          dangerouslySetInnerHTML={{ __html: chartSvg }}
           ref={svgRef}
           className="subtle-system-chart min-h-[400px] max-h-[550px] sm:h-[550px] sm:max-h-[80vh] max-w-full block mx-auto"
-          dangerouslySetInnerHTML={{ __html: chartSvg }}
         />
 
         {/* Fullscreen Button */}
         <div className="absolute top-4 right-4">
           <Button
-            variant="outline"
-            size="sm"
-            onClick={handleFullscreenToggle}
-            icon={isFullscreen ? ArrowsPointingInIcon : ArrowsPointingOutIcon}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            icon={isFullscreen ? ArrowsPointingInIcon : ArrowsPointingOutIcon}
+            size="sm"
+            variant="outline"
+            onClick={handleFullscreenToggle}
           />
         </div>
 
@@ -286,23 +313,19 @@ export function SubtleSystem({
             return (
               <div
                 key={item.id}
-                data-node-id={item.id}
                 className={`hidden sm:block opacity-0 invisible transition-[visibility,opacity] duration-500 ease-in-out ${
                   isActive ? 'delay-0 block! opacity-100! visible!' : 'delay-0'
                 } bg-white/50 shadow-[0_0_10px_5px_rgba(255,255,255,0.5)] sm:absolute sm:top-16 sm:w-80 sm:max-w-[45%] sm:mt-[70px] ${
                   index % 2 === 0 ? 'sm:left-0 sm:pr-0' : 'sm:right-0 sm:pl-0'
                 } p-4 sm:p-8`}
+                data-node-id={item.id}
               >
-                <h3 className="text-xl font-semibold mb-2 text-gray-900">
-                  {item.title}
-                </h3>
-                <p className="text-base mb-4 text-gray-700">
-                  {item.description}
-                </p>
+                <h3 className="text-xl font-semibold mb-2 text-gray-900">{item.title}</h3>
+                <p className="text-base mb-4 text-gray-700">{item.description}</p>
                 <a
-                  href={item.linkHref}
-                  className="inline-block text-teal-600 hover:text-teal-700 font-medium transition-colors"
                   aria-label={`Learn more about ${item.title}`}
+                  className="inline-block text-teal-600 hover:text-teal-700 font-medium transition-colors"
+                  href={item.linkHref}
                 >
                   Learn More →
                 </a>

--- a/components/templates/PageTemplate.tsx
+++ b/components/templates/PageTemplate.tsx
@@ -43,7 +43,7 @@ export function PageTemplate({ page }: PageTemplateProps) {
   return (
     <article>
       {hasHeader && (
-        <Container maxWidth="prose">
+        <Container maxWidth="md">
           {video && video.hlsUrl ? (
             <VideoPlayer
               className="mb-8"

--- a/components/templates/PageTemplate.tsx
+++ b/components/templates/PageTemplate.tsx
@@ -16,6 +16,7 @@ import { VideoPlayer, Author as AuthorByline } from '../molecules'
 import { PageTitle } from '../atoms'
 import { usePageHead } from '../../lib/head'
 import { isPopulated, populatedImageUrl } from '../../lib/cms-relationships'
+import { getLeadSplash } from '../../lib/cms-blocks'
 
 export interface PageTemplateProps {
   /**
@@ -24,26 +25,15 @@ export interface PageTemplateProps {
   page: Page
 }
 
-/**
- * True when the page's content leads with a `splash` block. A splash renders
- * its own full-bleed title, so the PageTitle banner is skipped to avoid showing
- * the title twice.
- */
-function leadsWithSplash(content: Page['content']): boolean {
-  const first = content?.root?.children?.[0] as
-    | { type?: string; fields?: { blockType?: string } }
-    | undefined
-
-  return first?.type === 'block' && first?.fields?.blockType === 'splash'
-}
-
 export function PageTemplate({ page }: PageTemplateProps) {
   // Set <title>/description/og:image from CMS meta (must run unconditionally).
   usePageHead({ meta: page.meta, fallbackTitle: page.title })
 
   const author = isPopulated<Author>(page.author) ? page.author : null
   const video = isPopulated<Video>(page.featuredVideo) ? page.featuredVideo : null
-  const showTitle = !leadsWithSplash(page.content)
+  // A lead splash renders its own full-bleed title, so skip the PageTitle banner
+  // to avoid showing the title twice.
+  const showTitle = !getLeadSplash(page.content)
 
   return (
     <article className="max-w-4xl mx-auto">

--- a/components/templates/PageTemplate.tsx
+++ b/components/templates/PageTemplate.tsx
@@ -13,7 +13,7 @@
 import type { Page, Author, Video } from '../../server/cms-types'
 import { RichText } from '../organisms'
 import { VideoPlayer, Author as AuthorByline } from '../molecules'
-import { PageTitle } from '../atoms'
+import { Container, PageTitle } from '../atoms'
 import { usePageHead } from '../../lib/head'
 import { isPopulated, populatedImageUrl } from '../../lib/cms-relationships'
 import { getLeadSplash } from '../../lib/cms-blocks'
@@ -34,31 +34,40 @@ export function PageTemplate({ page }: PageTemplateProps) {
   // A lead splash renders its own full-bleed title, so skip the PageTitle banner
   // to avoid showing the title twice.
   const showTitle = !getLeadSplash(page.content)
+  const hasVideo = Boolean(video && video.hlsUrl)
+  const hasHeader = hasVideo || showTitle || Boolean(author)
 
+  // The article no longer constrains width; the readable column is owned by the
+  // Container here (header chrome) and by RichText's own Container (the body), so
+  // full-bleed blocks can break out cleanly and rendering is consistent in stories.
   return (
-    <article className="max-w-4xl mx-auto">
-      {video && video.hlsUrl ? (
-        <VideoPlayer
-          className="mb-8"
-          hlsUrl={video.hlsUrl}
-          poster={populatedImageUrl(video.thumbnail)}
-          subtitles={video.subtitles}
-          title={video.title}
-        />
-      ) : null}
+    <article>
+      {hasHeader && (
+        <Container maxWidth="prose">
+          {video && video.hlsUrl ? (
+            <VideoPlayer
+              className="mb-8"
+              hlsUrl={video.hlsUrl}
+              poster={populatedImageUrl(video.thumbnail)}
+              subtitles={video.subtitles}
+              title={video.title}
+            />
+          ) : null}
 
-      {showTitle ? <PageTitle title={page.title} /> : null}
+          {showTitle ? <PageTitle title={page.title} /> : null}
 
-      {author ? (
-        <AuthorByline
-          className="mb-8"
-          countryCode={author.countryCode ?? undefined}
-          imageUrl={populatedImageUrl(author.photo)}
-          meditationYears={author.yearsMeditating ?? undefined}
-          name={author.name}
-          variant="mini"
-        />
-      ) : null}
+          {author ? (
+            <AuthorByline
+              className="mb-8"
+              countryCode={author.countryCode ?? undefined}
+              imageUrl={populatedImageUrl(author.photo)}
+              meditationYears={author.yearsMeditating ?? undefined}
+              name={author.name}
+              variant="mini"
+            />
+          ) : null}
+        </Container>
+      )}
 
       <RichText content={page.content} />
     </article>

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -145,10 +145,12 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
       )}
 
       {/* `container-type: inline-size` makes `full-bleed` blocks size with `cqi`
-          relative to this window-width box (not the viewport — excludes scrollbar);
-          `overflow-x-clip` contains decorative horizontal bleed. The sticky nav
-          lives outside <main>, so this containment never touches it. */}
-      <main className="flex-1 @container overflow-x-clip">
+          relative to this window-width box (not the viewport — excludes scrollbar).
+          The sticky nav lives outside <main>, so this containment never touches it.
+          NB: no `overflow-x-clip` here — it would clip ContentTextBox's intentional
+          desktop overlap (negative `-ml-32`/`-mr-32` margins). Blocks that bleed
+          horizontally (OrnateTextBox) clip themselves instead. */}
+      <main className="flex-1 @container">
         <div className={`max-w-7xl mx-auto px-6 ${leadSplash ? 'pb-8' : 'py-8'}`}>{children}</div>
       </main>
 

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -3,8 +3,9 @@ import { Header } from '../components/organisms/Header'
 import { Footer } from '../components/organisms/Footer'
 import { useData } from 'vike-react/useData'
 import { usePageContext } from 'vike-react/usePageContext'
-import type { WebConfig } from '../server/cms-types'
+import type { WebConfig, Page } from '../server/cms-types'
 import type { HeaderDropdownProps } from '../components/organisms'
+import { getLeadSplash } from '../lib/cms-blocks'
 import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
 
 /**
@@ -15,9 +16,16 @@ import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdow
  * error boundary). Embed routes omit it entirely and render bare.
  */
 export default function LayoutChrome({ children }: { children: React.ReactNode }) {
-  const data = useData<{ settings?: WebConfig }>()
+  const data = useData<{ settings?: WebConfig; page?: Page }>()
   const { locale } = usePageContext()
   const settings = data?.settings
+
+  // When the page leads with a Splash, overlay the header on it (transparent,
+  // themed to match) and let the splash sit flush at the top. The Splash reserves
+  // `pt-60` for exactly this. `data.page` is present on content routes ([slug]);
+  // the live-preview route uses a different data shape (`initialData`) and keeps
+  // the in-flow header.
+  const leadSplash = getLeadSplash(data?.page?.content)
 
   // CMS-down / error-page fallback: when settings are unavailable (the _error
   // page carries no data, or the CMS is unreachable) render the content with no
@@ -115,19 +123,33 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
     { code: 'fr' as const, label: 'Français', flagCode: 'fr', href: '/fr' },
   ]
 
-  return (
-    <div className="flex flex-col min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 w-full">
-        <Header
-          actionLinkHref={classPages[0] ? '/' + classPages[0].slug : '/'}
-          actionLinkText={classPages[0]?.title}
-          logoHref="/"
-          navItems={navItems}
-        />
-      </div>
+  const header = (
+    <div className="max-w-7xl mx-auto px-6 w-full">
+      <Header
+        actionLinkHref={classPages[0] ? '/' + classPages[0].slug : '/'}
+        actionLinkText={classPages[0]?.title}
+        logoHref="/"
+        navItems={navItems}
+        theme={leadSplash?.theme}
+      />
+    </div>
+  )
 
-      <main className="flex-1">
-        <div className="max-w-7xl mx-auto px-6 py-8">{children}</div>
+  return (
+    <div className={`flex flex-col min-h-screen ${leadSplash ? 'relative' : ''}`}>
+      {leadSplash ? (
+        // Overlay the header transparently on the lead splash.
+        <div className="absolute inset-x-0 top-0 z-30">{header}</div>
+      ) : (
+        header
+      )}
+
+      {/* `container-type: inline-size` makes `full-bleed` blocks size with `cqi`
+          relative to this window-width box (not the viewport — excludes scrollbar);
+          `overflow-x-clip` contains decorative horizontal bleed. The sticky nav
+          lives outside <main>, so this containment never touches it. */}
+      <main className="flex-1 @container overflow-x-clip">
+        <div className={`max-w-7xl mx-auto px-6 ${leadSplash ? 'pb-8' : 'py-8'}`}>{children}</div>
       </main>
 
       <Footer

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -5,7 +5,7 @@ import { useData } from 'vike-react/useData'
 import { usePageContext } from 'vike-react/usePageContext'
 import type { WebConfig, Page } from '../server/cms-types'
 import type { HeaderDropdownProps } from '../components/organisms'
-import { getLeadSplash } from '../lib/cms-blocks'
+import { leadSplashFromRouteData } from '../lib/cms-blocks'
 import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
 
 /**
@@ -16,16 +16,21 @@ import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdow
  * error boundary). Embed routes omit it entirely and render bare.
  */
 export default function LayoutChrome({ children }: { children: React.ReactNode }) {
-  const data = useData<{ settings?: WebConfig; page?: Page }>()
+  const data = useData<{
+    settings?: WebConfig
+    page?: Page
+    collection?: string
+    initialData?: Page
+  }>()
   const { locale } = usePageContext()
   const settings = data?.settings
 
   // When the page leads with a Splash, overlay the header on it (transparent,
   // themed to match) and let the splash sit flush at the top. The Splash reserves
-  // `pt-60` for exactly this. `data.page` is present on content routes ([slug]);
-  // the live-preview route uses a different data shape (`initialData`) and keeps
-  // the in-flow header.
-  const leadSplash = getLeadSplash(data?.page?.content)
+  // `pt-60` for exactly this. Works on both content routes ([slug], `page`) and the
+  // live-preview route (/preview, `initialData`) so preview matches the published
+  // layout — see leadSplashFromRouteData.
+  const leadSplash = leadSplashFromRouteData(data)
 
   // CMS-down / error-page fallback: when settings are unavailable (the _error
   // page carries no data, or the CMS is unreachable) render the content with no
@@ -144,14 +149,21 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
         header
       )}
 
-      {/* `container-type: inline-size` makes `full-bleed` blocks size with `cqi`
-          relative to this window-width box (not the viewport — excludes scrollbar).
-          The sticky nav lives outside <main>, so this containment never touches it.
+      {/* `container-type: inline-size` (@container) makes this <main> the query
+          container; the content wrapper below captures its inline size into
+          `--page-width` (`[--page-width:100cqi]`) so `full-bleed` blocks span this
+          window-width box (excluding the scrollbar) regardless of any nested
+          `@container` between them and here. The sticky nav lives outside <main>,
+          so it keeps the `:root` viewport default.
           NB: no `overflow-x-clip` here — it would clip ContentTextBox's intentional
           desktop overlap (negative `-ml-32`/`-mr-32` margins). Blocks that bleed
           horizontally (OrnateTextBox) clip themselves instead. */}
       <main className="flex-1 @container">
-        <div className={`max-w-7xl mx-auto px-6 ${leadSplash ? 'pb-8' : 'py-8'}`}>{children}</div>
+        <div
+          className={`max-w-7xl mx-auto px-6 [--page-width:100cqi] ${leadSplash ? 'pb-8' : 'py-8'}`}
+        >
+          {children}
+        </div>
       </main>
 
       <Footer

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -109,17 +109,41 @@
 }
 
 /**
+ * `--page-width` — the width a `full-bleed` block should span. It's a *registered*
+ * `<length>`, which is what makes this robust: a container-query unit assigned to a
+ * registered `<length>` is resolved (captured) at the element where it's set and
+ * then inherits down as a fixed length — even through descendant `@container`s.
+ *
+ * That immunity to nested containers is the whole point. A raw `100cqi` on the
+ * block resolves against the *nearest* container, so a full-bleed block placed
+ * inside some inner `@container` (e.g. a future component reusing MeditationPlayer's
+ * container) would size to that inner box instead of the page. Capturing the width
+ * at the page-content wrapper removes that footgun.
+ *
+ * Defaults to the viewport (no container context — embed routes, and the sticky nav
+ * which lives outside `<main>`). The page-content wrapper in <main> and the Ladle
+ * story container override it with `100cqi` so it tracks the content area and
+ * excludes the scrollbar. See LayoutChrome.tsx and .ladle/components.tsx.
+ */
+@property --page-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+:root {
+  --page-width: 100vw;
+}
+
+/**
  * Full-bleed: break a block out of its centered, width-constrained ancestors to
- * span the full content container. Uses container-query inline units (`cqi`) so it
- * fills the window on real pages (the `<main>` inline-size container) and the story
- * area in Ladle (the global Provider container), excluding the scrollbar. Where no
- * container ancestor exists, `cqi` falls back to viewport units. The centering math
- * matches the legacy `vw` break-out; it relies on the element's containing block
- * being horizontally centered within the query container (true for the article).
+ * span `--page-width` (the captured content-area width). The centering math relies
+ * on the element's containing block being horizontally centered within the page
+ * (true for the article column).
  */
 @utility full-bleed {
-  width: 100cqi;
-  max-width: 100cqi;
-  margin-left: calc(50% - 50cqi);
-  margin-right: calc(50% - 50cqi);
+  width: var(--page-width);
+  max-width: var(--page-width);
+  margin-left: calc(50% - var(--page-width) / 2);
+  margin-right: calc(50% - var(--page-width) / 2);
 }

--- a/layouts/tailwind.css
+++ b/layouts/tailwind.css
@@ -107,3 +107,19 @@
 @utility text-glow-dark {
   text-shadow: 0 0 8px rgb(0 0 0 / 80%), 0 0 16px rgb(0 0 0 / 60%), 0 0 24px rgb(0 0 0 / 40%);
 }
+
+/**
+ * Full-bleed: break a block out of its centered, width-constrained ancestors to
+ * span the full content container. Uses container-query inline units (`cqi`) so it
+ * fills the window on real pages (the `<main>` inline-size container) and the story
+ * area in Ladle (the global Provider container), excluding the scrollbar. Where no
+ * container ancestor exists, `cqi` falls back to viewport units. The centering math
+ * matches the legacy `vw` break-out; it relies on the element's containing block
+ * being horizontally centered within the query container (true for the article).
+ */
+@utility full-bleed {
+  width: 100cqi;
+  max-width: 100cqi;
+  margin-left: calc(50% - 50cqi);
+  margin-right: calc(50% - 50cqi);
+}

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -3,6 +3,7 @@ import {
   contentIndexCard,
   galleryImages,
   getLeadSplash,
+  leadSplashFromRouteData,
   isExternalUrl,
   populatedImage,
   showcaseItems,
@@ -201,5 +202,35 @@ describe('getLeadSplash', () => {
     expect(getLeadSplash(leadContent({ type: 'paragraph' }))).toBeNull()
     expect(getLeadSplash(leadContent())).toBeNull()
     expect(getLeadSplash(undefined as unknown as Page['content'])).toBeNull()
+  })
+})
+
+describe('leadSplashFromRouteData', () => {
+  const splashPage = (textColor?: 'dark' | 'light') => ({
+    content: leadContent({
+      type: 'block',
+      fields: { blockType: 'splash', ...(textColor ? { textColor } : {}) },
+    }),
+  })
+
+  it('reads page content on content routes ([slug])', () => {
+    expect(leadSplashFromRouteData({ page: splashPage('dark') })).toEqual({ theme: 'light' })
+  })
+
+  it('reads initialData content on a pages preview', () => {
+    expect(leadSplashFromRouteData({ collection: 'pages', initialData: splashPage() })).toEqual({
+      theme: 'dark',
+    })
+  })
+
+  it('ignores initialData for non-page previews (meditations/lectures)', () => {
+    expect(
+      leadSplashFromRouteData({ collection: 'meditations', initialData: splashPage() }),
+    ).toBeNull()
+  })
+
+  it('returns null without a lead splash or data', () => {
+    expect(leadSplashFromRouteData(undefined)).toBeNull()
+    expect(leadSplashFromRouteData({})).toBeNull()
   })
 })

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -8,6 +8,7 @@ import {
   showcaseItems,
   splashTheme,
   subtleSystemItems,
+  textColorToTheme,
   type ShowcaseItem,
 } from './cms-blocks'
 import type { Page } from '../server/cms-types'
@@ -155,6 +156,17 @@ describe('isExternalUrl', () => {
     expect(isExternalUrl('http://example.com')).toBe(true)
     expect(isExternalUrl('/about')).toBe(false)
     expect(isExternalUrl('#anchor')).toBe(false)
+  })
+})
+
+describe('textColorToTheme', () => {
+  it('inverts textColor and falls back when absent', () => {
+    // The inversion is fixed; only the fallback for absent values varies per caller.
+    expect(textColorToTheme('dark', 'light')).toBe('light')
+    expect(textColorToTheme('light', 'dark')).toBe('dark')
+    expect(textColorToTheme('dark', 'dark')).toBe('light') // explicit value wins over fallback
+    expect(textColorToTheme(undefined, 'light')).toBe('light')
+    expect(textColorToTheme(null, 'dark')).toBe('dark')
   })
 })
 

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -2,12 +2,19 @@ import { describe, it, expect } from 'vitest'
 import {
   contentIndexCard,
   galleryImages,
+  getLeadSplash,
   isExternalUrl,
   populatedImage,
   showcaseItems,
+  splashTheme,
   subtleSystemItems,
   type ShowcaseItem,
 } from './cms-blocks'
+import type { Page } from '../server/cms-types'
+
+/** Build a `pages.content` shape whose first child is `firstBlock` (or none). */
+const leadContent = (firstBlock?: Record<string, unknown>) =>
+  ({ root: { children: firstBlock ? [firstBlock] : [] } }) as unknown as Page['content']
 
 /** A populated Cloudflare image (1600×900 ≈ 16:9 → `video`). */
 const cfImage = (over: Record<string, unknown> = {}) => ({
@@ -148,5 +155,39 @@ describe('isExternalUrl', () => {
     expect(isExternalUrl('http://example.com')).toBe(true)
     expect(isExternalUrl('/about')).toBe(false)
     expect(isExternalUrl('#anchor')).toBe(false)
+  })
+})
+
+describe('splashTheme', () => {
+  it('inverts textColor → background theme, defaulting to dark', () => {
+    // textColor describes the *text*; theme describes the *background* (they invert).
+    expect(splashTheme('dark')).toBe('light')
+    expect(splashTheme('light')).toBe('dark')
+    // Absent/null → dark (the splash's historical hardcoded treatment).
+    expect(splashTheme(undefined)).toBe('dark')
+    expect(splashTheme(null)).toBe('dark')
+  })
+})
+
+describe('getLeadSplash', () => {
+  const splashBlock = (textColor?: 'dark' | 'light') => ({
+    type: 'block',
+    fields: { blockType: 'splash', ...(textColor ? { textColor } : {}) },
+  })
+
+  it('returns the derived theme when content leads with a splash block', () => {
+    expect(getLeadSplash(leadContent(splashBlock()))).toEqual({ theme: 'dark' })
+    expect(getLeadSplash(leadContent(splashBlock('dark')))).toEqual({ theme: 'light' })
+    expect(getLeadSplash(leadContent(splashBlock('light')))).toEqual({ theme: 'dark' })
+  })
+
+  it('returns null when the first block is not a splash', () => {
+    expect(getLeadSplash(leadContent({ type: 'block', fields: { blockType: 'quote' } }))).toBeNull()
+  })
+
+  it('returns null when the first child is not a block, or content is empty', () => {
+    expect(getLeadSplash(leadContent({ type: 'paragraph' }))).toBeNull()
+    expect(getLeadSplash(leadContent())).toBeNull()
+    expect(getLeadSplash(undefined as unknown as Page['content'])).toBeNull()
   })
 })

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -202,14 +202,29 @@ export function galleryImages(images: ImageGalleryBlockFields['items']): Populat
 }
 
 /**
- * Derive a Splash background-context theme from its `textColor` field. `textColor`
- * describes the *text* (dark/light); `theme` describes the *background* (they
- * invert, matching the `textbox` overlay convention in blockConverters). Defaults
- * to `'dark'` (light text over a dark hero) when the field is absent — the splash's
- * historical hardcoded treatment.
+ * Invert a CMS `textColor` (which describes the *text*: dark/light) into a
+ * background-context `theme` — light text implies a dark background, and vice
+ * versa. When `textColor` is absent, fall back to `fallback`. Shared by the
+ * splash hero and the `textbox` overlay, which use this same inversion but
+ * differ only in their default.
+ */
+export function textColorToTheme(
+  textColor: 'dark' | 'light' | null | undefined,
+  fallback: 'light' | 'dark',
+): 'light' | 'dark' {
+  if (textColor === 'dark') return 'light'
+  if (textColor === 'light') return 'dark'
+
+  return fallback
+}
+
+/**
+ * Derive a Splash background-context theme from its `textColor` field. Defaults
+ * to `'dark'` (light text over a dark hero) when the field is absent — the
+ * splash's historical hardcoded treatment.
  */
 export function splashTheme(textColor?: SplashBlockFields['textColor']): 'light' | 'dark' {
-  return textColor === 'dark' ? 'light' : 'dark'
+  return textColorToTheme(textColor, 'dark')
 }
 
 /**

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -95,6 +95,12 @@ export interface SplashBlockFields {
   subtitle?: string | null
   actionText?: string | null
   actionURL?: string | null
+  /**
+   * Describes the *text* color (dark/light), mirroring the `textbox` overlay
+   * convention. Not yet authored in the CMS (see SahajCloud ticket) — absent is
+   * treated as light text on a dark hero (`theme: 'dark'`).
+   */
+  textColor?: 'dark' | 'light' | null
 }
 
 /** `layout` — LayoutBlock item. */
@@ -193,6 +199,34 @@ export function galleryImages(images: ImageGalleryBlockFields['items']): Populat
   }
 
   return result
+}
+
+/**
+ * Derive a Splash background-context theme from its `textColor` field. `textColor`
+ * describes the *text* (dark/light); `theme` describes the *background* (they
+ * invert, matching the `textbox` overlay convention in blockConverters). Defaults
+ * to `'dark'` (light text over a dark hero) when the field is absent — the splash's
+ * historical hardcoded treatment.
+ */
+export function splashTheme(textColor?: SplashBlockFields['textColor']): 'light' | 'dark' {
+  return textColor === 'dark' ? 'light' : 'dark'
+}
+
+/**
+ * When a page's content leads with a `splash` block, return its background-context
+ * theme; otherwise `null`. Shared by the layout (header overlay theme), the page
+ * wrappers (flush-to-top spacing) and PageTemplate (skipping the duplicate title).
+ */
+export function getLeadSplash(content: Page['content']): { theme: 'light' | 'dark' } | null {
+  const first = content?.root?.children?.[0] as
+    | { type?: string; fields?: SplashBlockFields & { blockType?: string } }
+    | undefined
+
+  if (first?.type !== 'block' || first.fields?.blockType !== 'splash') {
+    return null
+  }
+
+  return { theme: splashTheme(first.fields.textColor) }
 }
 
 /** Coerce a possibly-null/absent CMS text field to a string. */

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -244,6 +244,29 @@ export function getLeadSplash(content: Page['content']): { theme: 'light' | 'dar
   return { theme: splashTheme(first.fields.textColor) }
 }
 
+/**
+ * Resolve the lead splash from a layout route's data, whose shape differs by route:
+ * content routes ([slug]) carry the page as `page`; the live-preview route (/preview)
+ * carries the previewed document as `initialData` — only a `pages` preview has
+ * splash-leading content (meditation/lecture previews never do). Lets LayoutChrome
+ * apply the same overlaid-header treatment in preview as on the published page.
+ */
+export function leadSplashFromRouteData(
+  data:
+    | {
+        page?: Pick<Page, 'content'> | null
+        collection?: string
+        initialData?: Pick<Page, 'content'> | null
+      }
+    | null
+    | undefined,
+): { theme: 'light' | 'dark' } | null {
+  const content =
+    data?.page?.content ?? (data?.collection === 'pages' ? data?.initialData?.content : undefined)
+
+  return getLeadSplash(content)
+}
+
 /** Coerce a possibly-null/absent CMS text field to a string. */
 function asText(value: unknown): string {
   return typeof value === 'string' ? value : ''

--- a/pages/[slug]/+Page.tsx
+++ b/pages/[slug]/+Page.tsx
@@ -14,7 +14,10 @@ export function Page() {
   const leadSplash = getLeadSplash(page.content)
 
   return (
-    <div className={`min-h-screen px-4 ${leadSplash ? 'pb-12' : 'py-12'}`}>
+    // Horizontal gutters now come from the Container inside PageTemplate/RichText,
+    // so no px here (avoids over-narrowing content). Drop the top padding when the
+    // page leads with a splash so the full-bleed hero sits flush at the top.
+    <div className={`min-h-screen ${leadSplash ? 'pb-12' : 'py-12'}`}>
       <PageTemplate page={page} />
     </div>
   )

--- a/pages/[slug]/+Page.tsx
+++ b/pages/[slug]/+Page.tsx
@@ -5,12 +5,16 @@
 import { useData } from 'vike-react/useData'
 import { PageData } from './+data'
 import { PageTemplate } from '../../components/templates'
+import { getLeadSplash } from '../../lib/cms-blocks'
 
 export function Page() {
   const { page } = useData<PageData>()
+  // Drop the top padding when the page leads with a splash so the full-bleed hero
+  // sits flush at the top of the page, under the overlaid header (see LayoutChrome).
+  const leadSplash = getLeadSplash(page.content)
 
   return (
-    <div className="min-h-screen py-12 px-4">
+    <div className={`min-h-screen px-4 ${leadSplash ? 'pb-12' : 'py-12'}`}>
       <PageTemplate page={page} />
     </div>
   )


### PR DESCRIPTION
## Summary

- When a page leads with a Splash, the site header now overlays the hero transparently and themes itself (light/dark) to match, instead of sitting in normal flow above it.
- Adds a reusable full-bleed mechanism (container-query `cqi` units) so Splash, OrnateTextBox, subtle-system, and `align: wide` uploads span the full window — and the same width inside Ladle stories, not just the viewport.
- Wide uploads lose their rounding (they meet the view edges); the "About Meditation" mega-menu now aligns to the page content area; and several image blocks render larger on mobile.

## Changes

- `lib/cms-blocks.ts` — `getLeadSplash` / `splashTheme` helpers + optional `SplashBlockFields.textColor`; replaces the private `leadsWithSplash` in PageTemplate.
- `layouts/tailwind.css` + `.ladle/components.tsx` + `layouts/LayoutChrome.tsx` — `full-bleed` utility (`cqi`) and inline-size `@container` on `<main>` / the Ladle Provider; lead-splash header overlay + flush-to-top padding.
- `components/organisms/Header/{Header,HeaderNavDropdown}.tsx`, `HeaderDropdown/HeaderDropdown.tsx` — sticky nav migrated to the `full-bleed` utility; mega-menu pinned to a viewport-spanning panel whose inner `max-w-7xl` box aligns to the content area.
- `components/organisms/RichText/{blockConverters.tsx,RichText.tsx,lexical-helpers.ts}`, `components/atoms/Image/Image.tsx` — apply full-bleed to splash/ornate/subtle/wide media; `rounded="none"` for wide uploads; image-gallery & content-index keep 2 columns until `lg:`.
- `components/organisms/ContentTextBox/ContentTextBox.tsx` — mobile images fill width capped to ≤ 1:1 (`object-cover`).

## Test Results

- Lint: ✓ No new errors (`pnpm lint` — 0 errors; only pre-existing baseline warnings)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 276 passed (`pnpm test:run`) — adds `getLeadSplash`/`splashTheme` coverage in `lib/cms-blocks.test.ts`
- Build: ✓ Success (`pnpm build`)

## Preview deployment

- Verifying the Cloudflare web Worker + Ladle Pages previews and CI in step 14 (`gh pr checks --watch`).

## Manual verification

Per the repo's debugging rule, these are server-rendered from live CMS data — confirm on the deployed preview / in Ladle, not just locally:

1. **Home page (leads with a splash):** header overlays the hero, text is legible (dark theme), splash is flush to the top and full-window width. No horizontal scrollbar.
2. **Sticky nav:** scroll down — the nav becomes a full-window-width white bar (it relies on `cqi` → viewport fallback; verified empirically in a headless browser, but worth eyeballing).
3. **Mega-menu ("About Meditation"):** the gray panel is centered and matches the `max-w-7xl` content-area width.
4. **Ladle:** Splash / OrnateTextBox / SubtleSystem stories fill the story area (not overflowing under the sidebar); ContentTextBox at mobile widths is ≤ square; wide-image story has square corners.

## Notes for reviewer

- **Empirically verified** (headless Chrome): `100cqi` falls back to the viewport when no `@container` ancestor exists (sticky nav) and resolves to the container otherwise (`<main>` / Ladle Provider); `overflow-x: clip` keeps `overflow-y` visible.
- `overflow-x-clip` is scoped to the OrnateTextBox root (the only block with horizontal decorative bleed) rather than `<main>`, so it can't clip ContentTextBox's intentional desktop overlap. (Found and fixed during the code-review pass.)
- **Deferred / known:** the live-preview route (`/preview`) uses a different data shape (`initialData`, not `page`), so it keeps the in-flow header rather than the overlay — published pages are unaffected. Splash `textColor` needs an upstream CMS field, filed as sydevs/SahajCloud#516 (the app defaults to dark until then). The mega-menu can clip its own bottom only on very short viewports (top-anchored, opens downward by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: image loading + Cloudflare variants (added after initial review)

- **`components/atoms/Image/Image.tsx`** — two loading-state fixes plus a decoupling:
  - The loading `<Placeholder>` no longer receives intrinsic pixel `width`/`height`. It's always `absolute inset-0`, so explicit px were sizing the overlay to the raw image and anchoring it top-left (larger than, and offset above, the final image). The `<img>`'s own attributes still reserve layout space. *Empirically verified in Ladle: a 900×1200 source rendered at 312×416 produced a 900×1200 top-left-anchored old placeholder vs a 312×416 fixed one.*
  - A cached image can become `complete` before React attaches `onLoad`, leaving `isLoading` stuck `true` (placeholder lingers, image held at `opacity-0`). A mount-time effect now clears the loading state for an already-decoded image. *Verified on cache reload: no completed image stuck behind a placeholder.*
  - New **`forceAspectRatio`** prop (default `true`, backward-compatible): the aspect ratio always drives Cloudflare variant/srcset selection, but only constrains the layout to a fixed-ratio box when set. Natural-flow feature blocks pass `false`.
- **`ContentTextBox` / `OrnateTextBox`** — accept `imageAspectRatio` (threaded from the converter's populated image) and render `<Image forceAspectRatio={false}>`, so they fetch an **optimized Cloudflare variant + responsive srcset** instead of the full-resolution original, while still rendering at the image's natural ratio. ContentTextBox also gains vertical margin (`my-24 lg:my-32`); OrnateTextBox reserves a right gutter (`lg:pr-24`) so the body clears the vertical sidetext.
- **`ContentOverlay`** — readable text container widened md → lg.
- **`lib/cms-blocks.ts`** — extracted shared `textColorToTheme(textColor, fallback)`; `splashTheme` and the textbox-overlay converter now share one inversion rule (differing only in default).

### Deferred (non-blocking, from the fresh-context review)
- **Preview-route lead-splash parity:** the `/preview` route uses a different data shape (no top-level `page`), so a previewed page that leads with a splash keeps the in-flow header rather than the new overlay. This is **not a regression** (it matches the whole site's pre-PR behavior) and is documented in `LayoutChrome`. Bringing the live-preview iframe to parity (deriving the theme from `initialData`, reacting to live edits) is a follow-up.
- **full-bleed under a nested `@container`:** `cqi` resolves against the nearest container; the only inline-size container in the content area is `<main>`, so full-bleed blocks are correct today. A future block rendered inside another `@container` (e.g. MeditationPlayer) would size to that instead — an accepted tradeoff of the `cqi` approach.

### Updated test results
- Tests: ✓ **279 passed** (`pnpm test:run`) — adds `textColorToTheme` + `forceAspectRatio` coverage.
- Lint ✓ / Types ✓ clean.


---

## Both deferred items now resolved

- **Preview-route lead-splash parity** — LayoutChrome now derives the lead splash via a new, unit-tested `leadSplashFromRouteData` helper that handles both route data shapes (`page` on `[slug]`, `initialData` on `/preview`). A previewed page that leads with a splash now gets the overlaid, themed header + flush-to-top layout, matching the published page.
- **full-bleed under a nested `@container`** — replaced the raw `100cqi` break-out with a registered `@property --page-width` (`<length>`) set to `100cqi` on the page-content wrapper. Container units assigned to a registered `<length>` are *captured* at the declaring element and inherit down as a fixed length, so `full-bleed` spans the page width even through a nested `@container`; it falls back to the viewport (`:root`) outside `<main>` (sticky nav, embed routes). **Verified in a headless browser against the real compiled CSS:** a full-bleed block nested inside a 300px `@container` spans the full 1000px page width (raw `100cqi` gave 300px).

Tests: **283 passed** (adds `leadSplashFromRouteData` coverage). Lint ✓ / Types ✓ / Build ✓.
