### PR TITLE
feat(header): highlight active nav link, hide title on nav pages

### DIFF
--- a/components/atoms/Button/Button.stories.tsx
+++ b/components/atoms/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { Button } from "./Button";
+import type { Story, StoryDefault } from '@ladle/react'
+import { Button } from './Button'
 import {
   PlayIcon,
   PauseIcon,
@@ -23,12 +23,12 @@ import {
   StoryGridHeaderCell,
   StoryGridBody,
   StoryGridRow,
-  StoryGridCell
-} from '../../ladle';
+  StoryGridCell,
+} from '../../ladle'
 
 export default {
-  title: "Atoms"
-} satisfies StoryDefault;
+  title: 'Atoms',
+} satisfies StoryDefault
 
 /**
  * Unified Button component showcasing all variants, sizes, shapes, and use cases.
@@ -55,80 +55,100 @@ export const Default: Story = () => (
           <StoryGridRow>
             <StoryGridCell isLabel>Primary</StoryGridCell>
             <StoryGridCell>
-              <Button icon={PlayIcon} variant="primary" shape="square" aria-label="Play" />
+              <Button aria-label="Play" icon={PlayIcon} shape="square" variant="primary" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={PlayIcon} variant="primary" shape="circular" aria-label="Play" />
+              <Button aria-label="Play" icon={PlayIcon} shape="circular" variant="primary" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={PlayIcon} variant="primary" shape="square">Button</Button>
+              <Button icon={PlayIcon} shape="square" variant="primary">
+                Button
+              </Button>
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={PlayIcon} variant="primary" shape="circular">Button</Button>
+              <Button icon={PlayIcon} shape="circular" variant="primary">
+                Button
+              </Button>
             </StoryGridCell>
           </StoryGridRow>
 
           <StoryGridRow>
             <StoryGridCell isLabel>Secondary</StoryGridCell>
             <StoryGridCell>
-              <Button icon={HeartIcon} variant="secondary" shape="square" aria-label="Like" />
+              <Button aria-label="Like" icon={HeartIcon} shape="square" variant="secondary" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={HeartIcon} variant="secondary" shape="circular" aria-label="Like" />
+              <Button aria-label="Like" icon={HeartIcon} shape="circular" variant="secondary" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={HeartIcon} variant="secondary" shape="square">Button</Button>
+              <Button icon={HeartIcon} shape="square" variant="secondary">
+                Button
+              </Button>
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={HeartIcon} variant="secondary" shape="circular">Button</Button>
+              <Button icon={HeartIcon} shape="circular" variant="secondary">
+                Button
+              </Button>
             </StoryGridCell>
           </StoryGridRow>
 
           <StoryGridRow>
             <StoryGridCell isLabel>Neutral</StoryGridCell>
             <StoryGridCell>
-              <Button icon={CheckIcon} variant="neutral" shape="square" aria-label="Confirm" />
+              <Button aria-label="Confirm" icon={CheckIcon} shape="square" variant="neutral" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={CheckIcon} variant="neutral" shape="circular" aria-label="Confirm" />
+              <Button aria-label="Confirm" icon={CheckIcon} shape="circular" variant="neutral" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={CheckIcon} variant="neutral" shape="square">Button</Button>
+              <Button icon={CheckIcon} shape="square" variant="neutral">
+                Button
+              </Button>
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={CheckIcon} variant="neutral" shape="circular">Button</Button>
+              <Button icon={CheckIcon} shape="circular" variant="neutral">
+                Button
+              </Button>
             </StoryGridCell>
           </StoryGridRow>
 
           <StoryGridRow>
             <StoryGridCell isLabel>Outline</StoryGridCell>
             <StoryGridCell>
-              <Button icon={StarIcon} variant="outline" shape="square" aria-label="Favorite" />
+              <Button aria-label="Favorite" icon={StarIcon} shape="square" variant="outline" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={StarIcon} variant="outline" shape="circular" aria-label="Favorite" />
+              <Button aria-label="Favorite" icon={StarIcon} shape="circular" variant="outline" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={StarIcon} variant="outline" shape="square">Button</Button>
+              <Button icon={StarIcon} shape="square" variant="outline">
+                Button
+              </Button>
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={StarIcon} variant="outline" shape="circular">Button</Button>
+              <Button icon={StarIcon} shape="circular" variant="outline">
+                Button
+              </Button>
             </StoryGridCell>
           </StoryGridRow>
 
           <StoryGridRow>
             <StoryGridCell isLabel>Ghost</StoryGridCell>
             <StoryGridCell>
-              <Button icon={XMarkIcon} variant="ghost" shape="square" aria-label="Close" />
+              <Button aria-label="Close" icon={XMarkIcon} shape="square" variant="ghost" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={XMarkIcon} variant="ghost" shape="circular" aria-label="Close" />
+              <Button aria-label="Close" icon={XMarkIcon} shape="circular" variant="ghost" />
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={XMarkIcon} variant="ghost" shape="square">Button</Button>
+              <Button icon={XMarkIcon} shape="square" variant="ghost">
+                Button
+              </Button>
             </StoryGridCell>
             <StoryGridCell>
-              <Button icon={XMarkIcon} variant="ghost" shape="circular">Button</Button>
+              <Button icon={XMarkIcon} shape="circular" variant="ghost">
+                Button
+              </Button>
             </StoryGridCell>
           </StoryGridRow>
         </StoryGridBody>
@@ -136,22 +156,32 @@ export const Default: Story = () => (
     </StorySection>
 
     <StorySection
-      title="Dark Theme"
-      theme="dark"
       background="neutral"
       description="All button variants on dark backgrounds - outline and ghost use white, primary and secondary remain vibrant"
+      theme="dark"
+      title="Dark Theme"
     >
       <div className="flex gap-4 items-center flex-wrap">
-        <Button variant="primary" theme="dark" icon={PlayIcon} aria-label="Play" />
-        <Button variant="primary" theme="dark">Primary</Button>
-        <Button variant="secondary" theme="dark" icon={HeartIcon} aria-label="Like" />
-        <Button variant="secondary" theme="dark">Secondary</Button>
-        <Button variant="neutral" theme="dark" icon={CheckIcon} aria-label="Confirm" />
-        <Button variant="neutral" theme="dark">Neutral</Button>
-        <Button variant="outline" theme="dark" icon={StarIcon} aria-label="Favorite" />
-        <Button variant="outline" theme="dark">Outline</Button>
-        <Button variant="ghost" theme="dark" icon={XMarkIcon} aria-label="Close" />
-        <Button variant="ghost" theme="dark">Ghost</Button>
+        <Button aria-label="Play" icon={PlayIcon} theme="dark" variant="primary" />
+        <Button theme="dark" variant="primary">
+          Primary
+        </Button>
+        <Button aria-label="Like" icon={HeartIcon} theme="dark" variant="secondary" />
+        <Button theme="dark" variant="secondary">
+          Secondary
+        </Button>
+        <Button aria-label="Confirm" icon={CheckIcon} theme="dark" variant="neutral" />
+        <Button theme="dark" variant="neutral">
+          Neutral
+        </Button>
+        <Button aria-label="Favorite" icon={StarIcon} theme="dark" variant="outline" />
+        <Button theme="dark" variant="outline">
+          Outline
+        </Button>
+        <Button aria-label="Close" icon={XMarkIcon} theme="dark" variant="ghost" />
+        <Button theme="dark" variant="ghost">
+          Ghost
+        </Button>
       </div>
     </StorySection>
 
@@ -166,16 +196,22 @@ export const Default: Story = () => (
         </StorySection>
         <StorySection title="Icon-only Buttons" variant="subsection">
           <div className="flex gap-4 items-center">
-            <Button icon={HeartIcon} size="sm" aria-label="Like (small)" />
-            <Button icon={HeartIcon} size="md" aria-label="Like (medium)" />
-            <Button icon={HeartIcon} size="lg" aria-label="Like (large)" />
+            <Button aria-label="Like (small)" icon={HeartIcon} size="sm" />
+            <Button aria-label="Like (medium)" icon={HeartIcon} size="md" />
+            <Button aria-label="Like (large)" icon={HeartIcon} size="lg" />
           </div>
         </StorySection>
         <StorySection title="Icon + Text Buttons" variant="subsection">
           <div className="flex gap-4 items-center">
-            <Button icon={CheckIcon} size="sm">Small</Button>
-            <Button icon={CheckIcon} size="md">Medium</Button>
-            <Button icon={CheckIcon} size="lg">Large</Button>
+            <Button icon={CheckIcon} size="sm">
+              Small
+            </Button>
+            <Button icon={CheckIcon} size="md">
+              Medium
+            </Button>
+            <Button icon={CheckIcon} size="lg">
+              Large
+            </Button>
           </div>
         </StorySection>
       </div>
@@ -188,26 +224,38 @@ export const Default: Story = () => (
             <div>
               <p className="text-sm text-gray-600 mb-2">Text Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button variant="primary" isLoading>Primary</Button>
-                <Button variant="secondary" isLoading>Secondary</Button>
-                <Button variant="outline" isLoading>Outline</Button>
-                <Button variant="ghost" isLoading>Ghost</Button>
+                <Button isLoading variant="primary">
+                  Primary
+                </Button>
+                <Button isLoading variant="secondary">
+                  Secondary
+                </Button>
+                <Button isLoading variant="outline">
+                  Outline
+                </Button>
+                <Button isLoading variant="ghost">
+                  Ghost
+                </Button>
               </div>
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-2">Icon-only Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button icon={PlayIcon} variant="primary" isLoading aria-label="Loading" />
-                <Button icon={HeartIcon} variant="secondary" isLoading aria-label="Loading" />
-                <Button icon={StarIcon} variant="outline" isLoading aria-label="Loading" />
-                <Button icon={XMarkIcon} variant="ghost" isLoading aria-label="Loading" />
+                <Button isLoading aria-label="Loading" icon={PlayIcon} variant="primary" />
+                <Button isLoading aria-label="Loading" icon={HeartIcon} variant="secondary" />
+                <Button isLoading aria-label="Loading" icon={StarIcon} variant="outline" />
+                <Button isLoading aria-label="Loading" icon={XMarkIcon} variant="ghost" />
               </div>
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-2">Icon + Text Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button icon={CheckIcon} variant="primary" isLoading>Saving</Button>
-                <Button icon={PlusIcon} variant="secondary" isLoading>Adding</Button>
+                <Button isLoading icon={CheckIcon} variant="primary">
+                  Saving
+                </Button>
+                <Button isLoading icon={PlusIcon} variant="secondary">
+                  Adding
+                </Button>
               </div>
             </div>
           </div>
@@ -218,29 +266,81 @@ export const Default: Story = () => (
             <div>
               <p className="text-sm text-gray-600 mb-2">Text Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button variant="primary" disabled>Primary</Button>
-                <Button variant="secondary" disabled>Secondary</Button>
-                <Button variant="outline" disabled>Outline</Button>
-                <Button variant="ghost" disabled>Ghost</Button>
+                <Button disabled variant="primary">
+                  Primary
+                </Button>
+                <Button disabled variant="secondary">
+                  Secondary
+                </Button>
+                <Button disabled variant="outline">
+                  Outline
+                </Button>
+                <Button disabled variant="ghost">
+                  Ghost
+                </Button>
               </div>
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-2">Icon-only Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button icon={PlayIcon} variant="primary" disabled aria-label="Play" />
-                <Button icon={HeartIcon} variant="secondary" disabled aria-label="Like" />
-                <Button icon={StarIcon} variant="outline" disabled aria-label="Favorite" />
-                <Button icon={XMarkIcon} variant="ghost" disabled aria-label="Close" />
+                <Button disabled aria-label="Play" icon={PlayIcon} variant="primary" />
+                <Button disabled aria-label="Like" icon={HeartIcon} variant="secondary" />
+                <Button disabled aria-label="Favorite" icon={StarIcon} variant="outline" />
+                <Button disabled aria-label="Close" icon={XMarkIcon} variant="ghost" />
               </div>
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-2">Icon + Text Buttons</p>
               <div className="flex gap-3 flex-wrap">
-                <Button icon={CheckIcon} variant="primary" disabled>Save</Button>
-                <Button icon={PlusIcon} variant="outline" disabled>Add</Button>
+                <Button disabled icon={CheckIcon} variant="primary">
+                  Save
+                </Button>
+                <Button disabled icon={PlusIcon} variant="outline">
+                  Add
+                </Button>
               </div>
             </div>
           </div>
+        </StorySection>
+      </div>
+    </StorySection>
+
+    <StorySection title="Active">
+      <div className="flex flex-col gap-6">
+        <StorySection title="Ghost on Light Background" variant="subsection">
+          <div className="flex gap-3 flex-wrap">
+            <Button isActive href="#" variant="ghost">
+              Meditate Now
+            </Button>
+            <Button href="#" variant="ghost">
+              Music for Meditation
+            </Button>
+            <Button href="#" variant="ghost">
+              Inspiration
+            </Button>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">
+            The active link keeps a persistent tinted fill and carries aria-current="page"
+          </p>
+        </StorySection>
+
+        <StorySection title="Ghost on Dark Background" variant="subsection">
+          <div className="bg-gray-900 p-6 rounded">
+            <div className="flex gap-3 flex-wrap">
+              <Button isActive href="#" theme="dark" variant="ghost">
+                Meditate Now
+              </Button>
+              <Button href="#" theme="dark" variant="ghost">
+                Music for Meditation
+              </Button>
+              <Button href="#" theme="dark" variant="ghost">
+                Inspiration
+              </Button>
+            </div>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">
+            The active tint is theme-aware — a lighter fill for dark (splash-overlay) headers
+          </p>
         </StorySection>
       </div>
     </StorySection>
@@ -249,32 +349,53 @@ export const Default: Story = () => (
       <div className="max-w-md flex flex-col items-start gap-3">
         <Button variant="primary">Ok</Button>
         <Button variant="secondary">Adaptive Button Width</Button>
-        <Button variant="outline" fullWidth>Full Width</Button>
+        <Button fullWidth variant="outline">
+          Full Width
+        </Button>
       </div>
       <p className="text-xs text-gray-500 mt-2">
-        Buttons automatically size to content with a minimum width constraint (min-w-20/24/28 for sm/md/lg)
+        Buttons automatically size to content with a minimum width constraint (min-w-20/24/28 for
+        sm/md/lg)
       </p>
     </StorySection>
 
-    <StorySection title="Examples" inContext={true}>
+    <StorySection inContext={true} title="Examples">
       <div className="flex flex-col gap-6">
-        <StorySection title="Call-to-Action on Light Background (wemeditate.com style)" variant="subsection">
+        <StorySection
+          title="Call-to-Action on Light Background (wemeditate.com style)"
+          variant="subsection"
+        >
           <div className="flex gap-4 flex-wrap">
-            <Button variant="outline" size="lg">Meditate Now</Button>
-            <Button variant="outline" size="lg">Learn More</Button>
-            <Button variant="outline" size="lg">Discover My Sound</Button>
+            <Button size="lg" variant="outline">
+              Meditate Now
+            </Button>
+            <Button size="lg" variant="outline">
+              Learn More
+            </Button>
+            <Button size="lg" variant="outline">
+              Discover My Sound
+            </Button>
           </div>
           <p className="text-xs text-gray-500 mt-2">
             Hover to see the animated background fill from center to edges
           </p>
         </StorySection>
 
-        <StorySection title="Call-to-Action on Dark Background (wemeditate.com style)" variant="subsection">
+        <StorySection
+          title="Call-to-Action on Dark Background (wemeditate.com style)"
+          variant="subsection"
+        >
           <div className="bg-gray-900 p-6 rounded">
             <div className="flex gap-4 flex-wrap">
-              <Button variant="outline" theme="dark" size="lg">Get Inspired</Button>
-              <Button variant="outline" theme="dark" size="lg">Start Today</Button>
-              <Button variant="outline" theme="dark" size="lg">Join Now</Button>
+              <Button size="lg" theme="dark" variant="outline">
+                Get Inspired
+              </Button>
+              <Button size="lg" theme="dark" variant="outline">
+                Start Today
+              </Button>
+              <Button size="lg" theme="dark" variant="outline">
+                Join Now
+              </Button>
             </div>
           </div>
           <p className="text-xs text-gray-500 mt-2">
@@ -291,16 +412,16 @@ export const Default: Story = () => (
 
         <StorySection title="Media Controls" variant="subsection">
           <div className="flex gap-3 flex-wrap">
-            <Button icon={PlayIcon} variant="primary" aria-label="Play" />
-            <Button icon={PauseIcon} variant="primary" aria-label="Pause" />
-            <Button icon={ChevronLeftIcon} variant="ghost" aria-label="Previous" />
-            <Button icon={ChevronRightIcon} variant="ghost" aria-label="Next" />
+            <Button aria-label="Play" icon={PlayIcon} variant="primary" />
+            <Button aria-label="Pause" icon={PauseIcon} variant="primary" />
+            <Button aria-label="Previous" icon={ChevronLeftIcon} variant="ghost" />
+            <Button aria-label="Next" icon={ChevronRightIcon} variant="ghost" />
           </div>
         </StorySection>
 
         <StorySection title="Dialog Actions" variant="subsection">
           <div className="flex gap-3 flex-wrap">
-            <Button icon={XMarkIcon} variant="ghost" shape="square" aria-label="Close dialog" />
+            <Button aria-label="Close dialog" icon={XMarkIcon} shape="square" variant="ghost" />
             <div className="flex-1" />
             <Button variant="ghost">Cancel</Button>
             <Button variant="primary">Confirm</Button>
@@ -309,17 +430,21 @@ export const Default: Story = () => (
 
         <StorySection title="Navigation" variant="subsection">
           <div className="flex gap-3 flex-wrap">
-            <Button icon={ChevronLeftIcon} variant="outline">Back</Button>
-            <Button icon={ArrowRightIcon} variant="primary">Continue</Button>
+            <Button icon={ChevronLeftIcon} variant="outline">
+              Back
+            </Button>
+            <Button icon={ArrowRightIcon} variant="primary">
+              Continue
+            </Button>
           </div>
         </StorySection>
 
         <StorySection title="Toolbar" variant="subsection">
           <div className="flex gap-2">
-            <Button icon={Bars3Icon} variant="ghost" aria-label="Menu" />
-            <Button icon={MagnifyingGlassIcon} variant="ghost" aria-label="Search" />
-            <Button icon={HeartIcon} variant="ghost" aria-label="Favorites" />
-            <Button icon={StarIcon} variant="ghost" aria-label="Rate" />
+            <Button aria-label="Menu" icon={Bars3Icon} variant="ghost" />
+            <Button aria-label="Search" icon={MagnifyingGlassIcon} variant="ghost" />
+            <Button aria-label="Favorites" icon={HeartIcon} variant="ghost" />
+            <Button aria-label="Rate" icon={StarIcon} variant="ghost" />
           </div>
         </StorySection>
       </div>
@@ -327,6 +452,6 @@ export const Default: Story = () => (
 
     <div />
   </StoryWrapper>
-);
+)
 
-Default.storyName = "Button"
+Default.storyName = 'Button'

--- a/components/atoms/Button/Button.test.tsx
+++ b/components/atoms/Button/Button.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Button } from './Button'
+
+describe('Button isActive (current-page nav state)', () => {
+  it('marks an active link with aria-current="page" and a persistent ghost fill', () => {
+    const html = renderToStaticMarkup(
+      <Button isActive href="/about" variant="ghost">
+        About
+      </Button>,
+    )
+
+    // aria-current signals the current page to assistive tech.
+    expect(html).toContain('aria-current="page"')
+    // The ghost fill (::after) is shown permanently rather than on hover.
+    expect(html).toContain('after:scale-x-100')
+    expect(html).toContain('after:opacity-100')
+    // Light theme reuses the ghost hover colour (gray-100).
+    expect(html).toContain('after:bg-gray-100')
+    // The hover-only hidden state is not emitted when active.
+    expect(html).not.toContain('after:scale-x-0')
+  })
+
+  it('uses the dark-theme ghost tint on dark backgrounds', () => {
+    const html = renderToStaticMarkup(
+      <Button isActive href="/about" theme="dark" variant="ghost">
+        About
+      </Button>,
+    )
+
+    expect(html).toContain('aria-current="page"')
+    expect(html).toContain('after:bg-white/20')
+  })
+
+  it('emits aria-current on the plain button (non-link) form too', () => {
+    const html = renderToStaticMarkup(
+      <Button isActive variant="ghost">
+        About
+      </Button>,
+    )
+
+    expect(html).toContain('<button')
+    expect(html).toContain('aria-current="page"')
+  })
+
+  it('does not mark inactive buttons and keeps the hover-triggered fill', () => {
+    const html = renderToStaticMarkup(
+      <Button href="/about" variant="ghost">
+        About
+      </Button>,
+    )
+
+    expect(html).not.toContain('aria-current')
+    // Inactive: fill starts hidden and scales in on hover.
+    expect(html).toContain('after:scale-x-0')
+    expect(html).toContain('hover:after:scale-x-100')
+  })
+})

--- a/components/atoms/Button/Button.tsx
+++ b/components/atoms/Button/Button.tsx
@@ -51,6 +51,15 @@ export interface ButtonProps extends Omit<ComponentProps<'button'>, 'type'> {
   isLoading?: boolean
 
   /**
+   * Active/current state for navigation links. When true, the button renders
+   * with a persistent tinted fill (reusing the ghost hover fill, so it's
+   * theme-aware) and carries `aria-current="page"`. Intended for the current
+   * page's link in a nav.
+   * @default false
+   */
+  isActive?: boolean
+
+  /**
    * Full width button (only applies to text buttons, not icon-only)
    * @default false
    */
