### PR TITLE
fix(image): never render <img> with an empty src

### DIFF
--- a/components/atoms/Image/Image.test.tsx
+++ b/components/atoms/Image/Image.test.tsx
@@ -46,6 +46,39 @@ describe('<Image> Cloudflare Images integration', () => {
   })
 })
 
+describe('<Image> blank src', () => {
+  it('renders no <img> for an empty src (never emits src="")', () => {
+    const html = renderToStaticMarkup(<Image alt="test" src="" />)
+
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('src=""')
+  })
+
+  it('renders no <img> for a whitespace-only src', () => {
+    const html = renderToStaticMarkup(<Image alt="test" src="   " />)
+
+    expect(html).not.toContain('<img')
+  })
+
+  it('still shows the placeholder overlay so layout is preserved', () => {
+    const html = renderToStaticMarkup(<Image alt="test" src="" />)
+
+    // The loading/placeholder overlay fills the container in the absence of an image.
+    expect(html).toContain('absolute inset-0')
+  })
+
+  it('does not emit src="" for a blank src inside a lightbox trigger', () => {
+    const html = renderToStaticMarkup(
+      <LightboxProvider>
+        <Image alt="A sunrise" aspectRatio="video" lightboxGroup="g1" src="" />
+      </LightboxProvider>,
+    )
+
+    expect(html).not.toContain('src=""')
+    expect(html).not.toContain('<img')
+  })
+})
+
 describe('<Image> forceAspectRatio', () => {
   it('constrains to a fixed-ratio box by default (aspect class on container, img fills it)', () => {
     const html = renderToStaticMarkup(<Image alt="test" aspectRatio="video" src={CF_URL} />)

--- a/components/atoms/Image/Image.tsx
+++ b/components/atoms/Image/Image.tsx
@@ -285,6 +285,13 @@ export function Image({
     onError?.(e)
   }
 
+  // An empty `src` must never reach the <img>: the browser treats src="" as a
+  // request for the current page URL (re-downloading the whole document) and
+  // React warns about it. This happens when a caller threads an unpopulated CMS
+  // image field (e.g. a bare/absent relationship) straight through. Treat a
+  // blank src as a missing image — skip the <img> and let the placeholder show.
+  const hasSrc = typeof imageSrc === 'string' && imageSrc.trim() !== ''
+
   // `aspectRatioStyles` is '' unless boxed, so one literal covers both cases.
   const containerClasses = `relative ${aspectRatioStyles} ${roundedStyles} overflow-hidden`
 
@@ -300,14 +307,18 @@ export function Image({
           overlay to the raw image and anchor it top-left, overflowing/clipping
           instead of matching the rendered image box. The <img>'s own width/height
           attributes reserve layout space and prevent shift. */}
-      {showLoading && (isLoading || hasError) && (
-        <Placeholder animate={!hasError} className="absolute inset-0" variant={placeholderVariant}>
+      {showLoading && (isLoading || hasError || !hasSrc) && (
+        <Placeholder
+          animate={!hasError && hasSrc}
+          className="absolute inset-0"
+          variant={placeholderVariant}
+        >
           {hasError && <Icon icon={ExclamationCircleIcon} size="lg" />}
         </Placeholder>
       )}
 
-      {/* Image element (hidden until loaded, not rendered on error) */}
-      {!hasError && (
+      {/* Image element (hidden until loaded; skipped on error or a blank src) */}
+      {!hasError && hasSrc && (
         <img
           ref={imgRef}
           alt={alt}


### PR DESCRIPTION
## Summary

Resolves the console warning on `/classes-near-me` (and any page with an unpopulated CMS image):

```
Image.tsx:311 An empty string ("") was passed to the src attribute...
```

The `Image` atom rendered `<img src={imageSrc}>` unconditionally, so when a caller threaded an unpopulated CMS image field through as `""`, the browser received `src=""` — which it treats as a request for the current page URL (re-downloading the whole document), and React warns about it.

## Root cause (confirmed with evidence)

- The server-rendered HTML for `/classes-near-me` contains exactly **one** `<img>` (the valid `ContentTextBox` hero). The offending empty-src images are **client-only and transient** — they render during hydration, warn, then unmount within milliseconds, so the stable DOM never contains them (verified by sampling the live DOM over time in a headless browser).
- The defect and its fix are unambiguous regardless of the elusive trigger: this is exactly the case React's message tells you to handle — *"either do not render the element at all or pass null to src instead of an empty string."*

## The fix

In `components/atoms/Image/Image.tsx`, treat a blank/whitespace `src` as a missing image:
- Skip the `<img>` entirely so `src=""` is never committed to the DOM.
- Keep the placeholder overlay (static, not shimmering) so layout is preserved.

This is a defensive **atom-level** guard, so it protects every call site — including latent empty-string paths like `MeditationTemplate.tsx` (`thumbnailURL: populatedImageUrl(...) || ''`) feeding the AudioPlayer/MusicLibrary `<Image>`.

Valid images are unchanged.

## Tests

- Adds 4 tests covering empty and whitespace-only `src` (no `<img>`, never emits `src=""`, placeholder preserved, safe inside a lightbox trigger).
- Full suite green: **287 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)