### PR TITLE
feat(content-index): client-side filtering + MusicLibrary songs

### DIFF
--- a/components/molecules/ContentCard/ContentCard.test.tsx
+++ b/components/molecules/ContentCard/ContentCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ContentCard } from './ContentCard'
+
+/** Class attribute of the outer <article> (where fadeInOnLoad opacity lives). */
+function articleClass(html: string): string {
+  return (html.match(/<article[^>]*class="([^"]*)"/) || [])[1] ?? ''
+}
+
+describe('ContentCard fadeInOnLoad visibility', () => {
+  it('stays visible when there is no image to load (no <img> → onLoad never fires)', () => {
+    const cls = articleClass(
+      renderToStaticMarkup(<ContentCard fadeInOnLoad href="#" thumbnailSrc="" title="No image" />),
+    )
+
+    expect(cls).toContain('opacity-100')
+    expect(cls).not.toContain('opacity-0')
+  })
+
+  it('starts hidden (opacity-0) when an image will load and can fade in', () => {
+    const cls = articleClass(
+      renderToStaticMarkup(
+        <ContentCard
+          fadeInOnLoad
+          href="#"
+          thumbnailSrc="https://imagedelivery.net/acct/img/"
+          title="Has image"
+        />,
+      ),
+    )
+
+    expect(cls).toContain('opacity-0')
+  })
+
+  it('applies no opacity gating without fadeInOnLoad', () => {
+    const cls = articleClass(
+      renderToStaticMarkup(<ContentCard href="#" thumbnailSrc="" title="Plain" />),
+    )
+
+    expect(cls).not.toContain('opacity-0')
+    expect(cls).not.toContain('transition-opacity duration-500')
+  })
+})

--- a/components/molecules/ContentCard/ContentCard.test.tsx
+++ b/components/molecules/ContentCard/ContentCard.test.tsx
@@ -17,6 +17,17 @@ describe('ContentCard fadeInOnLoad visibility', () => {
     expect(cls).not.toContain('opacity-0')
   })
 