@@ -114,6 +123,7 @@ export function Button({
   shape,
   icon,
   isLoading = false,
+  isActive = false,
   fullWidth = false,
   href,
   locale,
@@ -129,9 +139,16 @@ export function Button({
 
   // Styles for animated hover effect (wemeditate.com center-to-edges animation)
   // Uses ::after pseudo-element that scales from center on hover
-  // Only applied to text buttons, not icon-only buttons
-  const animatedHoverEffect =
-    'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10 after:scale-x-0 after:opacity-0 after:transition-all after:duration-300 after:ease-out hover:after:scale-x-100 hover:after:opacity-100'
+  // Only applied to text buttons, not icon-only buttons.
+  //
+  // When `isActive`, the same ::after fill is shown permanently (scaled/opaque
+  // instead of hover-triggered) so the current-page nav link keeps a persistent,
+  // theme-aware tint. It reuses each variant's `after:bg-*` colour (ghost →
+  // gray-100 on light, white/20 on dark), so no separate `bg-*` override is
+  // needed and there's no Tailwind class-order conflict.
+  const animatedHoverEffect = isActive
+    ? 'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10 after:scale-x-100 after:opacity-100'
+    : 'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10 after:scale-x-0 after:opacity-0 after:transition-all after:duration-300 after:ease-out hover:after:scale-x-100 hover:after:opacity-100'
 
   const baseStyles =
     'inline-flex items-center justify-center text-center font-sans font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none'
@@ -142,30 +159,24 @@ export function Button({
 
   // Variant styles for light theme (icon-only buttons)
   const iconOnlyLightThemeStyles = {
-    primary:
-      'bg-teal-500 hover:bg-teal-600 text-white focus:ring-teal-500 active:bg-teal-700',
+    primary: 'bg-teal-500 hover:bg-teal-600 text-white focus:ring-teal-500 active:bg-teal-700',
     secondary:
       'bg-coral-500 hover:bg-coral-600 text-white focus:ring-coral-500 active:bg-coral-700',
     outline:
       'bg-transparent border border-gray-500 text-gray-700 focus:ring-gray-500 hover:bg-teal-100 hover:border-gray-500',
-    ghost:
-      'bg-transparent text-gray-700 focus:ring-gray-400 hover:bg-gray-100 hover:text-gray-900',
-    neutral:
-      'bg-white text-gray-700 focus:ring-gray-400 hover:bg-gray-50 border border-gray-200',
+    ghost: 'bg-transparent text-gray-700 focus:ring-gray-400 hover:bg-gray-100 hover:text-gray-900',
+    neutral: 'bg-white text-gray-700 focus:ring-gray-400 hover:bg-gray-50 border border-gray-200',
   }
 
   // Variant styles for dark theme (icon-only buttons)
   const iconOnlyDarkThemeStyles = {
-    primary:
-      'bg-teal-500 hover:bg-teal-600 text-white focus:ring-teal-500 active:bg-teal-700',
+    primary: 'bg-teal-500 hover:bg-teal-600 text-white focus:ring-teal-500 active:bg-teal-700',
     secondary:
       'bg-coral-500 hover:bg-coral-600 text-white focus:ring-coral-500 active:bg-coral-700',
     outline:
       'bg-transparent border border-white text-white focus:ring-white hover:bg-white hover:text-gray-800 hover:border-white',
-    ghost:
-      'bg-transparent text-white focus:ring-white hover:bg-white/20 hover:text-white',
-    neutral:
-      'bg-white text-gray-700 focus:ring-gray-400 hover:bg-gray-50 border border-gray-200',
+    ghost: 'bg-transparent text-white focus:ring-white hover:bg-white/20 hover:text-white',
+    neutral: 'bg-white text-gray-700 focus:ring-gray-400 hover:bg-gray-50 border border-gray-200',
   }
 
   // Variant styles for light theme (text buttons with animation)
@@ -176,10 +187,8 @@ export function Button({
       'bg-coral-500 after:bg-coral-600 text-white focus:ring-coral-500 active:after:bg-coral-700',
     outline:
       'bg-transparent border border-gray-500 text-gray-700 focus:ring-gray-500 after:bg-teal-100 hover:border-gray-500',
-    ghost:
-      'bg-transparent text-gray-700 focus:ring-gray-400 after:bg-gray-100 hover:text-gray-900',
-    neutral:
-      'bg-white after:bg-gray-50 text-gray-700 focus:ring-gray-400 border border-gray-200',
+    ghost: 'bg-transparent text-gray-700 focus:ring-gray-400 after:bg-gray-100 hover:text-gray-900',
+    neutral: 'bg-white after:bg-gray-50 text-gray-700 focus:ring-gray-400 border border-gray-200',
   }
 
   // Variant styles for dark theme (text buttons with animation)
@@ -190,15 +199,17 @@ export function Button({
       'bg-coral-600 after:bg-coral-500 text-white focus:ring-coral-500 active:after:bg-coral-700',
     outline:
       'bg-transparent border border-white text-white focus:ring-white after:bg-white hover:text-gray-800 hover:border-white',
-    ghost:
-      'bg-transparent text-white focus:ring-white after:bg-white/20 hover:text-white',
-    neutral:
-      'bg-white after:bg-gray-50 text-gray-700 focus:ring-gray-400 border border-gray-200',
+    ghost: 'bg-transparent text-white focus:ring-white after:bg-white/20 hover:text-white',
+    neutral: 'bg-white after:bg-gray-50 text-gray-700 focus:ring-gray-400 border border-gray-200',
   }
 
   const variantStyles = isIconOnly
-    ? (theme === 'dark' ? iconOnlyDarkThemeStyles : iconOnlyLightThemeStyles)
-    : (theme === 'dark' ? textButtonDarkThemeStyles : textButtonLightThemeStyles)
+    ? theme === 'dark'
+      ? iconOnlyDarkThemeStyles
+      : iconOnlyLightThemeStyles
+    : theme === 'dark'
+      ? textButtonDarkThemeStyles
+      : textButtonLightThemeStyles
 
   // Size styles for icon-only buttons
   const iconOnlySizeStyles = {
@@ -248,8 +259,10 @@ export function Button({
   // Spinner colors and theme based on button variant and theme
   const getSpinnerColor = () => {
     if (variant === 'primary' || variant === 'secondary') return 'neutral' as const
-    if (variant === 'outline') return theme === 'dark' ? 'neutral' as const : 'primary' as const
-    if (variant === 'ghost') return theme === 'dark' ? 'neutral' as const : 'currentColor' as const
+    if (variant === 'outline') return theme === 'dark' ? ('neutral' as const) : ('primary' as const)
+    if (variant === 'ghost')
+      return theme === 'dark' ? ('neutral' as const) : ('currentColor' as const)
+
     return 'currentColor' as const
   }
 
@@ -258,13 +271,12 @@ export function Button({
     if (variant === 'primary' || variant === 'secondary') return 'dark'
     // Outline and ghost with dark theme also need white spinners
     if (theme === 'dark') return 'dark'
+
     // Otherwise use light theme
     return 'light'
   }
 
-  const sizeClass = isIconOnly
-    ? iconOnlySizeStyles[size]
-    : textButtonSizeStyles[size]
+  const sizeClass = isIconOnly ? iconOnlySizeStyles[size] : textButtonSizeStyles[size]
 
   // Default shape differs based on button type
   const defaultShape = isIconOnly ? 'circular' : 'square'
@@ -279,7 +291,7 @@ export function Button({
   const commonClassNames = `${baseStyles} ${animatedStyles} ${variantStyles[variant]} ${sizeClass} ${shapeClass} ${widthStyles} ${className}`
 
   const content = isLoading ? (
-    <Spinner size={spinnerSizeMap[size]} color={getSpinnerColor()} theme={getSpinnerTheme()} />
+    <Spinner color={getSpinnerColor()} size={spinnerSizeMap[size]} theme={getSpinnerTheme()} />
   ) : (
     <>
       {icon && <Icon icon={icon} size={iconSizeMap[size]} />}
@@ -291,11 +303,12 @@ export function Button({
   if (href) {
     return (
       <Link
+        aria-current={isActive ? 'page' : undefined}
+        aria-label={isIconOnly ? ariaLabel : undefined}
+        className={commonClassNames}
         href={href}
         locale={locale}
         variant="unstyled"
-        className={commonClassNames}
-        aria-label={isIconOnly ? ariaLabel : undefined}
         {...(props as any)}
       >
         {content}
@@ -306,11 +319,12 @@ export function Button({
   // Render as button
   return (
     <button
-      type={type}
+      aria-busy={isLoading}
+      aria-current={isActive ? 'page' : undefined}
+      aria-label={isIconOnly ? ariaLabel : undefined}
       className={commonClassNames}
       disabled={disabled || isLoading}
-      aria-busy={isLoading}
-      aria-label={isIconOnly ? ariaLabel : undefined}
+      type={type}
       {...props}
     >
       {content}

--- a/components/atoms/Button/Button.tsx
+++ b/components/atoms/Button/Button.tsx
@@ -146,9 +146,10 @@ export function Button({
   // theme-aware tint. It reuses each variant's `after:bg-*` colour (ghost →
   // gray-100 on light, white/20 on dark), so no separate `bg-*` override is
   // needed and there's no Tailwind class-order conflict.
+  const animatedBase = 'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10'
   const animatedHoverEffect = isActive
-    ? 'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10 after:scale-x-100 after:opacity-100'
-    : 'relative isolate overflow-hidden after:absolute after:inset-0 after:-z-10 after:scale-x-0 after:opacity-0 after:transition-all after:duration-300 after:ease-out hover:after:scale-x-100 hover:after:opacity-100'
+    ? `${animatedBase} after:scale-x-100 after:opacity-100`
+    : `${animatedBase} after:scale-x-0 after:opacity-0 after:transition-all after:duration-300 after:ease-out hover:after:scale-x-100 hover:after:opacity-100`
 
   const baseStyles =
     'inline-flex items-center justify-center text-center font-sans font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none'

--- a/components/organisms/Header/Header.stories.tsx
+++ b/components/organisms/Header/Header.stories.tsx
@@ -53,7 +53,8 @@ export const Default: Story = () => (
         ]}
         logoHref="/"
         navItems={[
-          { label: 'Meditate Now', href: '/meditate' },
+          // `active` marks the current page — a persistent tint + aria-current.
+          { label: 'Meditate Now', href: '/meditate', active: true },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
           // Link-less: opens the mega-menu, no navigation of its own.
@@ -100,7 +101,8 @@ export const Default: Story = () => (
         ]}
         logoHref="/"
         navItems={[
-          { label: 'Meditate Now', href: '/meditate' },
+          // `active` marks the current page — a persistent tint + aria-current.
+          { label: 'Meditate Now', href: '/meditate', active: true },
           { label: 'Music for Meditation', href: '/music' },
           { label: 'Inspiration', href: '/inspiration' },
           // Link-less: opens the mega-menu, no navigation of its own.

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -5,6 +5,20 @@ import { HeaderIllustrationSvg } from '../../atoms/graphics/svgs'
 import { HeaderNavDropdown } from './HeaderNavDropdown'
 import type { HeaderDropdownProps } from '../HeaderDropdown'
 
+/**
+ * A single top-level nav entry. An item with a `dropdown` renders as a
+ * link-less hover/click mega-menu (HeaderNavDropdown) instead of a flat link;
+ * such items omit `href`. Plain link items provide `href`. `active` marks the
+ * current page's link (persistent tint + `aria-current="page"`); it applies
+ * only to plain link items.
+ */
+export interface NavItem {
+  label: string
+  href?: string
+  active?: boolean
+  dropdown?: HeaderDropdownProps
+}
+
 export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> {
   /** Logo href (default: "/") */
   logoHref?: string
@@ -12,19 +26,8 @@ export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> 
   actionLinkText?: string
   /** Action link href */
   actionLinkHref?: string
-  /**
-   * Main navigation menu items. An item with a `dropdown` renders as a
-   * link-less hover/click mega-menu (HeaderNavDropdown) instead of a flat link;
-   * such items omit `href`. Plain link items provide `href`. `active` marks the
-   * current page's link (persistent tint + `aria-current="page"`); it applies
-   * only to plain link items.
-   */
-  navItems?: Array<{
-    label: string
-    href?: string
-    active?: boolean
-    dropdown?: HeaderDropdownProps
-  }>
+  /** Main navigation menu items. */
+  navItems?: NavItem[]
   /** Breadcrumb navigation items */
   breadcrumbs?: BreadcrumbItem[]
   /**

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -15,9 +15,16 @@ export interface HeaderProps extends Omit<ComponentProps<'header'>, 'children'> 
   /**
    * Main navigation menu items. An item with a `dropdown` renders as a
    * link-less hover/click mega-menu (HeaderNavDropdown) instead of a flat link;
-   * such items omit `href`. Plain link items provide `href`.
+   * such items omit `href`. Plain link items provide `href`. `active` marks the
+   * current page's link (persistent tint + `aria-current="page"`); it applies
+   * only to plain link items.
    */
-  navItems?: Array<{ label: string; href?: string; dropdown?: HeaderDropdownProps }>
+  navItems?: Array<{
+    label: string
+    href?: string
+    active?: boolean
+    dropdown?: HeaderDropdownProps
+  }>
   /** Breadcrumb navigation items */
   breadcrumbs?: BreadcrumbItem[]
   /**
@@ -150,6 +157,7 @@ export function Header({
                     key={index}
                     className="px-0 basis-1/4"
                     href={item.href}
+                    isActive={item.active}
                     size="sm"
                     theme={isSticky ? 'light' : theme}
                     variant="ghost"

--- a/components/organisms/Header/index.ts
+++ b/components/organisms/Header/index.ts
@@ -1,4 +1,4 @@
 export { Header } from './Header'
-export type { HeaderProps } from './Header'
+export type { HeaderProps, NavItem } from './Header'
 export { HeaderNavDropdown } from './HeaderNavDropdown'
 export type { HeaderNavDropdownProps } from './HeaderNavDropdown'

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -8,7 +8,7 @@
 
 // Header
 export { Header } from './Header'
-export type { HeaderProps } from './Header'
+export type { HeaderProps, NavItem } from './Header'
 export { HeaderNavDropdown } from './Header'
 export type { HeaderNavDropdownProps } from './Header'
 

--- a/components/templates/PageTemplate.test.tsx
+++ b/components/templates/PageTemplate.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import type { Page } from '../../server/cms-types'
+import { PageTemplate } from './PageTemplate'
+
+// PageTemplate calls usePageHead → vike-react's useConfig, which needs vike's
+// page context (absent in a bare node render). Stub it to a no-op setter.
+vi.mock('vike-react/useConfig', () => ({
+  useConfig: () => () => {},
+}))
+
+// VideoPlayer is wrapped in vike-react's ClientOnly; render its fallback (what
+// it renders server-side) so a page with a featured video still produces markup.
+vi.mock('vike-react/ClientOnly', () => ({
+  ClientOnly: ({ fallback }: { fallback?: ReactNode }) => fallback ?? null,
+}))
+
+/** Empty Lexical editor state — no lead splash, no body content. */
+const emptyContent = {
+  root: { type: 'root', children: [], direction: 'ltr', format: '', indent: 0, version: 1 },
+}
+
+function makePage(overrides: Partial<Page> = {}): Page {
+  return {
+    id: 1,
+    slug: 'meditate',
+    title: 'Meditate Now',
+    content: emptyContent,
+    author: null,
+    featuredVideo: null,
+    meta: null,
+    ...overrides,
+  } as unknown as Page
+}
+
+describe('<PageTemplate> hideTitle', () => {
+  it('renders the PageTitle by default', () => {
+    const html = renderToStaticMarkup(<PageTemplate page={makePage()} />)
+
+    expect(html).toContain('Meditate Now')
+  })
+
+  it('omits the PageTitle when hideTitle is true', () => {
+    const html = renderToStaticMarkup(<PageTemplate hideTitle page={makePage()} />)
+
+    expect(html).not.toContain('Meditate Now')
+  })
+
+  it('still renders the header (author byline) when hideTitle hides only the title', () => {
+    const page = makePage({
+      author: { id: 7, name: 'Shri Mataji' },
+    } as unknown as Partial<Page>)
+
+    const html = renderToStaticMarkup(<PageTemplate hideTitle page={page} />)
+
+    // Title suppressed, but the byline keeps the header container present.
+    expect(html).not.toContain('Meditate Now')
+    expect(html).toContain('Shri Mataji')
+  })
+})

--- a/components/templates/PageTemplate.tsx
+++ b/components/templates/PageTemplate.tsx
@@ -23,17 +23,26 @@ export interface PageTemplateProps {
    * Page data from PayloadCMS
    */
   page: Page
+
+  /**
+   * Suppress the PageTitle banner (e.g. on featured nav pages, where the
+   * highlighted nav link already names the page). When this is the only header
+   * element, the surrounding header Container collapses cleanly.
+   * @default false
+   */
+  hideTitle?: boolean
 }
 
-export function PageTemplate({ page }: PageTemplateProps) {
+export function PageTemplate({ page, hideTitle = false }: PageTemplateProps) {
   // Set <title>/description/og:image from CMS meta (must run unconditionally).
   usePageHead({ meta: page.meta, fallbackTitle: page.title })
 
   const author = isPopulated<Author>(page.author) ? page.author : null
   const video = isPopulated<Video>(page.featuredVideo) ? page.featuredVideo : null
   // A lead splash renders its own full-bleed title, so skip the PageTitle banner
-  // to avoid showing the title twice.
-  const showTitle = !getLeadSplash(page.content)
+  // to avoid showing the title twice. `hideTitle` also suppresses it on featured
+  // nav pages, where the highlighted nav link already names the page.
+  const showTitle = !getLeadSplash(page.content) && !hideTitle
   const hasVideo = Boolean(video && video.hlsUrl)
   const hasHeader = hasVideo || showTitle || Boolean(author)
 

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -4,7 +4,7 @@ import { Footer } from '../components/organisms/Footer'
 import { useData } from 'vike-react/useData'
 import { usePageContext } from 'vike-react/usePageContext'
 import type { WebConfig, Page } from '../server/cms-types'
-import type { HeaderDropdownProps } from '../components/organisms'
+import type { NavItem } from '../components/organisms'
 import { leadSplashFromRouteData } from '../lib/cms-blocks'
 import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
 
@@ -22,10 +22,7 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
     collection?: string
     initialData?: Page
   }>()
-  // `urlPathname` is the logical, locale-stripped path (onBeforeRoute rewrites
-  // `/es/about` → `/about` and `/` → `/index`), so comparing it to the
-  // locale-agnostic nav hrefs (`/slug`) highlights the right link in every locale.
-  const { locale, urlPathname } = usePageContext()
+  const { locale } = usePageContext()
   const settings = data?.settings
 
   // When the page leads with a Splash, overlay the header on it (transparent,
@@ -63,15 +60,16 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
   // "About Meditation" item that only opens the knowledge mega-menu (every
   // knowledge page as a link + the 2 featured-article thumbnails). Appended only
   // when there are knowledge pages to show — otherwise the nav is featured-only.
-  const navItems: Array<{
-    label: string
-    href?: string
-    active?: boolean
-    dropdown?: HeaderDropdownProps
-  }> = featuredPages.map((page) => ({
+  //
+  // Highlight the featured link for the current page. Match on the current
+  // page's slug (locale-agnostic, and the same fact `isFeaturedNavPage` uses to
+  // suppress that page's title) so the nav highlight and the hidden title always
+  // agree. `data.page` is absent on non-[slug] routes, so nothing highlights there.
+  const currentSlug = data?.page?.slug
+  const navItems: NavItem[] = featuredPages.map((page) => ({
     label: page.title,
     href: '/' + page.slug,
-    active: '/' + page.slug === urlPathname,
+    active: page.slug === currentSlug,
   }))
 
   if (knowledgePages.length > 0) {

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -22,7 +22,10 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
     collection?: string
     initialData?: Page
   }>()
-  const { locale } = usePageContext()
+  // `urlPathname` is the logical, locale-stripped path (onBeforeRoute rewrites
+  // `/es/about` → `/about` and `/` → `/index`), so comparing it to the
+  // locale-agnostic nav hrefs (`/slug`) highlights the right link in every locale.
+  const { locale, urlPathname } = usePageContext()
   const settings = data?.settings
 
   // When the page leads with a Splash, overlay the header on it (transparent,
@@ -60,11 +63,16 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
   // "About Meditation" item that only opens the knowledge mega-menu (every
   // knowledge page as a link + the 2 featured-article thumbnails). Appended only
   // when there are knowledge pages to show — otherwise the nav is featured-only.
-  const navItems: Array<{ label: string; href?: string; dropdown?: HeaderDropdownProps }> =
-    featuredPages.map((page) => ({
-      label: page.title,
-      href: '/' + page.slug,
-    }))
+  const navItems: Array<{
+    label: string
+    href?: string
+    active?: boolean
+    dropdown?: HeaderDropdownProps
+  }> = featuredPages.map((page) => ({
+    label: page.title,
+    href: '/' + page.slug,
+    active: '/' + page.slug === urlPathname,
+  }))
 
   if (knowledgePages.length > 0) {
     // TODO: Source this label from WmWebTranslations.navigation once that global

--- a/layouts/LayoutChrome.tsx
+++ b/layouts/LayoutChrome.tsx
@@ -7,6 +7,7 @@ import type { WebConfig, Page } from '../server/cms-types'
 import type { NavItem } from '../components/organisms'
 import { leadSplashFromRouteData } from '../lib/cms-blocks'
 import { pageToArticle, pageToLink, pickFeaturedArticles } from './headerDropdown'
+import { activeFeaturedSlug } from '../lib/featured-nav'
 
 /**
  * LayoutChrome — the full site chrome (Header, nav, Footer) around page content.
@@ -61,15 +62,15 @@ export default function LayoutChrome({ children }: { children: React.ReactNode }
   // knowledge page as a link + the 2 featured-article thumbnails). Appended only
   // when there are knowledge pages to show — otherwise the nav is featured-only.
   //
-  // Highlight the featured link for the current page. Match on the current
-  // page's slug (locale-agnostic, and the same fact `isFeaturedNavPage` uses to
-  // suppress that page's title) so the nav highlight and the hidden title always
-  // agree. `data.page` is absent on non-[slug] routes, so nothing highlights there.
-  const currentSlug = data?.page?.slug
+  // Highlight the featured link for the current page. Both the highlight and the
+  // title suppression (pages/[slug]/+Page.tsx) derive from `activeFeaturedSlug`,
+  // so they can't disagree. `data.page` is absent on non-[slug] routes, so
+  // `activeSlug` is undefined there and nothing highlights.
+  const activeSlug = activeFeaturedSlug(data?.page?.slug, settings)
   const navItems: NavItem[] = featuredPages.map((page) => ({
     label: page.title,
     href: '/' + page.slug,
-    active: page.slug === currentSlug,
+    active: page.slug === activeSlug,
   }))
 
   if (knowledgePages.length > 0) {

--- a/lib/featured-nav.test.ts
+++ b/lib/featured-nav.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import type { Page, WebConfig } from '../server/cms-types'
+import { isFeaturedNavPage } from './featured-nav'
+
+/** Minimal featured-page list keyed by slug — only `slug` is read. */
+function settings(slugs: string[]): Pick<WebConfig, 'featuredPages'> {
+  return { featuredPages: slugs.map((slug) => ({ slug }) as Page) }
+}
+
+describe('isFeaturedNavPage', () => {
+  it('is true when the page slug is one of the featured nav pages', () => {
+    expect(isFeaturedNavPage({ slug: 'meditate' }, settings(['meditate', 'music']))).toBe(true)
+  })
+
+  it('is false for a page that is not featured', () => {
+    expect(isFeaturedNavPage({ slug: 'about' }, settings(['meditate', 'music']))).toBe(false)
+  })
+
+  it('is false when there are no featured pages', () => {
+    expect(isFeaturedNavPage({ slug: 'meditate' }, settings([]))).toBe(false)
+  })
+})

--- a/lib/featured-nav.test.ts
+++ b/lib/featured-nav.test.ts
@@ -1,11 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import type { Page, WebConfig } from '../server/cms-types'
-import { isFeaturedNavPage } from './featured-nav'
+import { activeFeaturedSlug, isFeaturedNavPage } from './featured-nav'
 
 /** Minimal featured-page list keyed by slug — only `slug` is read. */
 function settings(slugs: string[]): Pick<WebConfig, 'featuredPages'> {
   return { featuredPages: slugs.map((slug) => ({ slug }) as Page) }
 }
+
+describe('activeFeaturedSlug', () => {
+  it('returns the slug when the current page is a featured nav page', () => {
+    expect(activeFeaturedSlug('meditate', settings(['meditate', 'music']))).toBe('meditate')
+  })
+
+  it('returns undefined for a page that is not featured', () => {
+    expect(activeFeaturedSlug('about', settings(['meditate', 'music']))).toBeUndefined()
+  })
+
+  it('returns undefined when there is no current slug (non-[slug] routes)', () => {
+    expect(activeFeaturedSlug(undefined, settings(['meditate']))).toBeUndefined()
+  })
+
+  it('returns undefined when there are no featured pages', () => {
+    expect(activeFeaturedSlug('meditate', settings([]))).toBeUndefined()
+  })
+})
 
 describe('isFeaturedNavPage', () => {
   it('is true when the page slug is one of the featured nav pages', () => {
@@ -18,5 +36,29 @@ describe('isFeaturedNavPage', () => {
 
   it('is false when there are no featured pages', () => {
     expect(isFeaturedNavPage({ slug: 'meditate' }, settings([]))).toBe(false)
+  })
+})
+
+// The nav highlight (LayoutChrome) and the title suppression (+Page) both key off
+// activeFeaturedSlug, so a page hides its title iff exactly its own nav link is active.
+describe('highlight and title-suppression agree', () => {
+  const s = settings(['meditate', 'music'])
+
+  it('a featured page suppresses its title and matches exactly its own nav link', () => {
+    const page = { slug: 'music' }
+    const active = activeFeaturedSlug(page.slug, s)
+
+    expect(isFeaturedNavPage(page, s)).toBe(true)
+    expect(active).toBe('music')
+    // Exactly one featured nav item is active, and it's this page's.
+    expect(s.featuredPages.filter((f) => f.slug === active)).toHaveLength(1)
+  })
+
+  it('a non-featured page keeps its title and activates no nav link', () => {
+    const page = { slug: 'about' }
+    const active = activeFeaturedSlug(page.slug, s)
+
+    expect(isFeaturedNavPage(page, s)).toBe(false)
+    expect(s.featuredPages.filter((f) => f.slug === active)).toHaveLength(0)
   })
 })

--- a/lib/featured-nav.ts
+++ b/lib/featured-nav.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared rule for "is this page one of the site's featured top-level nav pages"
+ * — the pages the header renders as plain nav links (settings.featuredPages).
+ *
+ * Kept framework-free and centralised so the two places that care agree:
+ *  - the header highlights the matching nav link (LayoutChrome), and
+ *  - the page suppresses its own PageTitle banner, since the highlighted nav
+ *    link already names the page (pages/[slug]/+Page.tsx → PageTemplate).
+ */
+import type { Page, WebConfig } from '../server/cms-types'
+
+/** True when `page` is one of the featured top-level nav pages. */
+export function isFeaturedNavPage(
+  page: Pick<Page, 'slug'>,
+  settings: Pick<WebConfig, 'featuredPages'>,
+): boolean {
+  return settings.featuredPages.some((featured) => featured.slug === page.slug)
+}

--- a/lib/featured-nav.ts
+++ b/lib/featured-nav.ts
@@ -1,22 +1,37 @@
 /**
- * Shared rule for "is this page one of the site's featured top-level nav pages"
- * — the pages the header renders as plain nav links (settings.featuredPages).
+ * Shared rule for the featured top-level nav pages — the pages the header
+ * renders as plain nav links (settings.featuredPages).
  *
- * Both current-page behaviours key off the same fact — the current page's slug
- * matching a featured page's slug — so they can't drift:
- *  - the header highlights the matching nav link (LayoutChrome compares each
- *    featured page's slug to the current page's slug), and
- *  - the page suppresses its own PageTitle banner via this predicate, since the
- *    highlighted nav link already names the page (pages/[slug]/+Page.tsx).
+ * Two current-page behaviours are driven off ONE primitive (`activeFeaturedSlug`)
+ * so they can't drift:
+ *  - the header highlights the featured nav link for the active slug (LayoutChrome), and
+ *  - that page suppresses its own PageTitle banner (pages/[slug]/+Page.tsx),
+ *    since the highlighted nav link already names it.
  *
- * Kept framework-free so the membership test can be unit-tested without rendering.
+ * Kept framework-free so the rule can be unit-tested without rendering.
  */
 import type { Page, WebConfig } from '../server/cms-types'
+
+/**
+ * The slug of the featured nav page for the current page, or `undefined` when
+ * the current page isn't a featured nav page.
+ *
+ * `currentSlug` and the featured pages' slugs come from the same-locale CMS
+ * fetch (see pages/[slug]/+data), so matching by slug is correct in every locale.
+ */
+export function activeFeaturedSlug(
+  currentSlug: string | undefined,
+  settings: Pick<WebConfig, 'featuredPages'>,
+): string | undefined {
+  if (!currentSlug) return undefined
+
+  return settings.featuredPages.find((featured) => featured.slug === currentSlug)?.slug
+}
 
 /** True when `page` is one of the featured top-level nav pages. */
 export function isFeaturedNavPage(
   page: Pick<Page, 'slug'>,
   settings: Pick<WebConfig, 'featuredPages'>,
 ): boolean {
-  return settings.featuredPages.some((featured) => featured.slug === page.slug)
+  return activeFeaturedSlug(page.slug, settings) !== undefined
 }

--- a/lib/featured-nav.ts
+++ b/lib/featured-nav.ts
@@ -2,10 +2,14 @@
  * Shared rule for "is this page one of the site's featured top-level nav pages"
  * — the pages the header renders as plain nav links (settings.featuredPages).
  *
- * Kept framework-free and centralised so the two places that care agree:
- *  - the header highlights the matching nav link (LayoutChrome), and
- *  - the page suppresses its own PageTitle banner, since the highlighted nav
- *    link already names the page (pages/[slug]/+Page.tsx → PageTemplate).
+ * Both current-page behaviours key off the same fact — the current page's slug
+ * matching a featured page's slug — so they can't drift:
+ *  - the header highlights the matching nav link (LayoutChrome compares each
+ *    featured page's slug to the current page's slug), and
+ *  - the page suppresses its own PageTitle banner via this predicate, since the
+ *    highlighted nav link already names the page (pages/[slug]/+Page.tsx).
+ *
+ * Kept framework-free so the membership test can be unit-tested without rendering.
  */
 import type { Page, WebConfig } from '../server/cms-types'
 

--- a/pages/[slug]/+Page.tsx
+++ b/pages/[slug]/+Page.tsx
@@ -6,19 +6,23 @@ import { useData } from 'vike-react/useData'
 import { PageData } from './+data'
 import { PageTemplate } from '../../components/templates'
 import { getLeadSplash } from '../../lib/cms-blocks'
+import { isFeaturedNavPage } from '../../lib/featured-nav'
 
 export function Page() {
-  const { page } = useData<PageData>()
+  const { page, settings } = useData<PageData>()
   // Drop the top padding when the page leads with a splash so the full-bleed hero
   // sits flush at the top of the page, under the overlaid header (see LayoutChrome).
   const leadSplash = getLeadSplash(page.content)
+  // On featured nav pages the highlighted nav link already names the page, so
+  // suppress the redundant PageTitle banner (see lib/featured-nav).
+  const hideTitle = isFeaturedNavPage(page, settings)
 
   return (
     // Horizontal gutters now come from the Container inside PageTemplate/RichText,
     // so no px here (avoids over-narrowing content). Drop the top padding when the
     // page leads with a splash so the full-bleed hero sits flush at the top.
     <div className={`min-h-screen ${leadSplash ? 'pb-12' : 'py-12'}`}>
-      <PageTemplate page={page} />
+      <PageTemplate hideTitle={hideTitle} page={page} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Featured header nav pages now get a current-page state: the matching nav link shows a persistent, theme-aware tint and carries `aria-current="page"`.
- On those pages the redundant on-page `PageTitle` banner is suppressed, since the highlighted nav link already names the page.
- Non-nav pages (articles, the mega-menu's Knowledge pages, the homepage) are unchanged — no link highlighted, title still shown.

## Changes

- `components/atoms/Button/Button.tsx` — new `isActive` prop: shows the existing ghost hover fill permanently (reuses each variant's `after:bg-*`, so it's theme-aware with no `bg-*` override or `!important`) and sets `aria-current="page"`.
- `components/organisms/Header/Header.tsx` — export a shared `NavItem` type; thread `isActive` into the plain-link nav Button (the dropdown trigger is untouched).
- `layouts/LayoutChrome.tsx` — mark the featured link whose page slug matches the current page's slug active — the same fact `isFeaturedNavPage` uses to hide the title, so the highlight and the hidden title can't drift.
- `lib/featured-nav.ts` — small shared `isFeaturedNavPage(page, settings)` predicate.
- `components/templates/PageTemplate.tsx` — new `hideTitle` prop folded into the existing `showTitle` gate; a title-only header collapses cleanly.
- `pages/[slug]/+Page.tsx` — suppress the title on featured nav pages. The preview route (no `settings`) keeps every title.

## Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 348 passed (`pnpm test:run`) — adds `Button.test.tsx`, `PageTemplate.test.tsx`, `featured-nav.test.ts`
- Build: N/A — no build-affecting changes (component/lib only)

## Manual verification

Verified against the live dev server + real CMS across locales:

| Page | `aria-current` | Active link | PageTitle |
| --- | --- | --- | --- |
| `/meditate-now` (featured) | 1 | `/meditate-now` | hidden ✓ |
| `/es/meditate-now` (locale) | 1 | `/es/meditate-now` | hidden ✓ |
| `/about-meditation` (Knowledge/dropdown) | 0 | — | shown ✓ |
| `/` (homepage) | 0 | — | n/a ✓ |

Ladle: Button `isActive` "Active" section (light + dark); Header story with one nav item flagged active.

## Notes for reviewer

- The active-link rule and the hide-title rule intentionally share one source of truth (the current page's slug vs `featuredPages` slugs) so they can never disagree.
- Edge case (dismissed): if the CMS explicitly lists the homepage among `featuredPages`, `/` would highlight that link and hide the homepage title — consistent with treating it as a featured page; not special-cased on purpose (that would reintroduce rule divergence).

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