+  it('renders a branded 16:9 fallback (Placeholder + white Logo, no <img>) when imageless', () => {
+    const html = renderToStaticMarkup(<ContentCard href="#" thumbnailSrc="" title="No image" />)
+
+    expect(html).not.toContain('<img') // no image element for a blank src
+    expect(html).toContain('aspect-video') // fixed 16:9 fallback box
+    expect(html).toContain('from-teal-100') // coloured (primary) Placeholder gradient
+    expect(html).not.toContain('animate-shimmer') // non-animated
+    expect(html).toContain('<svg') // the centered Logo
+    expect(html).toContain('text-white') // white logo
+  })
+
   it('starts hidden (opacity-0) when an image will load and can fade in', () => {
     const cls = articleClass(
       renderToStaticMarkup(

--- a/components/molecules/ContentCard/ContentCard.tsx
+++ b/components/molecules/ContentCard/ContentCard.tsx
@@ -4,6 +4,8 @@ import { Image } from '../../atoms/Image/Image'
 import { Link } from '../../atoms/Link'
 import { Button } from '../../atoms/Button/Button'
 import { Badge } from '../../atoms/Badge/Badge'
+import { Placeholder } from '../../atoms/Placeholder/Placeholder'
+import { Logo } from '../../atoms/graphics/Logo/Logo'
 import type { AspectRatio } from '../../../lib/cloudflare-images'
 
 export interface ContentCardProps extends Omit<ComponentProps<'article'>, 'title'> {
@@ -191,15 +193,25 @@ export function ContentCard({
     >
       {/* Thumbnail with optional play button overlay */}
       <div className="relative">
-        <Image
-          alt={thumbnailAlt || title}
-          aspectRatio={imageHeight ? undefined : aspectRatio}
-          className={`transition-opacity duration-200 group-hover:opacity-90 ${imageHeight ? `${imageHeight} w-auto` : ''}`}
-          objectFit="cover"
-          src={thumbnailSrc}
-          onError={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
-          onLoad={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
-        />
+        {hasImageSrc ? (
+          <Image
+            alt={thumbnailAlt || title}
+            aspectRatio={imageHeight ? undefined : aspectRatio}
+            className={`transition-opacity duration-200 group-hover:opacity-90 ${imageHeight ? `${imageHeight} w-auto` : ''}`}
+            objectFit="cover"
+            src={thumbnailSrc}
+            onError={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
+            onLoad={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
+          />
+        ) : (
+          // No CMS thumbnail — a branded, non-animated fallback beats a blank
+          // card. Fixed 16:9 box so imageless cards read consistently in the grid.
+          <div className="relative aspect-video overflow-hidden rounded-xs">
+            <Placeholder animate={false} variant="primary">
+              <Logo className="text-white" size="xl" variant="icon" />
+            </Placeholder>
+          </div>
+        )}
 
         {/* Play button overlay */}
         {showPlayButton && (

--- a/components/molecules/ContentCard/ContentCard.tsx
+++ b/components/molecules/ContentCard/ContentCard.tsx
@@ -154,7 +154,11 @@ export function ContentCard({
   className = '',
   ...props
 }: ContentCardProps) {
-  const [imageLoaded, setImageLoaded] = useState(false)
+  // A card with no loadable image renders a placeholder, not an <img>, so its
+  // onLoad never fires — under fadeInOnLoad that would leave the card stuck at
+  // opacity-0 (invisible). Start "loaded" when there's no image src to wait for.
+  const hasImageSrc = thumbnailSrc.length > 0
+  const [imageLoaded, setImageLoaded] = useState(!hasImageSrc)
   const showPlayButton = playButton
   const isHeroVariant = variant === 'hero'
 
@@ -193,6 +197,7 @@ export function ContentCard({
           className={`transition-opacity duration-200 group-hover:opacity-90 ${imageHeight ? `${imageHeight} w-auto` : ''}`}
           objectFit="cover"
           src={thumbnailSrc}
+          onError={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
           onLoad={fadeInOnLoad ? () => setImageLoaded(true) : undefined}
         />
 

--- a/components/molecules/ContentGrid/ContentGrid.tsx
+++ b/components/molecules/ContentGrid/ContentGrid.tsx
@@ -61,9 +61,9 @@ export function ContentGrid({
   items,
   cardVariant = 'default',
   breakpointCols = {
-    default: 3,  // Desktop: 3 columns (1024px+)
-    1023: 2,     // Tablet: 2 columns (640px - 1023px)
-    639: 1,      // Mobile: 1 column (< 640px)
+    default: 3, // Desktop: 3 columns (1024px+)
+    1023: 2, // Tablet: 2 columns (640px - 1023px)
+    639: 1, // Mobile: 1 column (< 640px)
   },
   className = '',
   ...props
@@ -73,24 +73,30 @@ export function ContentGrid({
   // Hero: 24px mobile, 30px tablet, 36px desktop (50% larger)
   const isHero = cardVariant === 'hero'
   const gapClasses = isHero
-    ? '-ml-6 sm:-ml-[1.875rem] lg:-ml-9'  // 24px, 30px, 36px
-    : '-ml-4 sm:-ml-5 lg:-ml-6'           // 16px, 20px, 24px
+    ? '-ml-6 sm:-ml-[1.875rem] lg:-ml-9' // 24px, 30px, 36px
+    : '-ml-4 sm:-ml-5 lg:-ml-6' // 16px, 20px, 24px
   const columnGapClasses = isHero
-    ? 'pl-6 sm:pl-[1.875rem] lg:pl-9'     // 24px, 30px, 36px
-    : 'pl-4 sm:pl-5 lg:pl-6'              // 16px, 20px, 24px
+    ? 'pl-6 sm:pl-[1.875rem] lg:pl-9' // 24px, 30px, 36px
+    : 'pl-4 sm:pl-5 lg:pl-6' // 16px, 20px, 24px
 
   return (
-    <div className={`flex justify-center w-full ${className}`} {...props}>
+    // The Masonry must FILL this wrapper, not be a shrink-to-fit flex child:
+    // react-masonry-css sizes each column to 100%/columns, so a content-collapsed
+    // container makes columns (and their cards) collapse to the cards' min-content
+    // (e.g. the title). A plain block wrapper + w-full Masonry keeps columns at a
+    // consistent fraction of the available width regardless of item count.
+    <div className={`w-full ${className}`} {...props}>
       <Masonry
         breakpointCols={breakpointCols}
-        className={`flex ${gapClasses} max-w-full`}
+        className={`flex ${gapClasses} w-full`}
         columnClassName={`${columnGapClasses} bg-clip-padding`}
       >
         {items.map((item) => {
           const { id, ...cardProps } = item
+
           return (
             <div key={id} className="mb-8 flex justify-center">
-              <ContentCard {...cardProps} variant={cardVariant} fadeInOnLoad={true} />
+              <ContentCard {...cardProps} fadeInOnLoad={true} variant={cardVariant} />
             </div>
           )
         })}

--- a/components/organisms/ContentIndex/ContentIndex.stories.tsx
+++ b/components/organisms/ContentIndex/ContentIndex.stories.tsx
@@ -1,0 +1,72 @@
+import type { Story, StoryDefault } from '@ladle/react'
+import { ContentIndex } from './ContentIndex'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+import { StoryWrapper, StorySection } from '../../ladle'
+
+export default {
+  title: 'Organisms',
+} satisfies StoryDefault
+
+const WISDOM = { id: 'wisdom', label: 'Wisdom' }
+const LIFESTYLE = { id: 'lifestyle', label: 'Lifestyle' }
+const TECHNIQUE = { id: 'technique', label: 'Technique' }
+
+const card = (
+  id: number,
+  title: string,
+  seed: string,
+  tags?: { id: string; label: string }[],
+): ResolvedCardItem => ({
+  id,
+  title,
+  href: '#',
+  thumbnailSrc: `https://picsum.photos/seed/${seed}/600/400`,
+  aspectRatio: '3-2',
+  tags,
+})
+
+const tagged: ResolvedCardItem[] = [
+  card(1, 'What Is Meditation?', 'ci-wisdom-1', [WISDOM]),
+  card(2, 'A Balanced Daily Routine', 'ci-life-1', [LIFESTYLE]),
+  card(3, 'The Kundalini Awakening', 'ci-wisdom-2', [WISDOM, TECHNIQUE]),
+  card(4, 'Mindful Mornings', 'ci-life-2', [LIFESTYLE]),
+  card(5, 'The Three Channels', 'ci-tech-1', [TECHNIQUE]),
+  card(6, 'Inner Silence', 'ci-wisdom-3', [WISDOM]),
+]
+
+const untagged: ResolvedCardItem[] = [
+  card(1, 'Introduction', 'ci-plain-1'),
+  card(2, 'Getting Started', 'ci-plain-2'),
+  card(3, 'Next Steps', 'ci-plain-3'),
+]
+
+/**
+ * ContentIndex organism — a server-resolved card grid that the visitor filters
+ * client-side with multi-select pills. Toggle the pills to narrow the grid; the
+ * "All" pill clears the selection.
+ */
+export const Default: Story = () => (
+  <StoryWrapper>
+    <StorySection
+      description="Facets are derived from the items' own tags. Multi-select (OR); the 'All' pill resets."
+      title="With filter pills"
+    >
+      <ContentIndex items={tagged} />
+    </StorySection>
+
+    <StorySection
+      description="When no item carries tags (e.g. today's lecture feed), the pill row is omitted and it degrades to a plain grid."
+      title="No facets"
+    >
+      <ContentIndex items={untagged} />
+    </StorySection>
+
+    <StorySection description="An empty list renders nothing (no pills, no grid)." title="Empty">
+      <ContentIndex items={[]} />
+    </StorySection>
+
+    <div />
+  </StoryWrapper>
+)
+
+Default.storyName = 'Content Index'

--- a/components/organisms/ContentIndex/ContentIndex.test.tsx
+++ b/components/organisms/ContentIndex/ContentIndex.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ContentIndex, deriveFacets, filterByFacets } from './ContentIndex'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+
+const item = (
+  id: number,
+  title: string,
+  tags?: { id: string; label: string }[],
+): ResolvedCardItem => ({
+  id,
+  title,
+  href: `#${id}`,
+  thumbnailSrc: `https://picsum.photos/seed/${id}/400/400`,
+  tags,
+})
+
+const WISDOM = { id: 'wisdom', label: 'Wisdom' }
+const LIFESTYLE = { id: 'lifestyle', label: 'Lifestyle' }
+
+const items: ResolvedCardItem[] = [
+  item(1, 'Alpha', [WISDOM]),
+  item(2, 'Beta', [LIFESTYLE]),
+  item(3, 'Gamma', [WISDOM, LIFESTYLE]),
+  item(4, 'Delta'), // untagged
+]
+
+describe('deriveFacets', () => {
+  it('collects unique facets in first-appearance order (first label wins)', () => {
+    expect(deriveFacets(items)).toEqual([WISDOM, LIFESTYLE])
+  })
+
+  it('dedupes by id even when a later label differs', () => {
+    const facets = deriveFacets([
+      item(1, 'A', [{ id: 'wisdom', label: 'Wisdom' }]),
+      item(2, 'B', [{ id: 'wisdom', label: 'Other' }]),
+    ])
+
+    expect(facets).toEqual([{ id: 'wisdom', label: 'Wisdom' }])
+  })
+
+  it('returns [] when no item carries tags', () => {
+    expect(deriveFacets([item(1, 'A'), item(2, 'B')])).toEqual([])
+  })
+})
+
+describe('filterByFacets', () => {
+  it('returns everything when the selection is empty', () => {
+    expect(filterByFacets(items, new Set())).toHaveLength(4)
+  })
+
+  it('narrows to items intersecting a single facet', () => {
+    const titles = filterByFacets(items, new Set(['wisdom'])).map((i) => i.title)
+
+    expect(titles).toEqual(['Alpha', 'Gamma'])
+  })
+
+  it('is OR across multiple selected facets', () => {
+    const titles = filterByFacets(items, new Set(['wisdom', 'lifestyle'])).map((i) => i.title)
+
+    expect(titles).toEqual(['Alpha', 'Beta', 'Gamma'])
+  })
+})
+
+describe('ContentIndex (SSR markup)', () => {
+  it('renders an "All" pill plus one pill per facet, with "All" pressed by default', () => {
+    const html = renderToStaticMarkup(<ContentIndex items={items} />)
+
+    expect(html).toContain('>All<')
+    expect(html).toContain('>Wisdom<')
+    expect(html).toContain('>Lifestyle<')
+    // First render: "All" is active (aria-pressed="true"), facets are not.
+    expect(html).toContain('aria-pressed="true"')
+    expect(html).toContain('aria-pressed="false"')
+  })
+
+  it('renders every card on first render (SSR shows the full, SEO-friendly list)', () => {
+    const html = renderToStaticMarkup(<ContentIndex items={items} />)
+
+    for (const title of ['Alpha', 'Beta', 'Gamma', 'Delta']) {
+      expect(html).toContain(title)
+    }
+  })
+
+  it('renders no filter pill row when no item carries tags', () => {
+    const html = renderToStaticMarkup(<ContentIndex items={[item(1, 'Alpha'), item(2, 'Beta')]} />)
+
+    expect(html).not.toContain('Filter content by tag')
+    expect(html).toContain('Alpha')
+  })
+
+  it('renders without crashing on an empty list', () => {
+    expect(() => renderToStaticMarkup(<ContentIndex items={[]} />)).not.toThrow()
+  })
+})

--- a/components/organisms/ContentIndex/ContentIndex.tsx
+++ b/components/organisms/ContentIndex/ContentIndex.tsx
@@ -44,6 +44,13 @@ export function filterByFacets(
 const PILL_BASE =
   'inline-flex items-center justify-center min-h-11 min-w-11 px-4 py-2 rounded-full text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2'
 
+/** Pill classes for the given active state (teal when active, muted otherwise). */
+function pillClassName(active: boolean): string {
+  return `${PILL_BASE} ${
+    active ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+  }`
+}
+
 interface FilterPillsProps {
   facets: Facet[]
   /** Selected facet ids; empty means "All". */
@@ -68,9 +75,7 @@ function FilterPills({ facets, selected, onToggle, onClear }: FilterPillsProps) 
     >
       <button
         aria-pressed={allActive}
-        className={`${PILL_BASE} ${
-          allActive ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-        }`}
+        className={pillClassName(allActive)}
         type="button"
         onClick={onClear}
       >
@@ -83,9 +88,7 @@ function FilterPills({ facets, selected, onToggle, onClear }: FilterPillsProps) 
           <button
             key={facet.id}
             aria-pressed={active}
-            className={`${PILL_BASE} ${
-              active ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            }`}
+            className={pillClassName(active)}
             type="button"
             onClick={() => onToggle(facet.id)}
           >
@@ -125,12 +128,13 @@ export function ContentIndex({ items, className = '' }: ContentIndexProps) {
 
   const clear = () => setSelected(new Set())
 
-  // Narrow to items whose tags intersect the selection (OR); empty selection
-  // shows everything.
-  const visible = useMemo(() => filterByFacets(items, selected), [items, selected])
-
-  // Strip `tags` before the grid — ContentCard forwards unknown props to the DOM.
-  const gridItems = useMemo(() => visible.map(({ tags: _tags, ...card }) => card), [visible])
+  // Narrow to items whose tags intersect the selection (OR; empty selection
+  // shows everything), then strip `tags` — ContentCard forwards unknown props
+  // to the DOM.
+  const gridItems = useMemo(
+    () => filterByFacets(items, selected).map(({ tags: _tags, ...card }) => card),
+    [items, selected],
+  )
 
   return (
     <div className={className}>

--- a/components/organisms/ContentIndex/ContentIndex.tsx
+++ b/components/organisms/ContentIndex/ContentIndex.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from 'react'
+import { ContentGrid } from '../../molecules'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+
+export interface ContentIndexProps {
+  /** Server-resolved cards. Each item's `tags` drive the filter pills. */
+  items: ResolvedCardItem[]
+  className?: string
+}
+
+/** A filter facet — the id is matched against an item's `tags`. */
+export type Facet = { id: string; label: string }
+
+/** Unique facets across all items, in first-appearance order (first label wins). */
+export function deriveFacets(items: ResolvedCardItem[]): Facet[] {
+  const seen = new Map<string, string>()
+
+  for (const item of items) {
+    for (const tag of item.tags ?? []) {
+      if (!seen.has(tag.id)) {
+        seen.set(tag.id, tag.label)
+      }
+    }
+  }
+
+  return Array.from(seen, ([id, label]) => ({ id, label }))
+}
+
+/**
+ * Narrow items to those whose tags intersect the selected facet ids (OR). An
+ * empty selection returns every item unchanged.
+ */
+export function filterByFacets(
+  items: ResolvedCardItem[],
+  selected: Set<string>,
+): ResolvedCardItem[] {
+  if (selected.size === 0) {
+    return items
+  }
+
+  return items.filter((item) => (item.tags ?? []).some((tag) => selected.has(tag.id)))
+}
+
+const PILL_BASE =
+  'inline-flex items-center justify-center min-h-11 min-w-11 px-4 py-2 rounded-full text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2'
+
+interface FilterPillsProps {
+  facets: Facet[]
+  /** Selected facet ids; empty means "All". */
+  selected: Set<string>
+  onToggle: (id: string) => void
+  onClear: () => void
+}
+
+/**
+ * Filter pill row: an "All" pill plus one toggle per facet. Multi-select with OR
+ * semantics; "All" clears the selection. Kept internal — extract a reusable
+ * `FilterPills` molecule only when a second consumer appears.
+ */
+function FilterPills({ facets, selected, onToggle, onClear }: FilterPillsProps) {
+  const allActive = selected.size === 0
+
+  return (
+    <div
+      aria-label="Filter content by tag"
+      className="flex flex-wrap justify-center gap-2 mb-6"
+      role="group"
+    >
+      <button
+        aria-pressed={allActive}
+        className={`${PILL_BASE} ${
+          allActive ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+        }`}
+        type="button"
+        onClick={onClear}
+      >
+        All
+      </button>
+      {facets.map((facet) => {
+        const active = selected.has(facet.id)
+
+        return (
+          <button
+            key={facet.id}
+            aria-pressed={active}
+            className={`${PILL_BASE} ${
+              active ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+            type="button"
+            onClick={() => onToggle(facet.id)}
+          >
+            {facet.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * ContentIndex organism — a filterable card grid for `pages` / `lectures`
+ * content-index blocks. The full list is resolved server-side (SEO-friendly);
+ * the visitor narrows it client-side with multi-select filter pills derived from
+ * the items' own tags. Renders as a plain grid when no facets are present.
+ *
+ * SSR renders every card (pure `useState`, no `ClientOnly`); hydration wires up
+ * the pill toggles.
+ */
+export function ContentIndex({ items, className = '' }: ContentIndexProps) {
+  const facets = useMemo(() => deriveFacets(items), [items])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+
+      return next
+    })
+
+  const clear = () => setSelected(new Set())
+
+  // Narrow to items whose tags intersect the selection (OR); empty selection
+  // shows everything.
+  const visible = useMemo(() => filterByFacets(items, selected), [items, selected])
+
+  // Strip `tags` before the grid — ContentCard forwards unknown props to the DOM.
+  const gridItems = useMemo(() => visible.map(({ tags: _tags, ...card }) => card), [visible])
+
+  return (
+    <div className={className}>
+      {facets.length > 0 && (
+        <FilterPills facets={facets} selected={selected} onClear={clear} onToggle={toggle} />
+      )}
+      <ContentGrid items={gridItems} />
+    </div>
+  )
+}

--- a/components/organisms/ContentIndex/ContentIndex.tsx
+++ b/components/organisms/ContentIndex/ContentIndex.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { Button } from '../../atoms'
 import { ContentGrid } from '../../molecules'
 import type { ResolvedCardItem } from '../../../lib/cms-blocks'
 
@@ -41,16 +42,6 @@ export function filterByFacets(
   return items.filter((item) => (item.tags ?? []).some((tag) => selected.has(tag.id)))
 }
 
-const PILL_BASE =
-  'inline-flex items-center justify-center min-h-11 min-w-11 px-4 py-2 rounded-full text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2'
-
-/** Pill classes for the given active state (teal when active, muted otherwise). */
-function pillClassName(active: boolean): string {
-  return `${PILL_BASE} ${
-    active ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-  }`
-}
-
 interface FilterPillsProps {
   facets: Facet[]
   /** Selected facet ids; empty means "All". */
@@ -59,43 +50,51 @@ interface FilterPillsProps {
   onClear: () => void
 }
 
+/** A toggle pill built on the Button atom (square, primary when active).
+ * `min-h-11` keeps the ≥44px touch target the `sm` size alone doesn't guarantee. */
+function Pill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: string
+}) {
+  return (
+    <Button
+      aria-pressed={active}
+      className="min-h-11"
+      shape="square"
+      size="sm"
+      variant={active ? 'primary' : 'ghost'}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  )
+}
+
 /**
  * Filter pill row: an "All" pill plus one toggle per facet. Multi-select with OR
  * semantics; "All" clears the selection. Kept internal — extract a reusable
  * `FilterPills` molecule only when a second consumer appears.
  */
 function FilterPills({ facets, selected, onToggle, onClear }: FilterPillsProps) {
-  const allActive = selected.size === 0
-
   return (
     <div
       aria-label="Filter content by tag"
       className="flex flex-wrap justify-center gap-2 mb-6"
       role="group"
     >
-      <button
-        aria-pressed={allActive}
-        className={pillClassName(allActive)}
-        type="button"
-        onClick={onClear}
-      >
+      <Pill active={selected.size === 0} onClick={onClear}>
         All
-      </button>
-      {facets.map((facet) => {
-        const active = selected.has(facet.id)
-
-        return (
-          <button
-            key={facet.id}
-            aria-pressed={active}
-            className={pillClassName(active)}
-            type="button"
-            onClick={() => onToggle(facet.id)}
-          >
-            {facet.label}
-          </button>
-        )
-      })}
+      </Pill>
+      {facets.map((facet) => (
+        <Pill key={facet.id} active={selected.has(facet.id)} onClick={() => onToggle(facet.id)}>
+          {facet.label}
+        </Pill>
+      ))}
     </div>
   )
 }

--- a/components/organisms/ContentIndex/index.ts
+++ b/components/organisms/ContentIndex/index.ts
@@ -1,0 +1,2 @@
+export { ContentIndex } from './ContentIndex'
+export type { ContentIndexProps } from './ContentIndex'

--- a/components/organisms/RichText/RichText.test.tsx
+++ b/components/organisms/RichText/RichText.test.tsx
@@ -192,15 +192,15 @@ describe('<RichText>', () => {
         content={editorState([
           {
             type: 'relationship',
-            relationTo: 'lectures',
-            value: { id: 3, title: 'A Lecture' },
+            relationTo: 'app-cards',
+            value: { id: 3, title: 'An App Card' },
             version: 1,
           },
         ])}
       />,
     )
 
-    expect(html).toContain('A Lecture')
+    expect(html).toContain('An App Card')
     expect(html).not.toContain('<a')
   })
 
@@ -458,8 +458,10 @@ describe('<RichText>', () => {
                 relationTo: 'pages',
                 value: { id: 2, slug: 'about', title: 'About Sahaja', meta: { image: img() } },
               },
-              // Lectures have no public route yet → dropped.
+              // Lectures are routable now → rendered as /lectures/:id.
               { relationTo: 'lectures', value: { id: 3, title: 'A Lecture', thumbnail: img() } },
+              // App-cards have no public route → dropped.
+              { relationTo: 'app-cards', value: { id: 8, title: 'An App Card', thumbnail: img() } },
             ],
           }),
         ])}
@@ -470,7 +472,9 @@ describe('<RichText>', () => {
     expect(html).toContain('href="/meditations/5"')
     expect(html).toContain('About Sahaja')
     expect(html).toContain('href="/about"')
-    expect(html).not.toContain('A Lecture')
+    expect(html).toContain('A Lecture')
+    expect(html).toContain('href="/lectures/3"')
+    expect(html).not.toContain('An App Card')
   })
 
   it('renders a subtle-system block, mapping page relationships to SVG node ids', () => {

--- a/components/organisms/RichText/blockConverters.test.tsx
+++ b/components/organisms/RichText/blockConverters.test.tsx
@@ -76,3 +76,29 @@ describe('textbox block converter — routing', () => {
     expect(textbox({ node: { fields: { image: 123, title: 'Orphan' } } })).toBeNull()
   })
 })
+
+// Every block defined for `pages.content` upstream. Adding a block in the CMS
+// without a converter here should fail this test rather than silently fall
+// through to RichText's `unknown` fallback at runtime.
+const KNOWN_BLOCK_TYPES = [
+  'textbox',
+  'quote',
+  'button',
+  'image-gallery',
+  'layout',
+  'table-of-contents',
+  'showcase',
+  'subtle-system',
+  'splash',
+  'content-index',
+] as const
+
+describe('block coverage', () => {
+  it.each(KNOWN_BLOCK_TYPES)('has a converter function for the %s block', (blockType) => {
+    expect(typeof blockConverters[blockType]).toBe('function')
+  })
+
+  it('defines no converters beyond the known block types (spot stale keys)', () => {
+    expect(Object.keys(blockConverters).sort()).toEqual([...KNOWN_BLOCK_TYPES].sort())
+  })
+})

--- a/components/organisms/RichText/blockConverters.test.tsx
+++ b/components/organisms/RichText/blockConverters.test.tsx
@@ -139,16 +139,26 @@ describe('content-index block converter — dispatch', () => {
     expect(html).not.toContain('Filter content by tag') // no facets → no pill row
   })
 
-  it('meditations → static grid (no filter pills)', () => {
+  it('meditations → ContentIndex with user-choice pills', () => {
     const html = renderToStaticMarkup(
       convertCI({
         type: 'meditations',
-        resolvedItems: [{ ...CARD, id: 5, href: '/meditations/5', playButton: true }],
+        resolvedItems: [
+          {
+            ...CARD,
+            id: 5,
+            title: 'Feel Calm',
+            href: '/meditations/5',
+            playButton: true,
+            tags: [{ id: '25', label: '5 min' }],
+          },
+        ],
       }),
     )
 
-    expect(html).toContain('grid-cols-2')
-    expect(html).not.toContain('Filter content by tag')
+    expect(html).toContain('Filter content by tag') // user-choices → filter pills
+    expect(html).toContain('>5 min<')
+    expect(html).toContain('/meditations/5')
   })
 
   it('songs → MusicLibrary with tracks + music-tag filters', () => {

--- a/components/organisms/RichText/blockConverters.test.tsx
+++ b/components/organisms/RichText/blockConverters.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactElement } from 'react'
+import { MusicalNoteIcon } from '@heroicons/react/24/outline'
 import { blockConverters } from './blockConverters'
+import { MusicLibrary, type MusicFilter } from '../MusicLibrary'
+import type { Track } from '../../molecules'
 
 // The converter only reads `node.fields`; the other JSXConverter args are
 // unused, so narrow to the minimal callable shape this test exercises.
@@ -92,6 +95,99 @@ const KNOWN_BLOCK_TYPES = [
   'splash',
   'content-index',
 ] as const
+
+// The content-index converter reads `node.fields`; narrow to the callable shape.
+type CIConverter = (args: { node: { fields: Record<string, unknown> } }) => ReactElement | null
+
+const contentIndex = blockConverters['content-index'] as unknown as CIConverter
+
+function convertCI(fields: Record<string, unknown>) {
+  return contentIndex({ node: { fields: { blockType: 'content-index', ...fields } } })
+}
+
+const CARD = {
+  id: 1,
+  title: 'What Is Meditation?',
+  href: '/what-is-meditation',
+  thumbnailSrc: 'https://picsum.photos/seed/x/600/400',
+}
+
+describe('content-index block converter — dispatch', () => {
+  it('pages → ContentIndex (filter pills + cards)', () => {
+    const html = renderToStaticMarkup(
+      convertCI({
+        type: 'pages',
+        resolvedItems: [{ ...CARD, tags: [{ id: 'wisdom', label: 'Wisdom' }] }],
+      }),
+    )
+
+    expect(html).toContain('Filter content by tag')
+    expect(html).toContain('>Wisdom<')
+    expect(html).toContain('What Is Meditation?')
+  })
+
+  it('lectures → ContentIndex cards linking to /lectures/:id (no pills without facets)', () => {
+    const html = renderToStaticMarkup(
+      convertCI({
+        type: 'lectures',
+        resolvedItems: [{ ...CARD, id: 7, title: 'A Lecture', href: '/lectures/7' }],
+      }),
+    )
+
+    expect(html).toContain('/lectures/7')
+    expect(html).toContain('A Lecture')
+    expect(html).not.toContain('Filter content by tag') // no facets → no pill row
+  })
+
+  it('meditations → static grid (no filter pills)', () => {
+    const html = renderToStaticMarkup(
+      convertCI({
+        type: 'meditations',
+        resolvedItems: [{ ...CARD, id: 5, href: '/meditations/5', playButton: true }],
+      }),
+    )
+
+    expect(html).toContain('grid-cols-2')
+    expect(html).not.toContain('Filter content by tag')
+  })
+
+  it('songs → MusicLibrary with tracks + music-tag filters', () => {
+    const el = convertCI({
+      type: 'songs',
+      resolvedTracks: [
+        {
+          url: 'https://cdn/a.mp3',
+          title: 'Raga',
+          credit: 'X',
+          creditURL: '',
+          thumbnailURL: '',
+          duration: 0,
+          tags: ['vocals'],
+        },
+      ],
+    })
+
+    // Inspect the element tree rather than rendering the whole MusicLibrary /
+    // AudioPlayer subtree — this test only asserts the dispatch + filter derivation.
+    const wrapper = el as ReactElement<{
+      children: ReactElement<{ tracks: Track[]; filters: MusicFilter[] }>
+    }>
+    const library = wrapper.props.children
+
+    expect(library.type).toBe(MusicLibrary)
+    expect(library.props.tracks).toHaveLength(1)
+    expect(library.props.filters.map((f) => ({ id: f.id, label: f.label }))).toEqual([
+      { id: 'vocals', label: 'Vocals' },
+    ])
+    expect(library.props.filters[0].icon).toBe(MusicalNoteIcon)
+  })
+
+  it('renders nothing for empty / unresolved lists', () => {
+    expect(convertCI({ type: 'pages', resolvedItems: [] })).toBeNull()
+    expect(convertCI({ type: 'songs', resolvedTracks: [] })).toBeNull()
+    expect(convertCI({ type: 'pages' })).toBeNull()
+  })
+})
 
 describe('block coverage', () => {
   it.each(KNOWN_BLOCK_TYPES)('has a converter function for the %s block', (blockType) => {

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -367,7 +367,15 @@ export const blockConverters: BlockConverters = {
       )
     }
 
-    // Pages / lectures → filterable grid with facet pills.
-    return <ContentIndex className={BLOCK_SPACING} items={items} />
+    // Pages / lectures → filterable grid with facet pills. Break out of the prose
+    // column to the wider content Container (xl / 6xl), like ContentTextBox, so the
+    // grid has more room; the full-bleed wrapper owns the vertical spacing.
+    return (
+      <div className={FULL_BLEED_BLOCK}>
+        <Container maxWidth="xl">
+          <ContentIndex items={items} />
+        </Container>
+      </div>
+    )
   },
 }

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -13,7 +13,6 @@ import type { JSXConverters } from '@payloadcms/richtext-lexical/react'
 import { MusicalNoteIcon } from '@heroicons/react/24/outline'
 import { Button, Container, Image } from '../../atoms'
 import {
-  ContentCard,
   ContentCarousel,
   HeroQuote,
   LayoutBlock,
@@ -327,10 +326,10 @@ export const blockConverters: BlockConverters = {
 
   // content-index → the live list resolved server-side in `+data` (see
   // server/content-index.ts), dispatched by content type:
-  //   songs        → MusicLibrary (playback + its own tag filtering)
-  //   pages/lectures → ContentIndex (filterable card grid with pills)
-  //   meditations  → static card grid (deferred; no client filtering)
-  // Empty / unresolvable lists render nothing.
+  //   songs                    → MusicLibrary (playback + its own tag filtering)
+  //   pages/lectures/meditations → ContentIndex (filterable card grid with pills)
+  // Meditations resolve to user-choice categories flattened into meditation
+  // cards, with the categories as the filter pills. Empty lists render nothing.
   'content-index': ({ node }) => {
     const fields = node.fields as unknown as ContentIndexBlockFields
 
@@ -354,22 +353,9 @@ export const blockConverters: BlockConverters = {
       return null
     }
 
-    // Meditations keep the static grid (client filtering deferred). A plain grid
-    // fills the block width (unlike the centered masonry). `tags` is stripped —
-    // ContentCard forwards unknown props to the DOM.
-    if (fields.type === 'meditations') {
-      return (
-        <div className={`${BLOCK_SPACING} grid grid-cols-2 gap-4 lg:grid-cols-3`}>
-          {items.map(({ id, tags: _tags, ...card }) => (
-            <ContentCard key={id} {...card} />
-          ))}
-        </div>
-      )
-    }
-
-    // Pages / lectures → filterable grid with facet pills. Break out of the prose
-    // column to the wider content Container (xl / 6xl), like ContentTextBox, so the
-    // grid has more room; the full-bleed wrapper owns the vertical spacing.
+    // Filterable grid with facet pills. Break out of the prose column to the
+    // wider content Container (xl / 6xl), like ContentTextBox, so the grid has
+    // more room; the full-bleed wrapper owns the vertical spacing.
     return (
       <div className={FULL_BLEED_BLOCK}>
         <Container maxWidth="xl">

--- a/components/organisms/RichText/blockConverters.tsx
+++ b/components/organisms/RichText/blockConverters.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { JSXConverters } from '@payloadcms/richtext-lexical/react'
+import { MusicalNoteIcon } from '@heroicons/react/24/outline'
 import { Button, Container, Image } from '../../atoms'
 import {
   ContentCard,
@@ -17,9 +18,12 @@ import {
   HeroQuote,
   LayoutBlock,
   TableOfContents,
+  type Track,
 } from '../../molecules'
+import { ContentIndex } from '../ContentIndex'
 import { ContentOverlay } from '../ContentOverlay'
 import { ContentTextBox } from '../ContentTextBox'
+import { MusicLibrary, type MusicFilter } from '../MusicLibrary'
 import { OrnateTextBox } from '../OrnateTextBox'
 import { Splash } from '../Splash'
 import { SubtleSystem } from '../SubtleSystem'
@@ -66,6 +70,36 @@ export const BLOCK_SPACING = 'mx-auto my-6 clear-both'
  */
 export const FULL_BLEED_BLOCK = 'full-bleed my-6 clear-both'
 export const FULL_BLEED_SPLASH = 'full-bleed clear-both'
+
+/** Title-case a song-tag slug for a filter label ('wind-instruments' → 'Wind Instruments'). */
+function humanizeSlug(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+/**
+ * Build MusicLibrary filters from the unique song-tag slugs across the tracks.
+ * SongTag carries no icon, so every filter uses a single music glyph (the
+ * shared MusicLibrary/Playlist API takes a Heroicon per filter).
+ */
+function songMusicFilters(tracks: Track[]): MusicFilter[] {
+  const seen = new Set<string>()
+  const filters: MusicFilter[] = []
+
+  for (const track of tracks) {
+    for (const slug of track.tags ?? []) {
+      if (!seen.has(slug)) {
+        seen.add(slug)
+        filters.push({ id: slug, label: humanizeSlug(slug), icon: MusicalNoteIcon })
+      }
+    }
+  }
+
+  return filters
+}
 
 export const blockConverters: BlockConverters = {
   // textbox → one of three organisms by the block's mode:
@@ -291,23 +325,49 @@ export const blockConverters: BlockConverters = {
     )
   },
 
-  // content-index → responsive grid of the live list resolved server-side in
-  // `+data` (see server/content-index.ts). A plain grid fills the block width
-  // (unlike the centered masonry); empty/unresolvable lists render nothing.
+  // content-index → the live list resolved server-side in `+data` (see
+  // server/content-index.ts), dispatched by content type:
+  //   songs        → MusicLibrary (playback + its own tag filtering)
+  //   pages/lectures → ContentIndex (filterable card grid with pills)
+  //   meditations  → static card grid (deferred; no client filtering)
+  // Empty / unresolvable lists render nothing.
   'content-index': ({ node }) => {
     const fields = node.fields as unknown as ContentIndexBlockFields
+
+    if (fields.type === 'songs') {
+      const tracks = fields.resolvedTracks ?? []
+
+      if (tracks.length === 0) {
+        return null
+      }
+
+      return (
+        <div className={FULL_BLEED_BLOCK}>
+          <MusicLibrary filters={songMusicFilters(tracks)} tracks={tracks} />
+        </div>
+      )
+    }
+
     const items = fields.resolvedItems ?? []
 
     if (items.length === 0) {
       return null
     }
 
-    return (
-      <div className={`${BLOCK_SPACING} grid grid-cols-2 gap-4 lg:grid-cols-3`}>
-        {items.map(({ id, ...card }) => (
-          <ContentCard key={id} {...card} />
-        ))}
-      </div>
-    )
+    // Meditations keep the static grid (client filtering deferred). A plain grid
+    // fills the block width (unlike the centered masonry). `tags` is stripped —
+    // ContentCard forwards unknown props to the DOM.
+    if (fields.type === 'meditations') {
+      return (
+        <div className={`${BLOCK_SPACING} grid grid-cols-2 gap-4 lg:grid-cols-3`}>
+          {items.map(({ id, tags: _tags, ...card }) => (
+            <ContentCard key={id} {...card} />
+          ))}
+        </div>
+      )
+    }
+
+    // Pages / lectures → filterable grid with facet pills.
+    return <ContentIndex className={BLOCK_SPACING} items={items} />
   },
 }

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -73,3 +73,7 @@ export type { MeditationPlayerProps, Track, MeditationFrame } from './Meditation
 // RichText
 export { RichText } from './RichText'
 export type { RichTextProps } from './RichText'
+
+// ContentIndex
+export { ContentIndex } from './ContentIndex'
+export type { ContentIndexProps } from './ContentIndex'

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -164,6 +164,18 @@ describe('contentIndexCard', () => {
     ).toMatchObject({ href: '/lectures/7', playButton: false })
   })
 
+  it('uses the /for-audience feed thumbnailUrl string when there is no thumbnail relationship', () => {
+    const card = contentIndexCard(
+      { id: 7, title: 'Lecture', thumbnailUrl: 'https://img.example/mq.jpg' },
+      'lectures',
+    )
+
+    expect(card).toMatchObject({
+      href: '/lectures/7',
+      thumbnailSrc: 'https://img.example/mq.jpg',
+    })
+  })
+
   it('returns null when the doc has no id', () => {
     expect(contentIndexCard({ title: 'x' }, 'pages')).toBeNull()
   })

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -300,6 +300,18 @@ describe('meditationCardsFromUserChoices', () => {
     ])
   })
 
+  it('omits a sub-minute / zero duration rather than showing a "0 min" badge', () => {
+    const [subMinute] = meditationCardsFromUserChoices([
+      { id: 25, title: '5 min', morningMeditation: med({ duration: 20 }) }, // 20s → 0 min
+    ])
+    const [explicitZero] = meditationCardsFromUserChoices([
+      { id: 26, title: '5-10 min', morningMeditation: med({ durationMinutes: 0, duration: 0 }) },
+    ])
+
+    expect(subMinute.durationMinutes).toBeUndefined()
+    expect(explicitZero.durationMinutes).toBeUndefined()
+  })
+
   it('prefers an explicit durationMinutes and the meditation title over its label', () => {
     const [card] = meditationCardsFromUserChoices([
       {

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   contentIndexCard,
+  contentIndexTrack,
   galleryImages,
   getLeadSplash,
   leadSplashFromRouteData,
@@ -98,9 +99,20 @@ describe('showcaseItems', () => {
     expect(card.thumbnailSrc).toBe('https://imagedelivery.net/acct/img/')
   })
 
-  it('drops unroutable (lectures/app-cards), bare-id, and thumbnail-less refs', () => {
+  it('maps a lecture to a card by id (now routable)', () => {
     const items: ShowcaseItem[] = [
       { relationTo: 'lectures', value: { id: 3, title: 'Lecture', thumbnail: cfImage() } as never },
+    ]
+    const [card] = showcaseItems(items)
+
+    expect(card.href).toBe('/lectures/3')
+    expect(card.playButton).toBe(false)
+    expect(card.thumbnailSrc).toBe('https://imagedelivery.net/acct/img/')
+  })
+
+  it('drops unroutable (app-cards), bare-id, and thumbnail-less refs', () => {
+    const items: ShowcaseItem[] = [
+      { relationTo: 'app-cards', value: { id: 3, title: 'Card', thumbnail: cfImage() } as never },
       { relationTo: 'pages', value: 7 },
       { relationTo: 'pages', value: { id: 8, slug: 'no-thumb', title: 'NT' } as never },
     ]
@@ -146,8 +158,85 @@ describe('contentIndexCard', () => {
     ).toMatchObject({ href: '/meditations/5', playButton: true, durationMinutes: 8 })
   })
 
+  it('routes lectures by id (/lectures/:id)', () => {
+    expect(
+      contentIndexCard({ id: 7, title: 'Lecture', thumbnail: cfImage() }, 'lectures'),
+    ).toMatchObject({ href: '/lectures/7', playButton: false })
+  })
+
   it('returns null when the doc has no id', () => {
     expect(contentIndexCard({ title: 'x' }, 'pages')).toBeNull()
+  })
+
+  it('attaches page-tag facets with display labels, omitting unknown tags', () => {
+    const card = contentIndexCard(
+      { id: 2, slug: 'guide', title: 'Guide', tags: ['wisdom', 'technique', 'bogus'] },
+      'pages',
+    )
+
+    expect(card?.tags).toEqual([
+      { id: 'wisdom', label: 'Wisdom' },
+      { id: 'technique', label: 'Technique' },
+    ])
+  })
+
+  it('attaches lecture facets from populated user-choices (dropping bare ids / empty titles)', () => {
+    const card = contentIndexCard(
+      {
+        id: 7,
+        title: 'Lecture',
+        userChoices: [{ id: 3, title: 'Calm' }, 99, { id: 4, title: '' }],
+      },
+      'lectures',
+    )
+
+    expect(card?.tags).toEqual([{ id: '3', label: 'Calm' }])
+  })
+
+  it('omits tags entirely when none resolve', () => {
+    const card = contentIndexCard({ id: 2, slug: 'guide', title: 'Guide' }, 'pages')
+
+    expect(card?.tags).toBeUndefined()
+  })
+})
+
+describe('contentIndexTrack', () => {
+  const album = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    artist: 'Nightingale',
+    artistUrl: 'https://example.com/artist',
+    artwork: cfImage(),
+    ...over,
+  })
+
+  it('maps a song doc to a playable Track (duration 0, tags as songTag slugs)', () => {
+    const track = contentIndexTrack({
+      id: 10,
+      title: 'Raga',
+      url: 'https://cdn/audio.mp3',
+      album: album(),
+      tags: [{ id: 1, slug: 'strings' }, 42, { id: 2, slug: 'vocal' }],
+    })
+
+    expect(track).toEqual({
+      url: 'https://cdn/audio.mp3',
+      title: 'Raga',
+      credit: 'Nightingale',
+      creditURL: 'https://example.com/artist',
+      thumbnailURL: 'https://imagedelivery.net/acct/img/',
+      duration: 0,
+      tags: ['strings', 'vocal'],
+    })
+  })
+
+  it('returns null for a song with no playable url', () => {
+    expect(contentIndexTrack({ id: 10, title: 'Raga', album: album() })).toBeNull()
+  })
+
+  it('degrades gracefully when the album is a bare id (no credit/artwork)', () => {
+    const track = contentIndexTrack({ id: 10, title: 'Raga', url: 'https://cdn/a.mp3', album: 5 })
+
+    expect(track).toMatchObject({ credit: '', creditURL: '', thumbnailURL: '', tags: [] })
   })
 })
 

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -250,6 +250,18 @@ describe('contentIndexTrack', () => {
 
     expect(track).toMatchObject({ credit: '', creditURL: '', thumbnailURL: '', tags: [] })
   })
+
+  it("falls back to the song's own thumbnailURL when the album has no artwork", () => {
+    const track = contentIndexTrack({
+      id: 10,
+      title: 'Raga',
+      url: 'https://cdn/a.mp3',
+      album: { id: 1, artist: 'Nightingale', artwork: 99 }, // artwork unpopulated (bare id)
+      thumbnailURL: 'https://cdn/song-thumb.jpg',
+    })
+
+    expect(track?.thumbnailURL).toBe('https://cdn/song-thumb.jpg')
+  })
 })
 
 describe('isExternalUrl', () => {

--- a/lib/cms-blocks.test.ts
+++ b/lib/cms-blocks.test.ts
@@ -6,6 +6,7 @@ import {
   getLeadSplash,
   leadSplashFromRouteData,
   isExternalUrl,
+  meditationCardsFromUserChoices,
   populatedImage,
   showcaseItems,
   splashTheme,
@@ -261,6 +262,77 @@ describe('contentIndexTrack', () => {
     })
 
     expect(track?.thumbnailURL).toBe('https://cdn/song-thumb.jpg')
+  })
+})
+
+describe('meditationCardsFromUserChoices', () => {
+  const med = (over: Record<string, unknown> = {}) => ({
+    id: 105,
+    label: 'Morning med-5 min',
+    duration: 297, // seconds → 5 min
+    thumbnail: cfImage({ alt: '' }), // meditation thumbnails carry no alt
+    ...over,
+  })
+
+  it('flattens a category into meditation cards tagged by the user-choice', () => {
+    const cards = meditationCardsFromUserChoices([
+      {
+        id: 25,
+        title: '5 min',
+        morningMeditation: med(),
+        afternoonMeditation: 999, // bare id → skipped
+        eveningMeditation: null,
+      },
+    ])
+
+    expect(cards).toEqual([
+      {
+        id: 105,
+        title: 'Morning med-5 min',
+        href: '/meditations/105',
+        thumbnailSrc: 'https://imagedelivery.net/acct/img/',
+        thumbnailAlt: 'Morning med-5 min',
+        aspectRatio: expect.any(String),
+        playButton: true,
+        durationMinutes: 5, // derived from duration (297s)
+        tags: [{ id: '25', label: '5 min' }],
+      },
+    ])
+  })
+
+  it('prefers an explicit durationMinutes and the meditation title over its label', () => {
+    const [card] = meditationCardsFromUserChoices([
+      {
+        id: 26,
+        title: '5-10 min',
+        morningMeditation: med({ title: 'Feel Harmony', durationMinutes: 10, duration: 600 }),
+      },
+    ])
+
+    expect(card).toMatchObject({ title: 'Feel Harmony', durationMinutes: 10 })
+  })
+
+  it('dedupes a meditation shared across categories, merging both facets', () => {
+    const cards = meditationCardsFromUserChoices([
+      { id: 25, title: '5 min', morningMeditation: med({ id: 44 }) },
+      { id: 26, title: '5-10 min', eveningMeditation: med({ id: 44 }) },
+    ])
+
+    expect(cards).toHaveLength(1)
+    expect(cards[0].id).toBe(44)
+    expect(cards[0].tags).toEqual([
+      { id: '25', label: '5 min' },
+      { id: '26', label: '5-10 min' },
+    ])
+  })
+
+  it('skips categories without an id/title and slots that are bare ids', () => {
+    expect(
+      meditationCardsFromUserChoices([
+        { title: '', morningMeditation: med() }, // no title
+        { id: 27, title: '10-15 min', morningMeditation: 500 }, // bare-id slot
+      ]),
+    ).toEqual([])
   })
 })
 

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -521,6 +521,92 @@ export function contentIndexCard(
   }
 }
 
+/** The four time-of-day meditation slots on a UserChoice category. */
+const USER_CHOICE_MEDITATION_SLOTS = [
+  'morningMeditation',
+  'afternoonMeditation',
+  'eveningMeditation',
+  'nightMeditation',
+] as const
+
+/** Card duration (minutes) for a populated meditation: the explicit
+ * `durationMinutes`, else derived from `duration` (seconds), else omitted. */
+function meditationDurationMinutes(med: {
+  durationMinutes?: number | null
+  duration?: number | null
+}): number | undefined {
+  if (typeof med.durationMinutes === 'number') {
+    return med.durationMinutes
+  }
+  if (typeof med.duration === 'number' && med.duration > 0) {
+    return Math.round(med.duration / 60)
+  }
+
+  return undefined
+}
+
+/**
+ * Flatten a `meditations` content-index into a deduped grid of meditation cards.
+ *
+ * The block's endpoint resolves to user-choice *categories* (e.g. the "5 min" /
+ * "5-10 min" duration picker), each referencing up to four meditations
+ * (morning/afternoon/evening/night). We merge every referenced meditation into a
+ * single card list and tag each card with the user-choice(s) that reference it,
+ * so `ContentIndex` renders the meditations as a grid with the user-choices as
+ * filter pills. A meditation shared across choices appears once, carrying all its
+ * facets. Unpopulated slots and unidentifiable docs are skipped.
+ */
+export function meditationCardsFromUserChoices(
+  docs: Record<string, unknown>[],
+): ResolvedCardItem[] {
+  const byId = new Map<string | number, ResolvedCardItem>()
+
+  for (const uc of docs) {
+    const ucId = uc.id
+    const title = asText(uc.title)
+
+    if (ucId == null || title.length === 0) {
+      continue
+    }
+    const facet = { id: String(ucId), label: title }
+
+    for (const slot of USER_CHOICE_MEDITATION_SLOTS) {
+      const med = uc[slot]
+
+      if (!isPopulated<Meditation>(med) || med.id == null) {
+        continue
+      }
+      const existing = byId.get(med.id)
+
+      if (existing) {
+        // Referenced by more than one choice — add the facet (deduped).
+        if (!existing.tags?.some((t) => t.id === facet.id)) {
+          existing.tags = [...(existing.tags ?? []), facet]
+        }
+        continue
+      }
+      const img = populatedImage(med.thumbnail)
+      const medTitle = asText(med.title) || asText(med.label)
+
+      byId.set(med.id, {
+        id: med.id,
+        title: medTitle,
+        href: `/meditations/${med.id}`,
+        thumbnailSrc: img?.url ?? '',
+        // Meditation thumbnails are populated without `alt`; fall back to the
+        // title (`||`, so an empty alt still falls through).
+        thumbnailAlt: img?.alt || medTitle,
+        aspectRatio: img?.aspectRatio,
+        playButton: true,
+        durationMinutes: meditationDurationMinutes(med),
+        tags: [facet],
+      })
+    }
+  }
+
+  return Array.from(byId.values())
+}
+
 /**
  * Map a content-index `songs` API document to a playable {@link Track} for the
  * MusicLibrary organism. Songs without a playable URL are skipped. `duration` is

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -530,19 +530,21 @@ const USER_CHOICE_MEDITATION_SLOTS = [
 ] as const
 
 /** Card duration (minutes) for a populated meditation: the explicit
- * `durationMinutes`, else derived from `duration` (seconds), else omitted. */
+ * `durationMinutes`, else derived from `duration` (seconds), else omitted. A
+ * value below 1 (sub-minute duration or `0`) is omitted — a "0 min" badge is
+ * meaningless. */
 function meditationDurationMinutes(med: {
   durationMinutes?: number | null
   duration?: number | null
 }): number | undefined {
-  if (typeof med.durationMinutes === 'number') {
-    return med.durationMinutes
-  }
-  if (typeof med.duration === 'number' && med.duration > 0) {
-    return Math.round(med.duration / 60)
-  }
+  const minutes =
+    typeof med.durationMinutes === 'number'
+      ? med.durationMinutes
+      : typeof med.duration === 'number' && med.duration > 0
+        ? Math.round(med.duration / 60)
+        : undefined
 
-  return undefined
+  return minutes !== undefined && minutes >= 1 ? minutes : undefined
 }
 
 /**

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -492,12 +492,15 @@ export function contentIndexCard(
     return null
   }
   const img = cardImage(doc)
+  // The lectures /for-audience feed returns a plain `thumbnailUrl` string (not a
+  // populated `thumbnail` relationship), so fall back to it for the card image.
+  const thumbnailUrl = typeof doc.thumbnailUrl === 'string' ? doc.thumbnailUrl : ''
 
   return {
     id,
     title,
     href,
-    thumbnailSrc: img?.url ?? '',
+    thumbnailSrc: img?.url ?? thumbnailUrl,
     thumbnailAlt: img?.alt ?? title,
     aspectRatio: img?.aspectRatio,
     playButton: type === 'meditations',

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -536,6 +536,9 @@ export function contentIndexTrack(doc: Record<string, unknown>): Track | null {
   }
   const album = isPopulated<Album>(doc.album) ? doc.album : null
   const artwork = album ? populatedImage(album.artwork) : null
+  // Prefer the album cover; fall back to the song's own thumbnail when the album
+  // has no artwork (or is an unpublished/bare-id relationship).
+  const songThumbnail = typeof doc.thumbnailURL === 'string' ? doc.thumbnailURL : ''
   const tags = (Array.isArray(doc.tags) ? doc.tags : [])
     .map((tag) => (isPopulated<SongTag>(tag) && typeof tag.slug === 'string' ? tag.slug : null))
     .filter((slug): slug is string => slug !== null)
@@ -545,7 +548,7 @@ export function contentIndexTrack(doc: Record<string, unknown>): Track | null {
     title: asText(doc.title),
     credit: album?.artist ?? '',
     creditURL: album?.artistUrl ?? '',
-    thumbnailURL: artwork?.url ?? '',
+    thumbnailURL: artwork?.url ?? songThumbnail,
     duration: 0,
     tags,
   }

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -11,8 +11,11 @@
  * converters) so they can be unit-tested without rendering.
  */
 
-import type { AppCard, Image, Lecture } from '../server/payload-types'
+import type { AppCard, Album, Image, Lecture, SongTag, UserChoice } from '../server/payload-types'
 import type { Meditation, Page } from '../server/cms-types'
+// Type-only import (erased at build): reuse the audio player's Track shape so the
+// songs content-index feeds MusicLibrary without a parallel type.
+import type { Track } from '../components/molecules/AudioPlayer/types'
 import { cmsHref, type RelationValue } from './cms-routes'
 import { isPopulated } from './cms-relationships'
 import { nearestAspectRatio, type AspectRatio } from './cloudflare-images'
@@ -134,21 +137,48 @@ export interface TableOfContentsBlockFields {
   headings?: TocHeading[] | null
 }
 
-/** `content-index` — ContentIndexBlock. `resolvedItems` is attached by the
- * server-side pre-resolve pass in `+data`; the editor never stores it. */
+/** The `pages` collection's tag enum (drives page content-index facets). */
+export type PageTag = NonNullable<Page['tags']>[number]
+
+/** Display labels for page tags. Localizing these (via wm-web-translations) is
+ * a follow-up; the enum values are the stable identifiers used for filtering. */
+export const PAGE_TAG_LABELS: Record<PageTag, string> = {
+  wisdom: 'Wisdom',
+  lifestyle: 'Lifestyle',
+  creativity: 'Creativity',
+  event: 'Event',
+  technique: 'Technique',
+}
+
+/** `content-index` — ContentIndexBlock. `resolvedItems`/`resolvedTracks` are
+ * attached by the server-side pre-resolve pass in `+data`; the editor never
+ * stores them. The `*Filters` fields mirror the CMS schema but are unused for
+ * rendering — facets are derived from the resolved items' own `tags` instead. */
 export interface ContentIndexBlockFields {
   type: 'meditations' | 'pages' | 'songs' | 'lectures'
   limit: number
+  /** Configured page-tag filters (CMS schema mirror; facets come from items). */
+  pageFilters?: PageTag[] | null
+  /** Configured user-choice filters (CMS schema mirror; facets come from items). */
+  userChoiceFilters?: (number | UserChoice)[] | null
+  /** Configured song-tag filters (CMS schema mirror; facets come from tracks). */
+  songFilters?: (number | SongTag)[] | null
   /** Virtual field computed by the CMS (path + filters + limit). */
   apiEndpoint?: string | null
+  /** Cards for pages/lectures/meditations (attached in +data). */
   resolvedItems?: ResolvedCardItem[] | null
+  /** Playable tracks for the songs type (attached in +data). */
+  resolvedTracks?: Track[] | null
 }
 
 // ============================================================================
 // Shared card shape + helpers
 // ============================================================================
 
-/** A grid/card item shape, structurally compatible with `ContentGridItem`. */
+/** A grid/card item shape, structurally compatible with `ContentGridItem`.
+ * `tags` are the item's own facets (page-tag enum, or lecture user-choices),
+ * used by `ContentIndex` for client-side filter pills — strip before spreading
+ * onto `ContentCard`, which forwards unknown props to the DOM. */
 export interface ResolvedCardItem {
   id: string | number
   title: string
@@ -159,6 +189,7 @@ export interface ResolvedCardItem {
   playButton?: boolean
   durationMinutes?: number
   badge?: string
+  tags?: { id: string; label: string }[]
 }
 
 /** A populated image resolved to the fields the `Image` atom needs. */
@@ -295,8 +326,8 @@ function showcaseCard(item: ShowcaseItem): ResolvedCardItem | null {
   }
   const href = cmsHref(relationTo, value as RelationValue)
 
-  // Collections without a public web route (lectures until Ticket 3, app-cards)
-  // resolve to null — skip rather than emit a dead link.
+  // Collections without a public web route (app-cards) resolve to null —
+  // skip rather than emit a dead link.
   if (!href) {
     return null
   }
@@ -402,6 +433,40 @@ export function isExternalUrl(url: string): boolean {
   return /^https?:\/\//i.test(url)
 }
 
+/**
+ * Filter facets for a content-index card: page-tag enum labels (`pages`) or
+ * populated user-choice titles (`lectures`). Other types carry no card-level
+ * facets. Returns `undefined` (not `[]`) when empty so the field is omitted.
+ */
+function contentIndexCardTags(
+  doc: Record<string, unknown>,
+  type: ContentIndexBlockFields['type'],
+): ResolvedCardItem['tags'] {
+  if (type === 'pages') {
+    const raw = Array.isArray(doc.tags) ? doc.tags : []
+    const facets = raw
+      .filter((t): t is PageTag => typeof t === 'string' && t in PAGE_TAG_LABELS)
+      .map((t) => ({ id: t, label: PAGE_TAG_LABELS[t] }))
+
+    return facets.length > 0 ? facets : undefined
+  }
+
+  if (type === 'lectures') {
+    const raw = Array.isArray(doc.userChoices) ? doc.userChoices : []
+    const facets = raw
+      .map((uc) =>
+        isPopulated<UserChoice>(uc) && typeof uc.title === 'string' && uc.title.length > 0
+          ? { id: String(uc.id), label: uc.title }
+          : null,
+      )
+      .filter((f): f is { id: string; label: string } => f !== null)
+
+    return facets.length > 0 ? facets : undefined
+  }
+
+  return undefined
+}
+
 /** Map a content-index API document to a card for the given content type. */
 export function contentIndexCard(
   doc: Record<string, unknown>,
@@ -419,7 +484,9 @@ export function contentIndexCard(
       ? `/meditations/${id}`
       : type === 'pages'
         ? cmsHref('pages', doc as RelationValue)
-        : null
+        : type === 'lectures'
+          ? cmsHref('lectures', doc as RelationValue)
+          : null
 
   if (!href) {
     return null
@@ -438,5 +505,36 @@ export function contentIndexCard(
       type === 'meditations' && typeof doc.durationMinutes === 'number'
         ? doc.durationMinutes
         : undefined,
+    tags: contentIndexCardTags(doc, type),
+  }
+}
+
+/**
+ * Map a content-index `songs` API document to a playable {@link Track} for the
+ * MusicLibrary organism. Songs without a playable URL are skipped. `duration` is
+ * `0` — the Song CMS type has no duration field, so AudioPlayer derives it from
+ * the audio element at load. `tags` are the populated SongTag slugs, matched
+ * against MusicLibrary's filter ids.
+ */
+export function contentIndexTrack(doc: Record<string, unknown>): Track | null {
+  const url = typeof doc.url === 'string' ? doc.url : ''
+
+  if (url.length === 0) {
+    return null
+  }
+  const album = isPopulated<Album>(doc.album) ? doc.album : null
+  const artwork = album ? populatedImage(album.artwork) : null
+  const tags = (Array.isArray(doc.tags) ? doc.tags : [])
+    .map((tag) => (isPopulated<SongTag>(tag) && typeof tag.slug === 'string' ? tag.slug : null))
+    .filter((slug): slug is string => slug !== null)
+
+  return {
+    url,
+    title: asText(doc.title),
+    credit: album?.artist ?? '',
+    creditURL: album?.artistUrl ?? '',
+    thumbnailURL: artwork?.url ?? '',
+    duration: 0,
+    tags,
   }
 }

--- a/lib/cms-blocks.ts
+++ b/lib/cms-blocks.ts
@@ -467,6 +467,23 @@ function contentIndexCardTags(
   return undefined
 }
 
+/** Web path for a content-index card by type: meditations route by id, pages by
+ * slug, lectures by id; other types have no public route (`null`). */
+function cardHref(
+  type: ContentIndexBlockFields['type'],
+  doc: Record<string, unknown>,
+  id: string | number,
+): string | null {
+  if (type === 'meditations') {
+    return `/meditations/${id}`
+  }
+  if (type === 'pages' || type === 'lectures') {
+    return cmsHref(type, doc as RelationValue)
+  }
+
+  return null
+}
+
 /** Map a content-index API document to a card for the given content type. */
 export function contentIndexCard(
   doc: Record<string, unknown>,
@@ -478,15 +495,7 @@ export function contentIndexCard(
     return null
   }
   const title = asText(doc.title)
-
-  const href =
-    type === 'meditations'
-      ? `/meditations/${id}`
-      : type === 'pages'
-        ? cmsHref('pages', doc as RelationValue)
-        : type === 'lectures'
-          ? cmsHref('lectures', doc as RelationValue)
-          : null
+  const href = cardHref(type, doc, id)
 
   if (!href) {
     return null

--- a/lib/cms-routes.test.ts
+++ b/lib/cms-routes.test.ts
@@ -51,8 +51,12 @@ describe('cmsHref', () => {
     expect(cmsHref('meditations', { id: 12, slug: null })).toBe('/meditations/12')
   })
 
+  it('builds a lecture path from an id (bare or populated)', () => {
+    expect(cmsHref('lectures', 7)).toBe('/lectures/7')
+    expect(cmsHref('lectures', { id: 7, slug: null })).toBe('/lectures/7')
+  })
+
   it('returns null for collections without a public web route', () => {
-    expect(cmsHref('lectures', { id: 1 })).toBeNull()
     expect(cmsHref('albums', { id: 1 })).toBeNull()
     expect(cmsHref('app-cards', { id: 1 })).toBeNull()
     expect(cmsHref('forms', { id: 1 })).toBeNull()

--- a/lib/cms-routes.ts
+++ b/lib/cms-routes.ts
@@ -4,8 +4,8 @@
  * - matching an incoming URL back to its route params ({@link matchDocumentRoute}).
  *
  * `cmsHref` is used by the RichText renderer (internal links + inline relationship
- * nodes) and reused by the `showcase` block in Ticket 2. `matchDocumentRoute` is
- * used by the meditation/lecture `+route.ts` files. Keeping the mapping in one
+ * nodes) and reused by the `showcase` and `content-index` blocks. `matchDocumentRoute`
+ * is used by the meditation/lecture `+route.ts` files. Keeping the mapping in one
  * place means new routes (e.g. lectures, albums) are wired up by editing a single
  * table rather than hunting through converters.
  *
@@ -57,8 +57,9 @@ const ROUTE_BUILDERS: Record<
 > = {
   pages: ({ slug }) => (slug ? `/${slug}` : null),
   meditations: ({ id }) => (id ? `/meditations/${id}` : null),
-  // No public web route yet — added in later tickets (lectures: Ticket 3).
-  lectures: () => null,
+  // Lectures route by id, mirroring meditations (route: pages/lectures/[id]/(full)/).
+  lectures: ({ id }) => (id ? `/lectures/${id}` : null),
+  // No public web route yet.
   albums: () => null,
   // App-only / embedded content with no standalone web route.
   'app-cards': () => null,

--- a/pages/[slug]/+data.ts
+++ b/pages/[slug]/+data.ts
@@ -36,7 +36,10 @@ export async function data(pageContext: PageContextServer): Promise<PageData> {
     if (!settings.homePage) {
       throw render(404, 'Homepage not configured.')
     }
-    const content = await resolveContentIndexBlocks(settings.homePage.content, { locale })
+    const content = await resolveContentIndexBlocks(settings.homePage.content, {
+      locale,
+      audiences: settings.audiences,
+    })
 
     return { page: { ...settings.homePage, content }, locale, slug, settings }
   }
@@ -52,7 +55,10 @@ export async function data(pageContext: PageContextServer): Promise<PageData> {
     throw render(404, 'Page not found.')
   }
   // Resolve any content-index blocks' live lists for SSR.
-  const content = await resolveContentIndexBlocks(page.content, { locale })
+  const content = await resolveContentIndexBlocks(page.content, {
+    locale,
+    audiences: settings.audiences,
+  })
 
   return { page: { ...page, content }, locale, slug, settings }
 }

--- a/pages/preview/(full)/+data.ts
+++ b/pages/preview/(full)/+data.ts
@@ -93,6 +93,7 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
     withContent.content = await resolveContentIndexBlocks(withContent.content, {
       locale,
       preview: true,
+      audiences: settings.audiences,
     })
   }
 

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -162,7 +162,8 @@ const PAGE_POPULATE = {
   'app-cards': EMBEDDED_APP_CARD_SELECT,
 }
 
-/** Global config fields — all are `pages` relationships the layout + home page need. */
+/** Global config fields: `pages` relationships the layout + home page need, plus
+ * `audiences` (the site's fixed audience set the lectures /for-audience feed uses). */
 const WEB_CONFIG_SELECT = {
   homePage: true,
   featuredPages: true,
@@ -170,6 +171,7 @@ const WEB_CONFIG_SELECT = {
   classPages: true,
   knowledgePages: true,
   infoPages: true,
+  audiences: true,
 } satisfies WmWebConfigSelect<true>
 
 /**

--- a/server/content-index.test.ts
+++ b/server/content-index.test.ts
@@ -12,7 +12,11 @@ vi.mock('./kv-cache', async (importOriginal) => {
 })
 vi.mock('@sentry/react', () => ({ captureMessage: vi.fn() }))
 
-import { resolveContentIndexItems, resolveContentIndexBlocks } from './content-index'
+import {
+  resolveContentIndexItems,
+  resolveContentIndexTracks,
+  resolveContentIndexBlocks,
+} from './content-index'
 import type { ContentIndexBlockFields } from '../lib/cms-blocks'
 
 const jsonResponse = (docs: unknown[]) => ({ ok: true, json: async () => ({ docs }) }) as never
@@ -64,8 +68,38 @@ describe('resolveContentIndexItems', () => {
     expect(items).toHaveLength(2)
   })
 
-  it('degrades to [] on a non-200 (e.g. lectures needing runtime audiences)', async () => {
+  it('passes the site audiences to the lectures feed and routes cards to /lectures/:id', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse([{ id: 3, title: 'Lecture', thumbnail: null }]))
+
+    const items = await resolveContentIndexItems(
+      { type: 'lectures', limit: 100, apiEndpoint: '/api/lectures/for-audience?limit=100' },
+      { audiences: [1, { id: 2 } as never] },
+    )
+
+    expect(items[0].href).toBe('/lectures/3')
+
+    const url = fetchSpy.mock.calls[0][0] as string
+
+    expect(url).toContain('audiences=1,2')
+    expect(url).toContain('select[userChoices]=true')
+    expect(url).toContain('populate[user-choices][title]=true')
+  })
+
+  it('degrades to [] on a non-200 (e.g. a malformed endpoint)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 400 } as never)
+
+    const items = await resolveContentIndexItems(
+      { type: 'lectures', limit: 100, apiEndpoint: '/api/lectures/for-audience?limit=100' },
+      { audiences: [1] },
+    )
+
+    expect(items).toEqual([])
+  })
+
+  it('degrades to [] without fetching when a lectures block has no audiences', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
     const items = await resolveContentIndexItems(
       { type: 'lectures', limit: 100, apiEndpoint: '/api/lectures/for-audience?limit=100' },
@@ -73,10 +107,50 @@ describe('resolveContentIndexItems', () => {
     )
 
     expect(items).toEqual([])
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('returns [] when the block has no apiEndpoint', async () => {
     expect(await resolveContentIndexItems({ type: 'pages', limit: 10 }, {})).toEqual([])
+  })
+})
+
+describe('resolveContentIndexTracks', () => {
+  it('maps songs to playable tracks and populates album/artwork/tags', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse([
+        {
+          id: 9,
+          title: 'Raga',
+          url: 'https://cdn/audio.mp3',
+          album: { id: 1, artist: 'Nightingale', artwork: { id: 2, url: 'https://cdn/art.jpg' } },
+          tags: [{ id: 5, slug: 'strings' }],
+        },
+      ]),
+    )
+
+    const tracks = await resolveContentIndexTracks(
+      { type: 'songs', limit: 10, apiEndpoint: '/api/songs?limit=10' },
+      {},
+    )
+
+    expect(tracks).toEqual([
+      {
+        url: 'https://cdn/audio.mp3',
+        title: 'Raga',
+        credit: 'Nightingale',
+        creditURL: '',
+        thumbnailURL: 'https://cdn/art.jpg',
+        duration: 0,
+        tags: ['strings'],
+      },
+    ])
+
+    const url = fetchSpy.mock.calls[0][0] as string
+
+    expect(url).toContain('select[url]=true')
+    expect(url).toContain('populate[albums][artwork]=true')
+    expect(url).toContain('depth=2')
   })
 })
 
@@ -115,6 +189,36 @@ describe('resolveContentIndexBlocks', () => {
 
     expect(cloned.resolvedItems).toHaveLength(1)
     expect(cloned.resolvedItems?.[0].href).toBe('/about')
+  })
+
+  it('attaches resolvedTracks (not resolvedItems) for a songs block', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse([{ id: 9, title: 'Raga', url: 'https://cdn/a.mp3', album: 1, tags: [] }]),
+    )
+
+    const content = {
+      root: {
+        children: [
+          {
+            type: 'block',
+            fields: {
+              blockType: 'content-index',
+              id: 'ci-songs',
+              type: 'songs',
+              limit: 10,
+              apiEndpoint: '/api/songs?limit=10',
+            },
+          },
+        ],
+      },
+    }
+
+    const resolved = await resolveContentIndexBlocks(content, {})
+    const fields = (resolved as typeof content).root.children[0].fields as ContentIndexBlockFields
+
+    expect(fields.resolvedTracks).toHaveLength(1)
+    expect(fields.resolvedTracks?.[0].url).toBe('https://cdn/a.mp3')
+    expect(fields.resolvedItems).toBeUndefined()
   })
 
   it('returns the same content untouched when there are no content-index blocks', async () => {

--- a/server/content-index.test.ts
+++ b/server/content-index.test.ts
@@ -151,6 +151,10 @@ describe('resolveContentIndexTracks', () => {
     expect(url).toContain('select[url]=true')
     expect(url).toContain('populate[albums][artwork]=true')
     expect(url).toContain('depth=2')
+    // `url`/`thumbnailURL` are upload virtuals derived from `filename`; without
+    // it selected the CMS returns them null and every track is dropped.
+    expect(url).toContain('select[filename]=true')
+    expect(url).toContain('populate[images][filename]=true')
   })
 })
 

--- a/server/content-index.test.ts
+++ b/server/content-index.test.ts
@@ -51,6 +51,48 @@ describe('resolveContentIndexItems', () => {
     expect(auth).toContain('API-Key test-key')
   })
 
+  it('resolves a meditations block via user-choice categories (single depth, flattened + tagged)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse([
+        {
+          id: 25,
+          title: '5 min',
+          morningMeditation: { id: 105, label: 'Feel Calm', duration: 300, thumbnail: null },
+        },
+      ]),
+    )
+
+    const items = await resolveContentIndexItems(
+      {
+        type: 'meditations',
+        limit: 100,
+        // The CMS bakes `depth=1` into the endpoint; the resolver must not append
+        // a second one (duplicate `depth` params 400 the backend).
+        apiEndpoint: '/api/user-choices?where[id][in]=25&depth=1&limit=100',
+      },
+      { locale: 'en' },
+    )
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: 105,
+        title: 'Feel Calm',
+        href: '/meditations/105',
+        playButton: true,
+        durationMinutes: 5,
+        tags: [{ id: '25', label: '5 min' }],
+      }),
+    ])
+
+    const url = fetchSpy.mock.calls[0][0] as string
+
+    // Baked-in depth stripped; only our depth=2 remains.
+    expect(url).toContain('https://cms.test/api/user-choices?where[id][in]=25&limit=100')
+    expect(url).toContain('depth=2')
+    expect(url).not.toContain('depth=1')
+    expect(url).toContain('populate[meditations][thumbnail]=true')
+  })
+
   it('caps the result at the block limit', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       jsonResponse([

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -52,7 +52,8 @@ const QUERY_BY_TYPE: Record<
     depth: 1,
   },
   songs: {
-    select: 'select[title]=true&select[album]=true&select[url]=true&select[tags]=true',
+    select:
+      'select[title]=true&select[album]=true&select[url]=true&select[tags]=true&select[thumbnailURL]=true',
     populate:
       'populate[albums][artist]=true&populate[albums][artistUrl]=true&populate[albums][artwork]=true&populate[song-tags][slug]=true&populate[images][url]=true',
     depth: 2,

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -52,10 +52,15 @@ const QUERY_BY_TYPE: Record<
     depth: 1,
   },
   songs: {
+    // A Song is an upload: `url`/`thumbnailURL` are virtual fields the upload
+    // afterRead hook derives from `filename`, so `filename` MUST be selected or
+    // they come back null — dropping every track (empty MusicLibrary). Same for
+    // related image uploads: `populate[images][filename]` lets the album
+    // artwork's url compute (url-only populate would return null).
     select:
-      'select[title]=true&select[album]=true&select[url]=true&select[tags]=true&select[thumbnailURL]=true',
+      'select[title]=true&select[album]=true&select[url]=true&select[tags]=true&select[thumbnailURL]=true&select[filename]=true',
     populate:
-      'populate[albums][artist]=true&populate[albums][artistUrl]=true&populate[albums][artwork]=true&populate[song-tags][slug]=true&populate[images][url]=true',
+      'populate[albums][artist]=true&populate[albums][artistUrl]=true&populate[albums][artwork]=true&populate[song-tags][slug]=true&populate[images][url]=true&populate[images][filename]=true',
     depth: 2,
   },
 }

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -115,6 +115,9 @@ function audienceIds(audiences: ResolveOptions['audiences']): string[] {
 function contentIndexCacheKey(fields: ContentIndexBlockFields, options: ResolveOptions): string {
   return generateCacheKey('content-index', {
     endpoint: fields.apiEndpoint ?? undefined,
+    // Fold in the type so two blocks sharing an endpoint+locale can't collide
+    // and return the wrong shape from cache (a songs Track[] vs a card list).
+    type: fields.type,
     locale: options.locale,
     audiences: fields.type === 'lectures' ? audienceIds(options.audiences) : undefined,
   })

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -16,86 +16,181 @@
 import * as Sentry from '@sentry/react'
 import { getCmsContext } from './cms-context'
 import { withCache, generateCacheKey, CacheTTL } from './kv-cache'
+import type { Audience } from './payload-types'
 import type { Locale } from './cms-types'
 import {
   contentIndexCard,
+  contentIndexTrack,
   type ContentIndexBlockFields,
   type ResolvedCardItem,
 } from '../lib/cms-blocks'
+// Type-only import (erased at build): the songs index resolves to MusicLibrary tracks.
+import type { Track } from '../components/molecules/AudioPlayer/types'
 
-/** Per-type field selection appended to the computed endpoint (the backend
- * rejects API-client collection reads without a `select`). */
-const SELECT_BY_TYPE: Record<ContentIndexBlockFields['type'], string> = {
-  pages: 'select[title]=true&select[slug]=true&select[meta]=true',
-  meditations: 'select[title]=true&select[thumbnail]=true&select[durationMinutes]=true',
-  songs: 'select[title]=true&select[album]=true',
-  lectures: 'select[title]=true&select[thumbnail]=true',
+/**
+ * Per-type query fragments appended to the CMS-computed endpoint:
+ * - `select` is mandatory — the backend rejects API-client reads without it.
+ * - `populate` returns the fields of related docs a card/track needs (song
+ *   album credit + artwork + tags, lecture user-choice titles).
+ * - `depth` reaches those relations (songs need 2 for album → artwork).
+ */
+const QUERY_BY_TYPE: Record<
+  ContentIndexBlockFields['type'],
+  { select: string; populate?: string; depth: number }
+> = {
+  pages: {
+    select: 'select[title]=true&select[slug]=true&select[meta]=true&select[tags]=true',
+    depth: 1,
+  },
+  meditations: {
+    select: 'select[title]=true&select[thumbnail]=true&select[durationMinutes]=true',
+    depth: 1,
+  },
+  lectures: {
+    select: 'select[title]=true&select[thumbnail]=true&select[userChoices]=true',
+    populate: 'populate[user-choices][title]=true',
+    depth: 1,
+  },
+  songs: {
+    select: 'select[title]=true&select[album]=true&select[url]=true&select[tags]=true',
+    populate:
+      'populate[albums][artist]=true&populate[albums][artistUrl]=true&populate[albums][artwork]=true&populate[song-tags][slug]=true&populate[images][url]=true',
+    depth: 2,
+  },
 }
 
 interface ResolveOptions {
   locale?: Locale
   /** Bypass the KV cache (live preview). */
   preview?: boolean
+  /** The site's fixed audiences (WmWebConfig.audiences), passed to the lectures
+   * `/for-audience` feed so it resolves server-side. */
+  audiences?: (number | Audience)[]
 }
 
-/** Fetch and map the live list for a single content-index block. */
-export async function resolveContentIndexItems(
+/** Extract audience document ids (populated object or bare id) as strings. */
+function audienceIds(audiences: ResolveOptions['audiences']): string[] {
+  if (!audiences) {
+    return []
+  }
+
+  return audiences
+    .map((a) => (typeof a === 'number' ? String(a) : a?.id != null ? String(a.id) : null))
+    .filter((id): id is string => id !== null)
+}
+
+/**
+ * Cache key for a content-index resolve. Audience ids are folded in for lectures
+ * so a WmWebConfig audience change doesn't serve a stale `/for-audience` list.
+ */
+function contentIndexCacheKey(fields: ContentIndexBlockFields, options: ResolveOptions): string {
+  return generateCacheKey('content-index', {
+    endpoint: fields.apiEndpoint ?? undefined,
+    locale: options.locale,
+    audiences: fields.type === 'lectures' ? audienceIds(options.audiences) : undefined,
+  })
+}
+
+/**
+ * Fetch the live list for a content-index block and return its raw docs, capped
+ * at the block `limit`. Degrades to `[]` — warning to Sentry — on any non-200,
+ * fetch error, or (for lectures) missing audience context. Shared by the card
+ * and track resolvers.
+ */
+async function fetchContentIndexDocs(
   fields: ContentIndexBlockFields,
-  options: ResolveOptions = {},
-): Promise<ResolvedCardItem[]> {
+  options: ResolveOptions,
+): Promise<Record<string, unknown>[]> {
   const { type, limit, apiEndpoint } = fields
 
   if (!apiEndpoint) {
     return []
   }
+  // Lectures resolve via the /for-audience feed keyed on the site's fixed
+  // audiences; with none configured the block degrades to empty (not an error).
+  const audiences = type === 'lectures' ? audienceIds(options.audiences) : []
+
+  if (type === 'lectures' && audiences.length === 0) {
+    return []
+  }
   const { apiKey, baseURL } = getCmsContext()
-  const cacheKey = generateCacheKey('content-index', {
-    endpoint: apiEndpoint,
-    locale: options.locale,
-  })
+  const { select, populate, depth } = QUERY_BY_TYPE[type]
+  const separator = apiEndpoint.includes('?') ? '&' : '?'
+  const populateParam = populate ? `&${populate}` : ''
+  const localeParam = options.locale ? `&locale=${options.locale}` : ''
+  const audiencesParam = audiences.length > 0 ? `&audiences=${audiences.join(',')}` : ''
+  const url = `${baseURL}${apiEndpoint}${separator}${select}${populateParam}&depth=${depth}${localeParam}${audiencesParam}`
+
+  try {
+    const response = await fetch(url, {
+      headers: { Authorization: `clients API-Key ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      Sentry.captureMessage('content-index endpoint not resolvable', {
+        level: 'warning',
+        tags: { source: 'fetchContentIndexDocs' },
+        extra: { type, status: response.status },
+      })
+
+      return []
+    }
+    const json = (await response.json()) as { docs?: Record<string, unknown>[] }
+    const docs = json.docs ?? []
+    const cap = typeof limit === 'number' ? limit : docs.length
+
+    return docs.slice(0, cap)
+  } catch (error) {
+    Sentry.captureMessage('content-index fetch failed', {
+      level: 'warning',
+      tags: { source: 'fetchContentIndexDocs' },
+      extra: { type, error: error instanceof Error ? error.message : String(error) },
+    })
+
+    return []
+  }
+}
+
+/** Fetch and map a content-index block's list to cards (pages/lectures/meditations). */
+export async function resolveContentIndexItems(
+  fields: ContentIndexBlockFields,
+  options: ResolveOptions = {},
+): Promise<ResolvedCardItem[]> {
+  if (!fields.apiEndpoint) {
+    return []
+  }
 
   return withCache({
-    cacheKey,
+    cacheKey: contentIndexCacheKey(fields, options),
     ttl: CacheTTL.LIST,
     bypassCache: options.preview === true,
     fetchFn: async () => {
-      const separator = apiEndpoint.includes('?') ? '&' : '?'
-      const select = SELECT_BY_TYPE[type] ?? ''
-      const localeParam = options.locale ? `&locale=${options.locale}` : ''
-      const url = `${baseURL}${apiEndpoint}${separator}${select}&depth=1${localeParam}`
+      const docs = await fetchContentIndexDocs(fields, options)
 
-      try {
-        const response = await fetch(url, {
-          headers: { Authorization: `clients API-Key ${apiKey}` },
-        })
+      return docs
+        .map((doc) => contentIndexCard(doc, fields.type))
+        .filter((card): card is ResolvedCardItem => card !== null)
+    },
+  })
+}
 
-        if (!response.ok) {
-          // Lectures (/for-audience) and any malformed endpoint land here.
-          Sentry.captureMessage('content-index endpoint not resolvable', {
-            level: 'warning',
-            tags: { source: 'resolveContentIndexItems' },
-            extra: { type, status: response.status },
-          })
+/** Fetch and map a `songs` content-index block's list to playable tracks. */
+export async function resolveContentIndexTracks(
+  fields: ContentIndexBlockFields,
+  options: ResolveOptions = {},
+): Promise<Track[]> {
+  if (!fields.apiEndpoint) {
+    return []
+  }
 
-          return []
-        }
-        const json = (await response.json()) as { docs?: Record<string, unknown>[] }
-        const docs = json.docs ?? []
-        const cap = typeof limit === 'number' ? limit : docs.length
+  return withCache({
+    cacheKey: contentIndexCacheKey(fields, options),
+    ttl: CacheTTL.LIST,
+    bypassCache: options.preview === true,
+    fetchFn: async () => {
+      const docs = await fetchContentIndexDocs(fields, options)
 
-        return docs
-          .slice(0, cap)
-          .map((doc) => contentIndexCard(doc, type))
-          .filter((card): card is ResolvedCardItem => card !== null)
-      } catch (error) {
-        Sentry.captureMessage('content-index fetch failed', {
-          level: 'warning',
-          tags: { source: 'resolveContentIndexItems' },
-          extra: { type, error: error instanceof Error ? error.message : String(error) },
-        })
-
-        return []
-      }
+      return docs.map((doc) => contentIndexTrack(doc)).filter((t): t is Track => t !== null)
     },
   })
 }
@@ -162,7 +257,13 @@ export async function resolveContentIndexBlocks<T>(
 
   await Promise.all(
     targets.map(async (fields) => {
-      fields.resolvedItems = await resolveContentIndexItems(fields, options)
+      // Songs feed the MusicLibrary organism (tracks + playback); every other
+      // type feeds a card grid.
+      if (fields.type === 'songs') {
+        fields.resolvedTracks = await resolveContentIndexTracks(fields, options)
+      } else {
+        fields.resolvedItems = await resolveContentIndexItems(fields, options)
+      }
     }),
   )
 

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -151,11 +151,16 @@ async function fetchContentIndexDocs(
   }
 }
 
-/** Fetch and map a content-index block's list to cards (pages/lectures/meditations). */
-export async function resolveContentIndexItems(
+/**
+ * Fetch a content-index block's list (cached), mapping each doc via `mapper` and
+ * dropping the ones it rejects (`null`). Shared by the card and track resolvers,
+ * which differ only in their per-doc mapping.
+ */
+async function resolveContentIndex<T>(
   fields: ContentIndexBlockFields,
-  options: ResolveOptions = {},
-): Promise<ResolvedCardItem[]> {
+  options: ResolveOptions,
+  mapper: (doc: Record<string, unknown>) => T | null,
+): Promise<T[]> {
   if (!fields.apiEndpoint) {
     return []
   }
@@ -167,32 +172,25 @@ export async function resolveContentIndexItems(
     fetchFn: async () => {
       const docs = await fetchContentIndexDocs(fields, options)
 
-      return docs
-        .map((doc) => contentIndexCard(doc, fields.type))
-        .filter((card): card is ResolvedCardItem => card !== null)
+      return docs.map(mapper).filter((mapped): mapped is T => mapped !== null)
     },
   })
 }
 
+/** Fetch and map a content-index block's list to cards (pages/lectures/meditations). */
+export function resolveContentIndexItems(
+  fields: ContentIndexBlockFields,
+  options: ResolveOptions = {},
+): Promise<ResolvedCardItem[]> {
+  return resolveContentIndex(fields, options, (doc) => contentIndexCard(doc, fields.type))
+}
+
 /** Fetch and map a `songs` content-index block's list to playable tracks. */
-export async function resolveContentIndexTracks(
+export function resolveContentIndexTracks(
   fields: ContentIndexBlockFields,
   options: ResolveOptions = {},
 ): Promise<Track[]> {
-  if (!fields.apiEndpoint) {
-    return []
-  }
-
-  return withCache({
-    cacheKey: contentIndexCacheKey(fields, options),
-    ttl: CacheTTL.LIST,
-    bypassCache: options.preview === true,
-    fetchFn: async () => {
-      const docs = await fetchContentIndexDocs(fields, options)
-
-      return docs.map((doc) => contentIndexTrack(doc)).filter((t): t is Track => t !== null)
-    },
-  })
+  return resolveContentIndex(fields, options, contentIndexTrack)
 }
 
 /** Recursively collect every `content-index` block's `fields` object. */

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -21,6 +21,7 @@ import type { Locale } from './cms-types'
 import {
   contentIndexCard,
   contentIndexTrack,
+  meditationCardsFromUserChoices,
   type ContentIndexBlockFields,
   type ResolvedCardItem,
 } from '../lib/cms-blocks'
@@ -42,9 +43,18 @@ const QUERY_BY_TYPE: Record<
     select: 'select[title]=true&select[slug]=true&select[meta]=true&select[tags]=true',
     depth: 1,
   },
+  // A `meditations` block resolves to user-choice *categories* (a duration/mood
+  // picker), not meditation docs. Select each category's title (the filter-pill
+  // label) and its four time-of-day meditation slots, then populate those
+  // meditations (title/label/thumbnail/duration) and their thumbnail images
+  // (url needs `filename` — the upload virtual gotcha). depth=2 reaches
+  // category → meditation → image. See `meditationCardsFromUserChoices`.
   meditations: {
-    select: 'select[title]=true&select[thumbnail]=true&select[durationMinutes]=true',
-    depth: 1,
+    select:
+      'select[title]=true&select[morningMeditation]=true&select[afternoonMeditation]=true&select[eveningMeditation]=true&select[nightMeditation]=true',
+    populate:
+      'populate[meditations][title]=true&populate[meditations][label]=true&populate[meditations][thumbnail]=true&populate[meditations][duration]=true&populate[meditations][durationMinutes]=true&populate[images][url]=true&populate[images][filename]=true&populate[images][width]=true&populate[images][height]=true',
+    depth: 2,
   },
   lectures: {
     select: 'select[title]=true&select[thumbnail]=true&select[userChoices]=true',
@@ -72,6 +82,19 @@ interface ResolveOptions {
   /** The site's fixed audiences (WmWebConfig.audiences), passed to the lectures
    * `/for-audience` feed so it resolves server-side. */
   audiences?: (number | Audience)[]
+}
+
+/**
+ * Drop every `key=…` param from a path+query string. The CMS-computed endpoint
+ * sometimes bakes in its own `depth` (e.g. the meditations user-choices feed);
+ * our per-type `depth` must be the only one, since duplicate `depth` params
+ * parse to an array and the backend 400s ("populate required when depth > 1").
+ */
+function stripQueryParam(endpoint: string, key: string): string {
+  const [path, query = ''] = endpoint.split('?')
+  const kept = query.split('&').filter((part) => part !== '' && part.split('=')[0] !== key)
+
+  return kept.length > 0 ? `${path}?${kept.join('&')}` : path
 }
 
 /** Extract audience document ids (populated object or bare id) as strings. */
@@ -121,11 +144,13 @@ async function fetchContentIndexDocs(
   }
   const { apiKey, baseURL } = getCmsContext()
   const { select, populate, depth } = QUERY_BY_TYPE[type]
-  const separator = apiEndpoint.includes('?') ? '&' : '?'
+  // Strip any depth the CMS baked into the endpoint so ours is the only one.
+  const endpoint = stripQueryParam(apiEndpoint, 'depth')
+  const separator = endpoint.includes('?') ? '&' : '?'
   const populateParam = populate ? `&${populate}` : ''
   const localeParam = options.locale ? `&locale=${options.locale}` : ''
   const audiencesParam = audiences.length > 0 ? `&audiences=${audiences.join(',')}` : ''
-  const url = `${baseURL}${apiEndpoint}${separator}${select}${populateParam}&depth=${depth}${localeParam}${audiencesParam}`
+  const url = `${baseURL}${endpoint}${separator}${select}${populateParam}&depth=${depth}${localeParam}${audiencesParam}`
 
   try {
     const response = await fetch(url, {
@@ -158,14 +183,15 @@ async function fetchContentIndexDocs(
 }
 
 /**
- * Fetch a content-index block's list (cached), mapping each doc via `mapper` and
- * dropping the ones it rejects (`null`). Shared by the card and track resolvers,
- * which differ only in their per-doc mapping.
+ * Fetch a content-index block's list (cached) and run `transform` over the raw
+ * docs. A `transform` (not a per-doc mapper) because the meditations type is
+ * 1-doc→many-cards (a user-choice category expands into its meditations), while
+ * cards/tracks are 1:1.
  */
 async function resolveContentIndex<T>(
   fields: ContentIndexBlockFields,
   options: ResolveOptions,
-  mapper: (doc: Record<string, unknown>) => T | null,
+  transform: (docs: Record<string, unknown>[]) => T[],
 ): Promise<T[]> {
   if (!fields.apiEndpoint) {
     return []
@@ -175,11 +201,7 @@ async function resolveContentIndex<T>(
     cacheKey: contentIndexCacheKey(fields, options),
     ttl: CacheTTL.LIST,
     bypassCache: options.preview === true,
-    fetchFn: async () => {
-      const docs = await fetchContentIndexDocs(fields, options)
-
-      return docs.map(mapper).filter((mapped): mapped is T => mapped !== null)
-    },
+    fetchFn: async () => transform(await fetchContentIndexDocs(fields, options)),
   })
 }
 
@@ -188,7 +210,17 @@ export function resolveContentIndexItems(
   fields: ContentIndexBlockFields,
   options: ResolveOptions = {},
 ): Promise<ResolvedCardItem[]> {
-  return resolveContentIndex(fields, options, (doc) => contentIndexCard(doc, fields.type))
+  // Meditations resolve to user-choice categories and flatten into a deduped,
+  // facet-tagged grid; pages/lectures map one card per doc.
+  const transform =
+    fields.type === 'meditations'
+      ? meditationCardsFromUserChoices
+      : (docs: Record<string, unknown>[]) =>
+          docs
+            .map((doc) => contentIndexCard(doc, fields.type))
+            .filter((card): card is ResolvedCardItem => card !== null)
+
+  return resolveContentIndex(fields, options, transform)
 }
 
 /** Fetch and map a `songs` content-index block's list to playable tracks. */
@@ -196,7 +228,9 @@ export function resolveContentIndexTracks(
   fields: ContentIndexBlockFields,
   options: ResolveOptions = {},
 ): Promise<Track[]> {
-  return resolveContentIndex(fields, options, contentIndexTrack)
+  return resolveContentIndex(fields, options, (docs) =>
+    docs.map(contentIndexTrack).filter((track): track is Track => track !== null),
+  )
 }
 
 /** Recursively collect every `content-index` block's `fields` object. */

--- a/server/payload-types.ts
+++ b/server/payload-types.ts
@@ -607,6 +607,7 @@ export type RoleSlug =
   | 'meditations-editor'
   | 'path-editor'
   | 'web-translator'
+  | 'atlas-manager'
   | 'wemeditate-web-client'
   | 'wemeditate-app-client'
   | 'sahaj-atlas-client';
@@ -1053,7 +1054,7 @@ export interface Manager {
   /**
    * Assign roles for each locale. Different roles can be assigned for different languages.
    */
-  roles?: ('meditations-editor' | 'path-editor' | 'web-translator')[] | null;
+  roles?: ('meditations-editor' | 'path-editor' | 'web-translator' | 'atlas-manager')[] | null;
   /**
    * Pages this manager can edit.
    */
@@ -2141,7 +2142,7 @@ export interface Region {
     totalDocs?: number;
   };
   /**
-   * Region-level nodes nested directly beneath this one.
+   * Region-level nodes anywhere beneath this one.
    */
   childrenRegions?: {
     docs?: (number | Region)[];
@@ -2149,7 +2150,7 @@ export interface Region {
     totalDocs?: number;
   };
   /**
-   * Cities nested directly beneath this one.
+   * Cities anywhere beneath this one.
    */
   childrenCities?: {
     docs?: (number | Region)[];
@@ -2157,13 +2158,21 @@ export interface Region {
     totalDocs?: number;
   };
   /**
-   * SY Centers nested directly beneath this one.
+   * SY Centers anywhere beneath this one.
    */
   childrenCenters?: {
     docs?: (number | Region)[];
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * When enabled, the slug will auto-generate from the title field on save and autosave.
+   */
+  generateSlug?: boolean | null;
+  /**
+   * Stable identifier for Atlas routing (auto-generated from name).
+   */
+  slug: string;
   breadcrumbs?:
     | {
         doc?: (number | null) | Region;
@@ -3777,21 +3786,13 @@ export interface Client {
    */
   managers: (number | Manager)[];
   /**
-   * Primary user contact for this client
+   * Primary user contact for this client. Only needed when more than one manager is assigned.
    */
-  primaryContact: number | Manager;
+  primaryContact?: (number | null) | Manager;
   /**
    * What domains are associated with this client. Put each domain on a new line.
    */
-  domains?: string | null;
-  /**
-   * Enable or disable API access for this client
-   */
-  active?: boolean | null;
-  /**
-   * Atlas public key — reference only. Payload issues its own API key for this service.
-   */
-  clientId?: string | null;
+  allowedDomains?: string | null;
   /**
    * Hex color code (e.g., #FF5733)
    */
@@ -4011,6 +4012,10 @@ export interface Client {
     | boolean
     | null;
   /**
+   * Public identifier for this service. Auto-generated, or the Atlas public key for imported services.
+   */
+  clientId?: string | null;
+  /**
    * Timestamp of last API key generation
    */
   keyGeneratedAt?: string | null;
@@ -4068,6 +4073,7 @@ export interface Client {
     | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
   enableAPIKey?: boolean | null;
   apiKey?: string | null;
   apiKeyIndex?: string | null;
@@ -4987,15 +4993,14 @@ export interface ClientsSelect<T extends boolean = true> {
   roles?: T;
   managers?: T;
   primaryContact?: T;
-  domains?: T;
-  active?: T;
-  clientId?: T;
+  allowedDomains?: T;
   color1?: T;
   color2?: T;
   color3?: T;
   locale?: T;
   region?: T;
   legacyConfig?: T;
+  clientId?: T;
   keyGeneratedAt?: T;
   usage?:
     | T
@@ -5013,6 +5018,7 @@ export interface ClientsSelect<T extends boolean = true> {
   legacyData?: T;
   updatedAt?: T;
   createdAt?: T;
+  _status?: T;
   enableAPIKey?: T;
   apiKey?: T;
   apiKeyIndex?: T;
@@ -5139,6 +5145,8 @@ export interface RegionsSelect<T extends boolean = true> {
   childrenRegions?: T;
   childrenCities?: T;
   childrenCenters?: T;
+  generateSlug?: T;
+  slug?: T;
   breadcrumbs?:
     | T
     | {
@@ -5490,6 +5498,10 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
 export interface WmWebConfig {
   id: number;
   homePage: number | Page;
+  /**
+   * Audience(s) the public We Meditate Web site targets for audience-gated content (e.g. related lectures). The site has no per-user login, so this fixed set is what it passes as the `audiences` param.
+   */
+  audiences: (number | Audience)[];
   /**
    * Select 2-3 pages to feature in the website header and footer.
    */
@@ -6640,6 +6652,7 @@ export interface PayloadJobsStat {
  */
 export interface WmWebConfigSelect<T extends boolean = true> {
   homePage?: T;
+  audiences?: T;
   featuredPages?: T;
   featuredArticles?: T;
   classPages?: T;
@@ -6945,6 +6958,241 @@ export interface TaskSchedulePublish {
     user?: (number | null) | Manager;
   };
   output?: unknown;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TextBoxBlock".
+ */
+export interface TextBoxBlock {
+  image: number | Image;
+  imagePosition: 'left' | 'right' | 'overlay';
+  textPosition?: ('left' | 'right' | 'center') | null;
+  textColor?: ('dark' | 'light') | null;
+  wisdomStyle?: boolean | null;
+  title?: string | null;
+  subtitle?: string | null;
+  text?: string | null;
+  buttonText?: string | null;
+  buttonUrl?: string | null;
+  /**
+   * Original import data (background, color, position, spacing, decorations)
+   */
+  importData?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'textbox';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LayoutBlock".
+ */
+export interface LayoutBlock {
+  style: 'grid' | 'tabs' | 'accordion' | 'list' | 'textList';
+  /**
+   * If you use this title instead of a regular heading block, this title will be used as a sticky header that remains visible as you scroll through the blocks.
+   */
+  title?: string | null;
+  /**
+   * Enter the title of the tab that should be open by default. Will be converted to match the tab anchor (e.g. "My Tab" → "#my-tab").
+   */
+  defaultTab?: string | null;
+  /**
+   * Display tabs as side-by-side columns on desktop screens.
+   */
+  useColumnsOnDesktop?: boolean | null;
+  items?:
+    | {
+        image?: (number | null) | Image;
+        title?: string | null;
+        titleUrl?: string | null;
+        text?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'layout';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ImageGalleryBlock".
+ */
+export interface ImageGalleryBlock {
+  items?: (number | Image)[] | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'image-gallery';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ShowcaseBlock".
+ */
+export interface ShowcaseBlock {
+  items?:
+    | (
+        | {
+            relationTo: 'meditations';
+            value: number | Meditation;
+          }
+        | {
+            relationTo: 'pages';
+            value: number | Page;
+          }
+        | {
+            relationTo: 'lectures';
+            value: number | Lecture;
+          }
+        | {
+            relationTo: 'app-cards';
+            value: number | AppCard;
+          }
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'showcase';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ButtonBlock".
+ */
+export interface ButtonBlock {
+  text: string;
+  url: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'button';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "QuoteBlock".
+ */
+export interface QuoteBlock {
+  title?: string | null;
+  text: string;
+  /**
+   * This is the author or other source for the quote.
+   */
+  credit?: string | null;
+  /**
+   * This will appear below the credit.
+   */
+  caption?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'quote';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TableOfContentsBlock".
+ */
+export interface TableOfContentsBlock {
+  /**
+   * Optional heading displayed above the list (e.g. "In this article")
+   */
+  title?: string | null;
+  /**
+   * Select headings above to include in the table of contents
+   */
+  headings?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'table-of-contents';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ContentIndexBlock".
+ */
+export interface ContentIndexBlock {
+  type: 'meditations' | 'pages' | 'songs' | 'lectures';
+  /**
+   * Maximum number of items to return (1–100)
+   */
+  limit: number;
+  /**
+   * Select page tags to use as filters for this index grid
+   */
+  pageFilters?: ('wisdom' | 'lifestyle' | 'creativity' | 'event' | 'technique')[] | null;
+  /**
+   * Select user choices to use as filters for this index grid
+   */
+  userChoiceFilters?: (number | UserChoice)[] | null;
+  /**
+   * Select music tags to use as filters for this index grid
+   */
+  songFilters?: (number | SongTag)[] | null;
+  apiEndpoint?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'content-index';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubtleSystemBlock".
+ */
+export interface SubtleSystemBlock {
+  left: number | Page;
+  right: number | Page;
+  center: number | Page;
+  mooladhara: number | Page;
+  kundalini: number | Page;
+  swadhistan: number | Page;
+  nabhi: number | Page;
+  void: number | Page;
+  anahat: number | Page;
+  vishuddhi: number | Page;
+  agnya: number | Page;
+  sahasrara: number | Page;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'subtle-system';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SplashBlock".
+ */
+export interface SplashBlock {
+  /**
+   * Select the layout style for this splash section
+   */
+  layout: 'default' | 'countdown' | 'app' | 'map-search';
+  /**
+   * Text colour for the splash. Light text suits a dark hero; dark text suits a light hero. The overlaid site-header theme follows this setting.
+   */
+  textColor?: ('dark' | 'light') | null;
+  /**
+   * Select one or more images for the splash section
+   */
+  images?: (number | Image)[] | null;
+  title?: string | null;
+  subtitle?: string | null;
+  /**
+   * Button or call-to-action text
+   */
+  actionText?: string | null;
+  /**
+   * URL for the action button
+   */
+  actionURL?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'splash';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Summary

Makes the `content-index` rich-text block interactive across all four content types: the list is resolved once server-side (SEO-friendly, KV-cached) and filtered client-side with multi-select pills.

- **pages / lectures** → new `ContentIndex` organism (masonry card grid + filter pills derived from each item's tags).
- **songs** → the existing `MusicLibrary` (playback + tag filtering); tracks resolve with playable audio + album art.
- **meditations** → the block resolves to user-choice *categories* (a duration/mood picker); their referenced meditations are flattened into a deduped grid with the categories as filter pills.
- Imageless cards get a branded (teal + white logo) fallback; empty/unresolved lists render nothing.

## Changes

- `server/content-index.ts` — per-type `select`/`populate`/`depth`; strip any CMS-baked `depth` before appending ours (duplicate `depth` params 400 the backend); `resolveContentIndex` now takes a `transform(docs)` so meditations can expand 1-category→many-cards; `type` folded into the cache key.
- `lib/cms-blocks.ts` — `contentIndexCard`/`contentIndexTrack` mappers, `meditationCardsFromUserChoices` flatten+dedupe, page/lecture facet tags, `filename`-aware song image resolution.
- `components/organisms/ContentIndex/` — new organism; pills built on the `Button` atom (square/ghost).
- `components/organisms/RichText/blockConverters.tsx` — dispatch `content-index` by type (songs → MusicLibrary; everything else → ContentIndex).
- `components/molecules/ContentCard` / `ContentGrid` — branded imageless fallback; keep column width independent of item count.
- `lib/cms-routes.ts` — enable the `lectures` outbound route builder (`/lectures/:id`).

## Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 338 passed (`pnpm test:run`)
- Build: ✓ Success (`pnpm build`)

## Manual verification

1. `/inspiration` (pages) — toggle filter pills; single-item filter keeps card width consistent.
2. `/music-for-meditation` (songs) — MusicLibrary renders all tracks with playable audio; tag filters work.
3. `/meditate-now` (meditations) — grid of meditation cards with "5 min / 5-10 min / 10-15 min" category pills; play buttons link to `/meditations/:id`.
4. Ladle → Organisms → Content Index — all / filtered / empty states.

## Notes for reviewer

- **CMS data-quality:** meditation cards show the internal `label` ("Feel harmony-10 min-Neelam") because the meditations' public `title` is null upstream. Not a code bug — clean titles appear once the CMS populates `title`.
- **Songs upload gotcha:** a `Song`'s `url`/`thumbnailURL` are Payload afterRead virtuals derived from `filename`, so the query must `select[filename]` (and `populate[images][filename]`) or they return `null` and every track is dropped.
- **Lectures feed** returns no `userChoices`, so lecture pills are dormant until sydevs/SahajCloud#526 lands; `WmWebConfig.audiences` is currently empty, so the lectures path is inactive.
- The duplicate-`depth` 400 on `/meditate-now` was pre-existing on `main`; fixed here.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
