### PR TITLE
feat(meditations): cross-type related-content section on player pages

### DIFF
--- a/components/molecules/ContentCard/ContentCard.tsx
+++ b/components/molecules/ContentCard/ContentCard.tsx
@@ -246,10 +246,13 @@ export function ContentCard({
         )}
       </div>
 
-      {/* Content section */}
-      <div className={`flex flex-col ${contentGap}`}>
+      {/* Content section. In fixed-image-height mode the card sizes to the
+          image's natural width, so constrain the text to that width (`w-0
+          min-w-full` contributes 0 to the card's max-content but fills the image
+          width) — otherwise a title wider than the image would stretch the card. */}
+      <div className={`flex flex-col ${contentGap} ${imageHeight ? 'w-0 min-w-full' : ''}`}>
         {/* Title - styling based on variant and description presence */}
-        <h3 className={titleClasses}>
+        <h3 className={`${titleClasses} wrap-break-word`}>
           <Link
             className={
               isHeroVariant

--- a/components/molecules/blocks/ContentCarousel/ContentCarousel.stories.tsx
+++ b/components/molecules/blocks/ContentCarousel/ContentCarousel.stories.tsx
@@ -1,119 +1,123 @@
-import type { Story, StoryDefault } from "@ladle/react";
-import { ContentCarousel } from "./ContentCarousel";
-import { StoryWrapper, StorySection } from '../../../ladle';
+import type { Story, StoryDefault } from '@ladle/react'
+import { ContentCarousel } from './ContentCarousel'
+import { StoryWrapper, StorySection } from '../../../ladle'
 
 export default {
-  title: "Molecules"
-} satisfies StoryDefault;
+  title: 'Molecules',
+} satisfies StoryDefault
 
 // Sample meditation data - with play button, duration, title, and optional category badges (no description)
 const meditationItems = [
   {
-    title: "Inner Peace",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med1/800/450",
+    title: 'Inner Peace',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med1/800/450',
     playButton: true,
     durationMinutes: 15,
-    aspectRatio: "video" as const,
-    badge: "Relaxation",
-    badgeUrl: "#",
+    aspectRatio: 'video' as const,
+    badge: 'Relaxation',
+    badgeUrl: '#',
   },
   {
-    title: "Morning Energy",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med2/800/450",
+    title: 'Morning Energy',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med2/800/450',
     playButton: true,
     durationMinutes: 10,
-    aspectRatio: "video" as const,
+    aspectRatio: 'video' as const,
   },
   {
-    title: "Stress Relief",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med3/800/450",
+    title: 'Stress Relief',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med3/800/450',
     playButton: true,
     durationMinutes: 20,
-    aspectRatio: "video" as const,
-    badge: "Wellness",
-    badgeUrl: "#",
+    aspectRatio: 'video' as const,
+    badge: 'Wellness',
+    badgeUrl: '#',
   },
   {
-    title: "Deep Relaxation",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med4/800/450",
+    title: 'Deep Relaxation',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med4/800/450',
     playButton: true,
     durationMinutes: 25,
-    aspectRatio: "video" as const,
+    aspectRatio: 'video' as const,
   },
   {
-    title: "Focus & Concentration",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med5/800/450",
+    title: 'Focus & Concentration',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med5/800/450',
     playButton: true,
     durationMinutes: 12,
-    aspectRatio: "video" as const,
-    badge: "Focus",
-    badgeUrl: "#",
+    aspectRatio: 'video' as const,
+    badge: 'Focus',
+    badgeUrl: '#',
   },
   {
-    title: "Sleep Meditation",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/med6/800/450",
+    title: 'Sleep Meditation',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/med6/800/450',
     playButton: true,
     durationMinutes: 30,
-    aspectRatio: "video" as const,
-    badge: "Sleep",
-    badgeUrl: "#",
+    aspectRatio: 'video' as const,
+    badge: 'Sleep',
+    badgeUrl: '#',
   },
-];
+]
 
 // Sample article data - with title, description, varied aspect ratios, and category badges (no play button or duration)
 const articleItems = [
   {
-    title: "What is Meditation?",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/article1/800/800",
-    description: "Discover the ancient practice that brings peace and clarity to millions around the world.",
-    aspectRatio: "square" as const,
-    badge: "Philosophy",
-    badgeUrl: "#",
+    title: 'What is Meditation?',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/article1/800/800',
+    description:
+      'Discover the ancient practice that brings peace and clarity to millions around the world.',
+    aspectRatio: 'square' as const,
+    badge: 'Philosophy',
+    badgeUrl: '#',
   },
   {
-    title: "Benefits of Daily Practice",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/article2/800/600",
-    description: "Learn how a consistent meditation routine can transform your mental and physical well-being.",
-    aspectRatio: "4-3" as const,
-    badge: "Wellness",
-    badgeUrl: "#",
+    title: 'Benefits of Daily Practice',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/article2/800/600',
+    description:
+      'Learn how a consistent meditation routine can transform your mental and physical well-being.',
+    aspectRatio: '4-3' as const,
+    badge: 'Wellness',
+    badgeUrl: '#',
   },
   {
-    title: "Meditation for Beginners",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/article3/800/533",
-    description: "Start your meditation journey with these simple techniques and practical tips.",
-    aspectRatio: "3-2" as const,
-    badge: "Guides",
-    badgeUrl: "#",
+    title: 'Meditation for Beginners',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/article3/800/533',
+    description: 'Start your meditation journey with these simple techniques and practical tips.',
+    aspectRatio: '3-2' as const,
+    badge: 'Guides',
+    badgeUrl: '#',
   },
   {
-    title: "Finding Your Inner Peace",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/article4/800/450",
-    description: "Explore the path to tranquility and discover your true self through mindful awareness.",
-    aspectRatio: "video" as const,
-    badge: "Mindfulness",
-    badgeUrl: "#",
+    title: 'Finding Your Inner Peace',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/article4/800/450',
+    description:
+      'Explore the path to tranquility and discover your true self through mindful awareness.',
+    aspectRatio: 'video' as const,
+    badge: 'Mindfulness',
+    badgeUrl: '#',
   },
   {
-    title: "The Science Behind Meditation",
-    href: "#",
-    thumbnailSrc: "https://picsum.photos/seed/article5/800/800",
-    description: "Understand the neuroscience and research supporting meditation's transformative effects.",
-    aspectRatio: "square" as const,
-    badge: "Science",
-    badgeUrl: "#",
+    title: 'The Science Behind Meditation',
+    href: '#',
+    thumbnailSrc: 'https://picsum.photos/seed/article5/800/800',
+    description:
+      "Understand the neuroscience and research supporting meditation's transformative effects.",
+    aspectRatio: 'square' as const,
+    badge: 'Science',
+    badgeUrl: '#',
   },
-];
+]
 
 // Mixed content - combination of meditations and articles with varied aspect ratios
 const mixedItems = [
@@ -125,40 +129,44 @@ const mixedItems = [
   articleItems[2],
   meditationItems[3],
   articleItems[3],
-];
+]
 
 export const ContentCarouselStory: Story = () => (
   <StoryWrapper>
-    <StorySection title="Meditations" inContext={true}>
+    <StorySection title="Sizes">
+      <p className="text-sm text-gray-600 mb-4">
+        The <code>size</code> prop resizes the whole card — image height, title, spacing, and play
+        button — in a coordinated way. The nav arrows stay centered on the image.
+      </p>
+      <div className="flex flex-col gap-12">
+        <ContentCarousel items={meditationItems} size="sm" title="Small" />
+        <ContentCarousel items={meditationItems} size="md" title="Medium" />
+        <ContentCarousel items={meditationItems} size="lg" title="Large (default)" />
+      </div>
+    </StorySection>
+
+    <StorySection inContext={true} title="Meditations">
       <p className="text-sm text-gray-600 mb-4">
         Meditation carousel with play buttons, duration badges, and titles (no descriptions).
       </p>
-      <ContentCarousel
-        title="Featured Meditations"
-        items={meditationItems}
-      />
+      <ContentCarousel items={meditationItems} title="Featured Meditations" />
     </StorySection>
 
-    <StorySection title="Articles" inContext={true}>
+    <StorySection inContext={true} title="Articles">
       <p className="text-sm text-gray-600 mb-4">
-        Article carousel with titles, descriptions, and varied aspect ratios (no play buttons or duration).
+        Article carousel with titles, descriptions, and varied aspect ratios (no play buttons or
+        duration).
       </p>
-      <ContentCarousel
-        title="Latest Articles"
-        items={articleItems}
-      />
+      <ContentCarousel items={articleItems} title="Latest Articles" />
     </StorySection>
 
-    <StorySection title="Mixed Content" inContext={true}>
+    <StorySection inContext={true} title="Mixed Content">
       <p className="text-sm text-gray-600 mb-4">
         Combination of meditations and articles with varied aspect ratios and features.
       </p>
-      <ContentCarousel
-        title="Explore Content"
-        items={mixedItems}
-      />
+      <ContentCarousel items={mixedItems} title="Explore Content" />
     </StorySection>
   </StoryWrapper>
-);
+)
 
-ContentCarouselStory.storyName = "Content Carousel"
+ContentCarouselStory.storyName = 'Content Carousel'

--- a/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
+++ b/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
@@ -87,9 +87,14 @@ export function ContentCarousel({
     align: 'center',
     slidesToScroll: 1,
     containScroll: 'trimSnaps',
+    // A slide counts as "in view" (full opacity + interactive) once ~3/4
+    // visible. Basing focus on actual visibility — not a single centered index
+    // — means every fully-visible card stays bright and only edge-clipped
+    // peekers fade, however many slides fit at the current size/viewport.
+    inViewThreshold: 0.75,
   })
 
-  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [slidesInView, setSlidesInView] = useState<number[]>([])
   // Whether the carousel can scroll further in each direction; drives hiding the
   // prev/next arrows at the first/last slide.
   const [canScrollPrev, setCanScrollPrev] = useState(false)
@@ -103,9 +108,9 @@ export function ContentCarousel({
     if (emblaApi) emblaApi.scrollNext()
   }, [emblaApi])
 
-  const onSelect = useCallback(() => {
+  const updateState = useCallback(() => {
     if (!emblaApi) return
-    setSelectedIndex(emblaApi.selectedScrollSnap())
+    setSlidesInView(emblaApi.slidesInView())
     setCanScrollPrev(emblaApi.canScrollPrev())
     setCanScrollNext(emblaApi.canScrollNext())
   }, [emblaApi])
@@ -119,17 +124,20 @@ export function ContentCarousel({
 
   useEffect(() => {
     if (!emblaApi) return
-    onSelect()
-    emblaApi.on('select', onSelect)
-    // reInit fires when the slides change (e.g. items load in), so the arrow
-    // visibility stays correct after a late data fetch.
-    emblaApi.on('reInit', onSelect)
+    updateState()
+    emblaApi.on('select', updateState)
+    // slidesInView fires as slides enter/leave the viewport while scrolling.
+    emblaApi.on('slidesInView', updateState)
+    // reInit fires when the slides change (e.g. items load in), so arrow
+    // visibility + in-view state stay correct after a late data fetch.
+    emblaApi.on('reInit', updateState)
 
     return () => {
-      emblaApi.off('select', onSelect)
-      emblaApi.off('reInit', onSelect)
+      emblaApi.off('select', updateState)
+      emblaApi.off('slidesInView', updateState)
+      emblaApi.off('reInit', updateState)
     }
-  }, [emblaApi, onSelect])
+  }, [emblaApi, updateState])
 
   return (
     <div className={`relative ${className}`} {...props}>
@@ -178,17 +186,22 @@ export function ContentCarousel({
         <div ref={emblaRef} className="overflow-hidden">
           <div className={`flex ${slideGap}`}>
             {items.map((item, index) => {
-              const isFocused = index === selectedIndex
+              // Before Embla measures (SSR + first paint) slidesInView is empty;
+              // treat that as "all visible" so the row renders bright rather than
+              // fully dimmed until the fade kicks in on mount.
+              const inView = slidesInView.length === 0 || slidesInView.includes(index)
 
               return (
                 <div
                   key={index}
                   className={`flex-[0_0_auto] transition-opacity duration-300 ${
-                    isFocused ? 'opacity-100 cursor-default' : 'opacity-40 cursor-pointer'
+                    inView ? 'opacity-100 cursor-default' : 'opacity-40 cursor-pointer'
                   }`}
-                  onClick={() => scrollTo(index)}
+                  // A clipped/edge slide scrolls into view on click; a fully
+                  // visible one keeps its own links/play button clickable.
+                  onClick={inView ? undefined : () => scrollTo(index)}
                 >
-                  <div className={isFocused ? '' : 'pointer-events-none'}>
+                  <div className={inView ? '' : 'pointer-events-none'}>
                     {/* Fixed image height (natural width) → consistent row height
                         without forcing a single aspect ratio. */}
                     <ContentCard {...item} imageHeight={imageHeight} variant={card} />

--- a/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
+++ b/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
@@ -4,6 +4,24 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid'
 import { ContentCard, ContentCardProps } from '../../ContentCard/ContentCard'
 import { Button } from '../../../atoms/Button/Button'
 
+/** Carousel size variant. */
+export type ContentCarouselSize = 'sm' | 'md' | 'lg'
+
+/**
+ * Coordinated dimensions per size: the image height, the ContentCard variant
+ * (which scales the title, gap, and play button together), and the gap between
+ * slides. Keeping these in one place is what lets `size` resize the whole card
+ * proportionally instead of just the image.
+ */
+const CAROUSEL_SIZES: Record<
+  ContentCarouselSize,
+  { imageHeight: string; card: 'default' | 'hero'; slideGap: string }
+> = {
+  sm: { imageHeight: 'h-40 sm:h-44 lg:h-48', card: 'default', slideGap: 'gap-3 sm:gap-4' },
+  md: { imageHeight: 'h-48 sm:h-56 lg:h-64', card: 'hero', slideGap: 'gap-4 sm:gap-6' },
+  lg: { imageHeight: 'h-56 sm:h-64 lg:h-72', card: 'hero', slideGap: 'gap-4 sm:gap-6' },
+}
+
 export interface ContentCarouselProps extends Omit<ComponentProps<'div'>, 'title'> {
   /**
    * Array of content items to display in the carousel
@@ -16,12 +34,14 @@ export interface ContentCarouselProps extends Omit<ComponentProps<'div'>, 'title
   title?: string
 
   /**
-   * Fixed image height (Tailwind height classes) applied to every card so the
-   * row shares a consistent height while each image keeps its own aspect ratio
-   * (widths vary). Overrides each item's aspect ratio.
-   * @default 'h-56 sm:h-64 lg:h-72'
+   * Size variant — resizes the whole card (image height, title, gap, play
+   * button) in a coordinated way, and positions the nav arrows on the image.
+   * - `sm`: compact (smaller image + default card title)
+   * - `md`: medium image, hero card title
+   * - `lg`: large image, hero card title
+   * @default 'lg'
    */
-  imageHeight?: string
+  size?: ContentCarouselSize
 
   /**
    * Custom class name for the carousel container
@@ -30,14 +50,18 @@ export interface ContentCarouselProps extends Omit<ComponentProps<'div'>, 'title
 }
 
 /**
- * ContentCarousel block - displays a horizontal scrolling carousel of hero-variant ContentCards.
+ * ContentCarousel block - a horizontal scrolling carousel of ContentCards.
  *
  * Uses Embla Carousel for lightweight, performant carousel functionality with
- * arrow navigation buttons using the Button component.
+ * arrow navigation buttons using the Button component. Each card renders its
+ * image at a fixed height (natural width) so the row shares a consistent image
+ * height while each image keeps its own aspect ratio; `size` picks that height
+ * plus the matching card title/spacing.
  *
  * @example
  * <ContentCarousel
  *   title="Featured Meditations"
+ *   size="sm"
  *   items={[
  *     {
  *       title: "Inner Peace",
@@ -53,10 +77,12 @@ export interface ContentCarouselProps extends Omit<ComponentProps<'div'>, 'title
 export function ContentCarousel({
   items,
   title,
-  imageHeight = 'h-56 sm:h-64 lg:h-72',
+  size = 'lg',
   className = '',
   ...props
 }: ContentCarouselProps) {
+  const { imageHeight, card, slideGap } = CAROUSEL_SIZES[size]
+
   const [emblaRef, emblaApi] = useEmblaCarousel({
     align: 'center',
     slidesToScroll: 1,
@@ -64,6 +90,10 @@ export function ContentCarousel({
   })
 
   const [selectedIndex, setSelectedIndex] = useState(0)
+  // Whether the carousel can scroll further in each direction; drives hiding the
+  // prev/next arrows at the first/last slide.
+  const [canScrollPrev, setCanScrollPrev] = useState(false)
+  const [canScrollNext, setCanScrollNext] = useState(false)
 
   const scrollPrev = useCallback(() => {
     if (emblaApi) emblaApi.scrollPrev()
@@ -76,6 +106,8 @@ export function ContentCarousel({
   const onSelect = useCallback(() => {
     if (!emblaApi) return
     setSelectedIndex(emblaApi.selectedScrollSnap())
+    setCanScrollPrev(emblaApi.canScrollPrev())
+    setCanScrollNext(emblaApi.canScrollNext())
   }, [emblaApi])
 
   const scrollTo = useCallback(
@@ -89,9 +121,13 @@ export function ContentCarousel({
     if (!emblaApi) return
     onSelect()
     emblaApi.on('select', onSelect)
+    // reInit fires when the slides change (e.g. items load in), so the arrow
+    // visibility stays correct after a late data fetch.
+    emblaApi.on('reInit', onSelect)
 
     return () => {
       emblaApi.off('select', onSelect)
+      emblaApi.off('reInit', onSelect)
     }
   }, [emblaApi, onSelect])
 
@@ -100,50 +136,67 @@ export function ContentCarousel({
       {/* Optional title */}
       {title && <h2 className="text-2xl font-semibold text-gray-900 mb-6">{title}</h2>}
 
-      {/* Navigation buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 left-0 right-0 flex justify-between pointer-events-none z-10">
-        <Button
-          aria-label="Previous slide"
-          className="pointer-events-auto -translate-x-1/2 shadow-lg hover:shadow-xl transition-shadow"
-          icon={ChevronLeftIcon}
-          shape="square"
-          size="md"
-          variant="primary"
-          onClick={scrollPrev}
-        />
-        <Button
-          aria-label="Next slide"
-          className="pointer-events-auto translate-x-1/2 shadow-lg hover:shadow-xl transition-shadow"
-          icon={ChevronRightIcon}
-          shape="square"
-          size="md"
-          variant="primary"
-          onClick={scrollNext}
-        />
-      </div>
+      {/* Slides area — its own positioning context so the nav arrows overlay the
+          image row (not the whole section). */}
+      <div className="relative">
+        {/* Navigation buttons. The overlay box is exactly the image height and
+            top-aligned with the slides, so `items-center` keeps the arrows
+            centered on the image even when a title wraps to two lines. Each
+            arrow hides at its end of the carousel. */}
+        <div
+          className={`absolute top-0 left-0 right-0 ${imageHeight} flex items-center justify-between pointer-events-none z-10`}
+        >
+          <Button
+            aria-hidden={!canScrollPrev}
+            aria-label="Previous slide"
+            className={`-translate-x-1/2 shadow-lg hover:shadow-xl transition duration-200 ${
+              canScrollPrev ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+            }`}
+            icon={ChevronLeftIcon}
+            shape="square"
+            size="md"
+            tabIndex={canScrollPrev ? undefined : -1}
+            variant="primary"
+            onClick={scrollPrev}
+          />
+          <Button
+            aria-hidden={!canScrollNext}
+            aria-label="Next slide"
+            className={`translate-x-1/2 shadow-lg hover:shadow-xl transition duration-200 ${
+              canScrollNext ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+            }`}
+            icon={ChevronRightIcon}
+            shape="square"
+            size="md"
+            tabIndex={canScrollNext ? undefined : -1}
+            variant="primary"
+            onClick={scrollNext}
+          />
+        </div>
 
-      {/* Carousel viewport */}
-      <div ref={emblaRef} className="overflow-hidden">
-        <div className="flex gap-4 sm:gap-6">
-          {items.map((item, index) => {
-            const isFocused = index === selectedIndex
+        {/* Carousel viewport */}
+        <div ref={emblaRef} className="overflow-hidden">
+          <div className={`flex ${slideGap}`}>
+            {items.map((item, index) => {
+              const isFocused = index === selectedIndex
 
-            return (
-              <div
-                key={index}
-                className={`flex-[0_0_auto] transition-opacity duration-300 ${
-                  isFocused ? 'opacity-100 cursor-default' : 'opacity-40 cursor-pointer'
-                }`}
-                onClick={() => scrollTo(index)}
-              >
-                <div className={isFocused ? '' : 'pointer-events-none'}>
-                  {/* Fixed image height (natural width) → consistent row height
-                      without forcing a single aspect ratio. */}
-                  <ContentCard {...item} imageHeight={imageHeight} variant="hero" />
+              return (
+                <div
+                  key={index}
+                  className={`flex-[0_0_auto] transition-opacity duration-300 ${
+                    isFocused ? 'opacity-100 cursor-default' : 'opacity-40 cursor-pointer'
+                  }`}
+                  onClick={() => scrollTo(index)}
+                >
+                  <div className={isFocused ? '' : 'pointer-events-none'}>
+                    {/* Fixed image height (natural width) → consistent row height
+                        without forcing a single aspect ratio. */}
+                    <ContentCard {...item} imageHeight={imageHeight} variant={card} />
+                  </div>
                 </div>
-              </div>
-            )
-          })}
+              )
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
+++ b/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
@@ -87,10 +87,10 @@ export function ContentCarousel({
     align: 'center',
     slidesToScroll: 1,
     containScroll: 'trimSnaps',
-    // A slide counts as "in view" (full opacity + interactive) once ~3/4
-    // visible. Basing focus on actual visibility — not a single centered index
-    // — means every fully-visible card stays bright and only edge-clipped
-    // peekers fade, however many slides fit at the current size/viewport.
+    // A slide counts as "in view" (full opacity + interactive) once nearly
+    // fully (~0.95) visible. Basing focus on actual visibility — not a single
+    // centered index — means every fully-visible card stays bright and only
+    // edge-clipped peekers fade, however many slides fit at the current viewport.
     inViewThreshold: 0.95,
   })
 

--- a/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
+++ b/components/molecules/blocks/ContentCarousel/ContentCarousel.tsx
@@ -91,7 +91,7 @@ export function ContentCarousel({
     // visible. Basing focus on actual visibility — not a single centered index
     // — means every fully-visible card stays bright and only edge-clipped
     // peekers fade, however many slides fit at the current size/viewport.
-    inViewThreshold: 0.75,
+    inViewThreshold: 0.95,
   })
 
   const [slidesInView, setSlidesInView] = useState<number[]>([])

--- a/components/organisms/RelatedContent/RelatedContent.stories.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.stories.tsx
@@ -1,0 +1,71 @@
+import type { Story, StoryDefault } from '@ladle/react'
+import { RelatedContent } from './RelatedContent'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+import { StoryWrapper, StorySection } from '../../ladle'
+
+export default {
+  title: 'Organisms',
+} satisfies StoryDefault
+
+const card = (
+  id: number,
+  title: string,
+  seed: string,
+  durationMinutes?: number,
+): ResolvedCardItem => ({
+  id,
+  title,
+  href: '#',
+  thumbnailSrc: `https://picsum.photos/seed/${seed}/800/450`,
+  aspectRatio: 'video',
+  playButton: true,
+  durationMinutes,
+})
+
+const meditations: ResolvedCardItem[] = [
+  card(1, 'Meditation for Vishuddhi', 'rc-med-1', 19),
+  card(2, 'Meditation for Nabhi', 'rc-med-2', 18),
+  card(3, 'Meditation for Agnya', 'rc-med-3', 20),
+  card(4, 'Meditation for Mooladhara', 'rc-med-4', 18),
+]
+
+const lectures: ResolvedCardItem[] = [
+  card(1, 'Truth Has to Be Experienced', 'rc-lec-1', 16),
+  card(2, 'The Kundalini Cleanses and Nourishes', 'rc-lec-2', 8),
+  card(3, "Who Is This 'I'?", 'rc-lec-3', 10),
+]
+
+/**
+ * RelatedContent organism — a titled grid of related cards rendered below a
+ * meditation or lecture player. The meditation route shows related lectures and
+ * the lecture route shows related meditations (SahajCloud's cross-type mirror).
+ * An empty list renders nothing at all.
+ */
+export const Default: Story = () => (
+  <StoryWrapper>
+    <StorySection
+      description="Shown below the lecture player, sourced from GET /api/lectures/:id/related-meditations."
+      title="Related meditations"
+    >
+      <RelatedContent items={meditations} title="Related meditations" />
+    </StorySection>
+
+    <StorySection
+      description="Shown below the meditation player, sourced from GET /api/meditations/:id/related-lectures."
+      title="Related lectures"
+    >
+      <RelatedContent items={lectures} title="Related lectures" />
+    </StorySection>
+
+    <StorySection
+      description="No matches (or a degraded/empty fetch, or a non-English locale) renders nothing — no bare heading."
+      title="Empty"
+    >
+      <RelatedContent items={[]} title="Related meditations" />
+    </StorySection>
+
+    <div />
+  </StoryWrapper>
+)
+
+Default.storyName = 'Related Content'

--- a/components/organisms/RelatedContent/RelatedContent.test.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { RelatedContent } from './RelatedContent'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+
+const item = (id: number, title: string): ResolvedCardItem => ({
+  id,
+  title,
+  href: `/meditations/${id}`,
+  thumbnailSrc: `https://picsum.photos/seed/${id}/800/450`,
+  aspectRatio: 'video',
+  playButton: true,
+  durationMinutes: 12,
+})
+
+describe('RelatedContent', () => {
+  it('renders the heading and a card per item when items are present', () => {
+    const html = renderToStaticMarkup(
+      <RelatedContent items={[item(1, 'Alpha'), item(2, 'Beta')]} title="Related meditations" />,
+    )
+
+    expect(html).toContain('Related meditations')
+    expect(html).toContain('Alpha')
+    expect(html).toContain('Beta')
+    expect(html).toContain('/meditations/1')
+    expect(html).toContain('/meditations/2')
+    // Accessible section label for the related grouping.
+    expect(html).toContain('aria-label="Related meditations"')
+  })
+
+  it('renders nothing when there are no items (empty section omitted, not a bare heading)', () => {
+    const html = renderToStaticMarkup(<RelatedContent items={[]} title="Related meditations" />)
+
+    expect(html).toBe('')
+  })
+})

--- a/components/organisms/RelatedContent/RelatedContent.test.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.test.tsx
@@ -14,7 +14,7 @@ const item = (id: number, title: string): ResolvedCardItem => ({
 })
 
 describe('RelatedContent', () => {
-  it('renders the heading and a card per item when items are present', () => {
+  it('renders a titled carousel with a card per item when items are present', () => {
     const html = renderToStaticMarkup(
       <RelatedContent items={[item(1, 'Alpha'), item(2, 'Beta')]} title="Related meditations" />,
     )
@@ -24,8 +24,9 @@ describe('RelatedContent', () => {
     expect(html).toContain('Beta')
     expect(html).toContain('/meditations/1')
     expect(html).toContain('/meditations/2')
-    // Accessible section label for the related grouping.
-    expect(html).toContain('aria-label="Related meditations"')
+    // Rendered via ContentCarousel (its nav controls are present).
+    expect(html).toContain('aria-label="Previous slide"')
+    expect(html).toContain('aria-label="Next slide"')
   })
 
   it('renders nothing when there are no items (empty section omitted, not a bare heading)', () => {

--- a/components/organisms/RelatedContent/RelatedContent.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.tsx
@@ -1,6 +1,5 @@
 import type { ResolvedCardItem } from '../../../lib/cms-blocks'
-import { ContentGrid } from '../../molecules'
-import { Heading } from '../../atoms'
+import { ContentCarousel } from '../../molecules/blocks/ContentCarousel/ContentCarousel'
 
 export interface RelatedContentProps {
   /** Section heading, e.g. "Related meditations" / "Related lectures". */
@@ -14,26 +13,31 @@ export interface RelatedContentProps {
 }
 
 /**
- * RelatedContent organism — a titled `ContentGrid` of related cards shown below
- * a meditation or lecture player.
+ * RelatedContent organism — a titled `ContentCarousel` of related cards shown
+ * below a meditation or lecture player.
  *
  * Renders `null` when there are no items, so a page with no matches (or a
  * degraded/empty fetch, or a non-English locale where meditation titles don't
- * resolve) simply omits the whole section rather than showing a bare heading.
- * This is what keeps the section off the minimal embed route: the embed data
- * loader never fetches related content, so `items` is empty there.
+ * resolve) omits the whole section rather than showing a bare heading. It is
+ * loaded client-side by RelatedContentLoader, so `items` is empty until the
+ * (slow, KV-cached) related-content fetch resolves — nothing renders meanwhile.
  */
 export function RelatedContent({ title, items, className = '' }: RelatedContentProps) {
   if (items.length === 0) {
     return null
   }
 
+  // ContentCarousel items are `Omit<ContentCardProps, 'variant'>`; strip the
+  // fields ResolvedCardItem carries that ContentCardProps doesn't model (`id`
+  // is `string | number`, `tags` is a facet list) so they aren't spread onto
+  // the ContentCard DOM node.
+  const carouselItems = items.map(({ id: _id, tags: _tags, ...card }) => card)
+
   return (
-    <section aria-label={title} className={`mt-10 sm:mt-12 ${className}`}>
-      <Heading className="mb-6 text-center" level="h2" styleAs="h4">
-        {title}
-      </Heading>
-      <ContentGrid items={items} />
-    </section>
+    <ContentCarousel
+      className={`mt-10 sm:mt-12 ${className}`}
+      items={carouselItems}
+      title={title}
+    />
   )
 }

--- a/components/organisms/RelatedContent/RelatedContent.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.tsx
@@ -1,0 +1,39 @@
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+import { ContentGrid } from '../../molecules'
+import { Heading } from '../../atoms'
+
+export interface RelatedContentProps {
+  /** Section heading, e.g. "Related meditations" / "Related lectures". */
+  title: string
+  /**
+   * Server-resolved related cards (see lib/related-content.ts). An empty list
+   * renders nothing at all.
+   */
+  items: ResolvedCardItem[]
+  className?: string
+}
+
+/**
+ * RelatedContent organism — a titled `ContentGrid` of related cards shown below
+ * a meditation or lecture player.
+ *
+ * Renders `null` when there are no items, so a page with no matches (or a
+ * degraded/empty fetch, or a non-English locale where meditation titles don't
+ * resolve) simply omits the whole section rather than showing a bare heading.
+ * This is what keeps the section off the minimal embed route: the embed data
+ * loader never fetches related content, so `items` is empty there.
+ */
+export function RelatedContent({ title, items, className = '' }: RelatedContentProps) {
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <section aria-label={title} className={`mt-10 sm:mt-12 ${className}`}>
+      <Heading className="mb-6 text-center" level="h2" styleAs="h4">
+        {title}
+      </Heading>
+      <ContentGrid items={items} />
+    </section>
+  )
+}

--- a/components/organisms/RelatedContent/RelatedContent.tsx
+++ b/components/organisms/RelatedContent/RelatedContent.tsx
@@ -37,6 +37,7 @@ export function RelatedContent({ title, items, className = '' }: RelatedContentP
     <ContentCarousel
       className={`mt-10 sm:mt-12 ${className}`}
       items={carouselItems}
+      size="sm"
       title={title}
     />
   )

--- a/components/organisms/RelatedContent/RelatedContentLoader.tsx
+++ b/components/organisms/RelatedContent/RelatedContentLoader.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
+import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+import { RelatedContent } from './RelatedContent'
+
+export interface RelatedContentLoaderProps {
+  /** Section heading, e.g. "Related meditations" / "Related lectures". */
+  title: string
+  /**
+   * Which same-origin JSON route to load (see server/api-routes.ts):
+   * - `related-meditations` for a lecture anchor
+   * - `related-lectures` for a meditation anchor
+   */
+  kind: 'related-meditations' | 'related-lectures'
+  /** The anchor document id (the lecture/meditation the page is about). */
+  anchorId: string | number
+  className?: string
+}
+
+/**
+ * Client-side loader for the related-content section.
+ *
+ * The related endpoints are slow (~5–12s, KV-cached), so fetching them in a
+ * Vike `data()` hook would block SSR and trip the slow-hook warning. Instead the
+ * player page renders immediately and this loader fetches the (already mapped)
+ * cards from `/api/:kind/:anchorId` after mount, rendering nothing until they
+ * arrive. SSR and the first client render both produce an empty list → `null`
+ * (no hydration mismatch); the section appears once the fetch resolves.
+ */
+export function RelatedContentLoader({
+  title,
+  kind,
+  anchorId,
+  className,
+}: RelatedContentLoaderProps) {
+  const { locale } = usePageContext()
+  const [items, setItems] = useState<ResolvedCardItem[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    const url = `/api/${kind}/${encodeURIComponent(String(anchorId))}?locale=${encodeURIComponent(locale)}`
+
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : { items: [] }))
+      .then((data: { items?: ResolvedCardItem[] }) => {
+        if (!cancelled) {
+          setItems(Array.isArray(data.items) ? data.items : [])
+        }
+      })
+      .catch(() => {
+        // Related content is supplementary — a failed load just omits the section.
+        if (!cancelled) {
+          setItems([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [kind, anchorId, locale])
+
+  return <RelatedContent className={className} items={items} title={title} />
+}

--- a/components/organisms/RelatedContent/RelatedContentLoader.tsx
+++ b/components/organisms/RelatedContent/RelatedContentLoader.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { usePageContext } from 'vike-react/usePageContext'
 import type { ResolvedCardItem } from '../../../lib/cms-blocks'
+import { Spinner } from '../../atoms/Spinner/Spinner'
 import { RelatedContent } from './RelatedContent'
 
 export interface RelatedContentLoaderProps {
@@ -25,9 +26,12 @@ export interface RelatedContentLoaderProps {
  * The related endpoints are slow (~5–12s, KV-cached), so fetching them in a
  * Vike `data()` hook would block SSR and trip the slow-hook warning. Instead the
  * player page renders immediately and this loader fetches the (already mapped)
- * cards from `/api/:kind/:anchorId` after mount, rendering nothing until they
- * arrive. SSR and the first client render both produce an empty list → `null`
- * (no hydration mismatch); the section appears once the fetch resolves.
+ * cards from `/api/:kind/:anchorId` after mount.
+ *
+ * While the fetch is in flight (`items === null`) it shows the heading + a
+ * spinner so the wait is visible; it then swaps in the carousel, or renders
+ * nothing if the result is empty (e.g. a non-English locale). SSR and the first
+ * client render both show the loading state, so there's no hydration mismatch.
  */
 export function RelatedContentLoader({
   title,
@@ -36,10 +40,15 @@ export function RelatedContentLoader({
   className,
 }: RelatedContentLoaderProps) {
   const { locale } = usePageContext()
-  const [items, setItems] = useState<ResolvedCardItem[]>([])
+  // null → loading (fetch in flight); [] → loaded but empty; [...] → loaded.
+  const [items, setItems] = useState<ResolvedCardItem[] | null>(null)
 
   useEffect(() => {
     let cancelled = false
+
+    // Reset to the loading state when the anchor/locale changes (client nav).
+    setItems(null)
+
     const url = `/api/${kind}/${encodeURIComponent(String(anchorId))}?locale=${encodeURIComponent(locale)}`
 
     fetch(url)
@@ -60,6 +69,17 @@ export function RelatedContentLoader({
       cancelled = true
     }
   }, [kind, anchorId, locale])
+
+  if (items === null) {
+    return (
+      <section aria-busy className={`mt-10 sm:mt-12 ${className ?? ''}`}>
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">{title}</h2>
+        <div className="flex justify-center py-8">
+          <Spinner label={`Loading ${title.toLowerCase()}`} size="lg" />
+        </div>
+      </section>
+    )
+  }
 
   return <RelatedContent className={className} items={items} title={title} />
 }

--- a/components/organisms/RelatedContent/index.ts
+++ b/components/organisms/RelatedContent/index.ts
@@ -1,2 +1,4 @@
 export { RelatedContent } from './RelatedContent'
 export type { RelatedContentProps } from './RelatedContent'
+export { RelatedContentLoader } from './RelatedContentLoader'
+export type { RelatedContentLoaderProps } from './RelatedContentLoader'

--- a/components/organisms/RelatedContent/index.ts
+++ b/components/organisms/RelatedContent/index.ts
@@ -1,0 +1,2 @@
+export { RelatedContent } from './RelatedContent'
+export type { RelatedContentProps } from './RelatedContent'

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -77,3 +77,7 @@ export type { RichTextProps } from './RichText'
 // ContentIndex
 export { ContentIndex } from './ContentIndex'
 export type { ContentIndexProps } from './ContentIndex'
+
+// RelatedContent
+export { RelatedContent } from './RelatedContent'
+export type { RelatedContentProps } from './RelatedContent'

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -79,5 +79,5 @@ export { ContentIndex } from './ContentIndex'
 export type { ContentIndexProps } from './ContentIndex'
 
 // RelatedContent
-export { RelatedContent } from './RelatedContent'
-export type { RelatedContentProps } from './RelatedContent'
+export { RelatedContent, RelatedContentLoader } from './RelatedContent'
+export type { RelatedContentProps, RelatedContentLoaderProps } from './RelatedContent'

--- a/components/templates/LectureTemplate.tsx
+++ b/components/templates/LectureTemplate.tsx
@@ -13,11 +13,10 @@
  * <LectureTemplate lecture={resolvedLecture} locale="en" />
  */
 
-import type { ResolvedLecture, RelatedMeditationCard } from '../../server/cms-types'
+import type { ResolvedLecture } from '../../server/cms-types'
 import { EmbedButton, VideoPlayer } from '../molecules'
 import { Badge, PageTitle } from '../atoms'
-import { RelatedContent } from '../organisms/RelatedContent'
-import { relatedMeditationsToCards } from '../../lib/related-content'
+import { RelatedContentLoader } from '../organisms/RelatedContent'
 
 export interface LecturePlayerProps {
   /** Normalized lecture view model (full or clip). */
@@ -69,12 +68,12 @@ export interface LectureTemplateProps {
    */
   showEmbedButton?: boolean
   /**
-   * Meditations related to this lecture (from `getRelatedMeditations`), rendered
-   * as a grid below the player. Empty/omitted ⇒ no related section — which keeps
-   * the minimal embed route (LecturePlayer) player-only.
-   * @default []
+   * Whether to render the "Related meditations" section below the player (loaded
+   * client-side by RelatedContentLoader). The bare embed route uses LecturePlayer
+   * (not this template), so it's unaffected regardless.
+   * @default false
    */
-  relatedMeditations?: RelatedMeditationCard[]
+  showRelated?: boolean
 }
 
 /** Format a length in seconds as a duration label ("40 sec" / "20 min"). */
@@ -88,7 +87,7 @@ export function LectureTemplate({
   lecture,
   locale,
   showEmbedButton = true,
-  relatedMeditations = [],
+  showRelated = false,
 }: LectureTemplateProps) {
   // A clip shows its playable window length; a full lecture shows the whole
   // source duration.
@@ -133,12 +132,16 @@ export function LectureTemplate({
         ) : null}
       </div>
 
-      {/* Related meditations (SahajCloud cross-type mirror) — renders nothing
-          when empty, so the bare embed route (LecturePlayer) is unaffected. */}
-      <RelatedContent
-        items={relatedMeditationsToCards(relatedMeditations)}
-        title="Related meditations"
-      />
+      {/* Related meditations (SahajCloud cross-type mirror), loaded client-side
+          so the slow ranking endpoint never blocks SSR. The bare embed route
+          uses LecturePlayer (not this template), so it's unaffected regardless. */}
+      {showRelated ? (
+        <RelatedContentLoader
+          anchorId={lecture.id}
+          kind="related-meditations"
+          title="Related meditations"
+        />
+      ) : null}
     </article>
   )
 }

--- a/components/templates/LectureTemplate.tsx
+++ b/components/templates/LectureTemplate.tsx
@@ -13,9 +13,11 @@
  * <LectureTemplate lecture={resolvedLecture} locale="en" />
  */
 
-import type { ResolvedLecture } from '../../server/cms-types'
+import type { ResolvedLecture, RelatedMeditationCard } from '../../server/cms-types'
 import { EmbedButton, VideoPlayer } from '../molecules'
 import { Badge, PageTitle } from '../atoms'
+import { RelatedContent } from '../organisms/RelatedContent'
+import { relatedMeditationsToCards } from '../../lib/related-content'
 
 export interface LecturePlayerProps {
   /** Normalized lecture view model (full or clip). */
@@ -66,6 +68,13 @@ export interface LectureTemplateProps {
    * @default true
    */
   showEmbedButton?: boolean
+  /**
+   * Meditations related to this lecture (from `getRelatedMeditations`), rendered
+   * as a grid below the player. Empty/omitted ⇒ no related section — which keeps
+   * the minimal embed route (LecturePlayer) player-only.
+   * @default []
+   */
+  relatedMeditations?: RelatedMeditationCard[]
 }
 
 /** Format a length in seconds as a duration label ("40 sec" / "20 min"). */
@@ -75,7 +84,12 @@ function formatLength(seconds: number): string {
   return total < 60 ? `${total} sec` : `${Math.floor(total / 60)} min`
 }
 
-export function LectureTemplate({ lecture, locale, showEmbedButton = true }: LectureTemplateProps) {
+export function LectureTemplate({
+  lecture,
+  locale,
+  showEmbedButton = true,
+  relatedMeditations = [],
+}: LectureTemplateProps) {
   // A clip shows its playable window length; a full lecture shows the whole
   // source duration.
   const windowSeconds =
@@ -118,6 +132,13 @@ export function LectureTemplate({ lecture, locale, showEmbedButton = true }: Lec
           />
         ) : null}
       </div>
+
+      {/* Related meditations (SahajCloud cross-type mirror) — renders nothing
+          when empty, so the bare embed route (LecturePlayer) is unaffected. */}
+      <RelatedContent
+        items={relatedMeditationsToCards(relatedMeditations)}
+        title="Related meditations"
+      />
     </article>
   )
 }

--- a/components/templates/MeditationTemplate.tsx
+++ b/components/templates/MeditationTemplate.tsx
@@ -14,12 +14,11 @@
  * <MeditationTemplate meditation={meditationData} />
  */
 
-import type { Meditation, MeditationSong, RelatedLectureCard } from '../../server/cms-types'
+import type { Meditation, MeditationSong } from '../../server/cms-types'
 import { MeditationPlayer, type MeditationFrame } from '../organisms/MeditationPlayer'
-import { RelatedContent } from '../organisms/RelatedContent'
+import { RelatedContentLoader } from '../organisms/RelatedContent'
 import { EmbedButton } from '../molecules'
 import { populatedImageUrl } from '../../lib/cms-relationships'
-import { relatedLecturesToCards } from '../../lib/related-content'
 
 export interface MeditationTemplateProps {
   /**
@@ -54,12 +53,12 @@ export interface MeditationTemplateProps {
    */
   showEmbedButton?: boolean
   /**
-   * Lectures related to this meditation (from `getRelatedLectures`), rendered as
-   * a grid below the player. Empty/omitted ⇒ no related section — which is how
-   * the minimal embed route stays player-only (it never fetches these).
-   * @default []
+   * Whether to render the "Related lectures" section below the player (loaded
+   * client-side by RelatedContentLoader). Off on the minimal embed route so it
+   * stays player-only.
+   * @default false
    */
-  relatedLectures?: RelatedLectureCard[]
+  showRelated?: boolean
 }
 
 export function MeditationTemplate({
@@ -69,7 +68,7 @@ export function MeditationTemplate({
   timeDisplay,
   seekTo,
   showEmbedButton = true,
-  relatedLectures = [],
+  showRelated = false,
 }: MeditationTemplateProps) {
   // Get CMS base URL for building full frame URLs
   const cmsBaseUrl = import.meta.env.PUBLIC__SAHAJCLOUD_URL || ''
@@ -200,9 +199,15 @@ export function MeditationTemplate({
         />
       </div>
 
-      {/* Related lectures (SahajCloud cross-type mirror) — renders nothing when
-          empty, so the embed route (which never fetches these) stays bare. */}
-      <RelatedContent items={relatedLecturesToCards(relatedLectures)} title="Related lectures" />
+      {/* Related lectures (SahajCloud cross-type mirror), loaded client-side so
+          the slow ranking endpoint never blocks SSR. Off on the embed route. */}
+      {showRelated ? (
+        <RelatedContentLoader
+          anchorId={meditation.id}
+          kind="related-lectures"
+          title="Related lectures"
+        />
+      ) : null}
     </>
   )
 }

--- a/components/templates/MeditationTemplate.tsx
+++ b/components/templates/MeditationTemplate.tsx
@@ -14,10 +14,12 @@
  * <MeditationTemplate meditation={meditationData} />
  */
 
-import type { Meditation, MeditationSong } from '../../server/cms-types'
+import type { Meditation, MeditationSong, RelatedLectureCard } from '../../server/cms-types'
 import { MeditationPlayer, type MeditationFrame } from '../organisms/MeditationPlayer'
+import { RelatedContent } from '../organisms/RelatedContent'
 import { EmbedButton } from '../molecules'
 import { populatedImageUrl } from '../../lib/cms-relationships'
+import { relatedLecturesToCards } from '../../lib/related-content'
 
 export interface MeditationTemplateProps {
   /**
@@ -51,6 +53,13 @@ export interface MeditationTemplateProps {
    * @default true
    */
   showEmbedButton?: boolean
+  /**
+   * Lectures related to this meditation (from `getRelatedLectures`), rendered as
+   * a grid below the player. Empty/omitted ⇒ no related section — which is how
+   * the minimal embed route stays player-only (it never fetches these).
+   * @default []
+   */
+  relatedLectures?: RelatedLectureCard[]
 }
 
 export function MeditationTemplate({
@@ -60,6 +69,7 @@ export function MeditationTemplate({
   timeDisplay,
   seekTo,
   showEmbedButton = true,
+  relatedLectures = [],
 }: MeditationTemplateProps) {
   // Get CMS base URL for building full frame URLs
   const cmsBaseUrl = import.meta.env.PUBLIC__SAHAJCLOUD_URL || ''
@@ -157,36 +167,42 @@ export function MeditationTemplate({
   }
 
   return (
-    <div className="max-w-6xl mx-auto h-full">
-      {showEmbedButton ? (
-        <div className="mb-2 flex justify-end">
-          {/* No locale prop: EmbedButton self-resolves it from page context (like Link). */}
-          <EmbedButton
-            embedPath={`/meditations/${meditation.id}/embed`}
-            title={meditation.title ?? undefined}
-          />
-        </div>
-      ) : null}
+    <>
+      <div className="max-w-6xl mx-auto h-full">
+        {showEmbedButton ? (
+          <div className="mb-2 flex justify-end">
+            {/* No locale prop: EmbedButton self-resolves it from page context (like Link). */}
+            <EmbedButton
+              embedPath={`/meditations/${meditation.id}/embed`}
+              title={meditation.title ?? undefined}
+            />
+          </div>
+        ) : null}
 
-      {/* Meditation Player */}
-      <MeditationPlayer
-        frames={frames}
-        musicTracks={musicTracks}
-        seekTo={seekTo}
-        timeDisplay={timeDisplay}
-        track={{
-          url: meditation.url,
-          title: meditation.title || 'Untitled Meditation',
-          credit: '',
-          creditURL: '',
-          thumbnailURL: populatedImageUrl(meditation.thumbnail) || '',
-          duration:
-            typeof meditation.durationMinutes === 'number' && meditation.durationMinutes > 0
-              ? meditation.durationMinutes * 60
-              : 0,
-        }}
-        onPlaybackTimeUpdate={onPlaybackTimeUpdate}
-      />
-    </div>
+        {/* Meditation Player */}
+        <MeditationPlayer
+          frames={frames}
+          musicTracks={musicTracks}
+          seekTo={seekTo}
+          timeDisplay={timeDisplay}
+          track={{
+            url: meditation.url,
+            title: meditation.title || 'Untitled Meditation',
+            credit: '',
+            creditURL: '',
+            thumbnailURL: populatedImageUrl(meditation.thumbnail) || '',
+            duration:
+              typeof meditation.durationMinutes === 'number' && meditation.durationMinutes > 0
+                ? meditation.durationMinutes * 60
+                : 0,
+          }}
+          onPlaybackTimeUpdate={onPlaybackTimeUpdate}
+        />
+      </div>
+
+      {/* Related lectures (SahajCloud cross-type mirror) — renders nothing when
+          empty, so the embed route (which never fetches these) stays bare. */}
+      <RelatedContent items={relatedLecturesToCards(relatedLectures)} title="Related lectures" />
+    </>
   )
 }

--- a/lib/related-content.test.ts
+++ b/lib/related-content.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { relatedMeditationsToCards, relatedLecturesToCards } from './related-content'
+
+describe('relatedMeditationsToCards', () => {
+  it('maps to grid cards linking to the full meditation route with a play button', () => {
+    const cards = relatedMeditationsToCards([
+      {
+        id: 141,
+        title: 'Meditation for Vishuddhi',
+        durationMinutes: 19,
+        thumbnailUrl: 'https://imagedelivery.net/acct/abc/public',
+        narratorName: 'Sidd',
+      },
+    ])
+
+    expect(cards).toEqual([
+      {
+        id: 141,
+        title: 'Meditation for Vishuddhi',
+        href: '/meditations/141',
+        thumbnailSrc: 'https://imagedelivery.net/acct/abc/public',
+        thumbnailAlt: 'Meditation for Vishuddhi',
+        aspectRatio: 'video',
+        playButton: true,
+        durationMinutes: 19,
+      },
+    ])
+  })
+
+  it('omits a sub-1-minute duration badge (no "0 min")', () => {
+    const [card] = relatedMeditationsToCards([
+      {
+        id: 1,
+        title: 'T',
+        durationMinutes: 0,
+        thumbnailUrl: 'https://x/y/public',
+        narratorName: '',
+      },
+    ])
+
+    expect(card.durationMinutes).toBeUndefined()
+  })
+})
+
+describe('relatedLecturesToCards', () => {
+  it('maps to grid cards linking to the full lecture route, seconds → minutes', () => {
+    const cards = relatedLecturesToCards([
+      {
+        id: 150,
+        title: 'Truth Has to Be Experienced',
+        durationSeconds: 952,
+        thumbnailUrl: 'https://img.youtube.com/vi/abc/mqdefault.jpg',
+      },
+    ])
+
+    expect(cards).toEqual([
+      {
+        id: 150,
+        title: 'Truth Has to Be Experienced',
+        href: '/lectures/150',
+        thumbnailSrc: 'https://img.youtube.com/vi/abc/mqdefault.jpg',
+        thumbnailAlt: 'Truth Has to Be Experienced',
+        aspectRatio: 'video',
+        playButton: true,
+        durationMinutes: 16, // round(952 / 60)
+      },
+    ])
+  })
+
+  it('omits the duration badge when the clip length is unknown (0s)', () => {
+    const [card] = relatedLecturesToCards([
+      { id: 2, title: 'L', durationSeconds: 0, thumbnailUrl: 'https://img/y.jpg' },
+    ])
+
+    expect(card.durationMinutes).toBeUndefined()
+  })
+})

--- a/lib/related-content.ts
+++ b/lib/related-content.ts
@@ -1,0 +1,55 @@
+/**
+ * Map the shaped related-content endpoint cards (SahajCloud #523) to the shared
+ * `ResolvedCardItem` grid shape rendered by `RelatedContent` / `ContentGrid`.
+ *
+ * The endpoints already shape and filter their docs server-side (dropping any
+ * card missing a public title / duration / thumbnail), and the cms-client
+ * fetchers guard the rendered fields again — so these mappers are pure shape
+ * translation with no further filtering.
+ *
+ * Both card types use `aspectRatio: 'video'`: meditation thumbnails are ~16:9
+ * (`imagedelivery.net/.../public`) and lecture thumbnails are YouTube
+ * `mqdefault` (320×180, exactly 16:9).
+ */
+
+import type { RelatedMeditationCard, RelatedLectureCard } from '../server/cms-types'
+import type { ResolvedCardItem } from './cms-blocks'
+
+/** Minutes badge from a length in seconds: rounded, omitted below 1 minute (a
+ * "0 min" badge is meaningless). Mirrors `meditationDurationMinutes` in
+ * cms-blocks.ts so lecture and meditation cards read consistently. */
+function minutesFromSeconds(seconds: number): number | undefined {
+  const minutes = seconds > 0 ? Math.round(seconds / 60) : 0
+
+  return minutes >= 1 ? minutes : undefined
+}
+
+/** Map related meditations (from a lecture) to grid cards linking to the full
+ * meditation route. */
+export function relatedMeditationsToCards(cards: RelatedMeditationCard[]): ResolvedCardItem[] {
+  return cards.map((card) => ({
+    id: card.id,
+    title: card.title,
+    href: `/meditations/${card.id}`,
+    thumbnailSrc: card.thumbnailUrl,
+    thumbnailAlt: card.title,
+    aspectRatio: 'video',
+    playButton: true,
+    durationMinutes: card.durationMinutes >= 1 ? card.durationMinutes : undefined,
+  }))
+}
+
+/** Map related lectures (from a meditation) to grid cards linking to the full
+ * lecture route. `durationSeconds` is the playable clip/lecture length. */
+export function relatedLecturesToCards(cards: RelatedLectureCard[]): ResolvedCardItem[] {
+  return cards.map((card) => ({
+    id: card.id,
+    title: card.title,
+    href: `/lectures/${card.id}`,
+    thumbnailSrc: card.thumbnailUrl,
+    thumbnailAlt: card.title,
+    aspectRatio: 'video',
+    playButton: true,
+    durationMinutes: minutesFromSeconds(card.durationSeconds),
+  }))
+}

--- a/pages/lectures/[id]/(full)/+Page.tsx
+++ b/pages/lectures/[id]/(full)/+Page.tsx
@@ -7,9 +7,7 @@ import { LectureTemplate } from '../../../../components/templates'
  * wraps the player with a title + duration and shows the Embed button.
  */
 export function Page() {
-  const { lecture, locale, relatedMeditations } = useData<LecturePageData>()
+  const { lecture, locale } = useData<LecturePageData>()
 
-  return (
-    <LectureTemplate lecture={lecture} locale={locale} relatedMeditations={relatedMeditations} />
-  )
+  return <LectureTemplate showRelated lecture={lecture} locale={locale} />
 }

--- a/pages/lectures/[id]/(full)/+Page.tsx
+++ b/pages/lectures/[id]/(full)/+Page.tsx
@@ -7,7 +7,9 @@ import { LectureTemplate } from '../../../../components/templates'
  * wraps the player with a title + duration and shows the Embed button.
  */
 export function Page() {
-  const { lecture, locale } = useData<LecturePageData>()
+  const { lecture, locale, relatedMeditations } = useData<LecturePageData>()
 
-  return <LectureTemplate lecture={lecture} locale={locale} />
+  return (
+    <LectureTemplate lecture={lecture} locale={locale} relatedMeditations={relatedMeditations} />
+  )
 }

--- a/pages/lectures/[id]/(full)/+data.ts
+++ b/pages/lectures/[id]/(full)/+data.ts
@@ -1,31 +1,26 @@
 import type { PageContextServer } from 'vike/types'
-import type { WebConfig, RelatedMeditationCard } from '../../../../server/cms-types'
-import { getWebConfig, getRelatedMeditations } from '../../../../server/cms-client'
+import type { WebConfig } from '../../../../server/cms-types'
+import { getWebConfig } from '../../../../server/cms-client'
 import { loadLecture, type LectureData } from '../_lecture'
 
 export interface LecturePageData extends LectureData {
   settings: WebConfig
-  /** Meditations related to this lecture, shown below the player. Empty when
-   * there are none or the fetch degrades (the section is then omitted). */
-  relatedMeditations: RelatedMeditationCard[]
 }
 
 /**
- * Fetch the lecture (shared with the embed route), the WebConfig that
- * LayoutChrome needs, and the related meditations — all in parallel. Unlike the
- * meditation route (whose related fetch needs the config's audiences),
- * getRelatedMeditations needs only the route id, so it joins the same
- * Promise.all. Related content is fetched only here on the full route, so the
- * embed route stays player-only; getRelatedMeditations degrades to [] on any
- * failure (and a malformed id makes loadLecture 404 the page anyway), so it
- * never blocks or breaks rendering.
+ * Fetch the lecture (shared with the embed route) plus the WebConfig that
+ * LayoutChrome needs to render the nav, in parallel.
+ *
+ * Related meditations are NOT fetched here: the ranking endpoint is slow
+ * (~12s), so blocking SSR on it trips Vike's slow-hook warning. The full route
+ * renders the related section client-side instead (RelatedContentLoader via the
+ * template's showRelated flag).
  */
 export async function data(pageContext: PageContextServer): Promise<LecturePageData> {
-  const [base, settings, relatedMeditations] = await Promise.all([
+  const [base, settings] = await Promise.all([
     loadLecture(pageContext),
     getWebConfig({ locale: pageContext.locale }),
-    getRelatedMeditations({ id: pageContext.routeParams.id, locale: pageContext.locale }),
   ])
 
-  return { ...base, settings, relatedMeditations }
+  return { ...base, settings }
 }

--- a/pages/lectures/[id]/(full)/+data.ts
+++ b/pages/lectures/[id]/(full)/+data.ts
@@ -11,22 +11,21 @@ export interface LecturePageData extends LectureData {
 }
 
 /**
- * Fetch the lecture (shared with the embed route) plus the WebConfig that
- * LayoutChrome needs, in parallel — then the related meditations (keyed on the
- * validated lecture id). Related content is fetched only here on the full
- * route, so the embed route stays player-only. `getRelatedMeditations` degrades
- * to [] on any failure, so it never blocks the page.
+ * Fetch the lecture (shared with the embed route), the WebConfig that
+ * LayoutChrome needs, and the related meditations — all in parallel. Unlike the
+ * meditation route (whose related fetch needs the config's audiences),
+ * getRelatedMeditations needs only the route id, so it joins the same
+ * Promise.all. Related content is fetched only here on the full route, so the
+ * embed route stays player-only; getRelatedMeditations degrades to [] on any
+ * failure (and a malformed id makes loadLecture 404 the page anyway), so it
+ * never blocks or breaks rendering.
  */
 export async function data(pageContext: PageContextServer): Promise<LecturePageData> {
-  const [base, settings] = await Promise.all([
+  const [base, settings, relatedMeditations] = await Promise.all([
     loadLecture(pageContext),
     getWebConfig({ locale: pageContext.locale }),
+    getRelatedMeditations({ id: pageContext.routeParams.id, locale: pageContext.locale }),
   ])
-
-  const relatedMeditations = await getRelatedMeditations({
-    id: base.id,
-    locale: pageContext.locale,
-  })
 
   return { ...base, settings, relatedMeditations }
 }

--- a/pages/lectures/[id]/(full)/+data.ts
+++ b/pages/lectures/[id]/(full)/+data.ts
@@ -1,15 +1,21 @@
 import type { PageContextServer } from 'vike/types'
-import type { WebConfig } from '../../../../server/cms-types'
-import { getWebConfig } from '../../../../server/cms-client'
+import type { WebConfig, RelatedMeditationCard } from '../../../../server/cms-types'
+import { getWebConfig, getRelatedMeditations } from '../../../../server/cms-client'
 import { loadLecture, type LectureData } from '../_lecture'
 
 export interface LecturePageData extends LectureData {
   settings: WebConfig
+  /** Meditations related to this lecture, shown below the player. Empty when
+   * there are none or the fetch degrades (the section is then omitted). */
+  relatedMeditations: RelatedMeditationCard[]
 }
 
 /**
  * Fetch the lecture (shared with the embed route) plus the WebConfig that
- * LayoutChrome needs to render the nav, in parallel.
+ * LayoutChrome needs, in parallel — then the related meditations (keyed on the
+ * validated lecture id). Related content is fetched only here on the full
+ * route, so the embed route stays player-only. `getRelatedMeditations` degrades
+ * to [] on any failure, so it never blocks the page.
  */
 export async function data(pageContext: PageContextServer): Promise<LecturePageData> {
   const [base, settings] = await Promise.all([
@@ -17,5 +23,10 @@ export async function data(pageContext: PageContextServer): Promise<LecturePageD
     getWebConfig({ locale: pageContext.locale }),
   ])
 
-  return { ...base, settings }
+  const relatedMeditations = await getRelatedMeditations({
+    id: base.id,
+    locale: pageContext.locale,
+  })
+
+  return { ...base, settings, relatedMeditations }
 }

--- a/pages/meditations/[id]/(full)/+Page.tsx
+++ b/pages/meditations/[id]/(full)/+Page.tsx
@@ -7,13 +7,7 @@ import { MeditationTemplate } from '../../../../components/templates'
  * Embed button so visitors can grab the iframe snippet.
  */
 export function Page() {
-  const { meditation, musicTracks, relatedLectures } = useData<MeditationPageData>()
+  const { meditation, musicTracks } = useData<MeditationPageData>()
 
-  return (
-    <MeditationTemplate
-      meditation={meditation}
-      musicTracks={musicTracks}
-      relatedLectures={relatedLectures}
-    />
-  )
+  return <MeditationTemplate showRelated meditation={meditation} musicTracks={musicTracks} />
 }

--- a/pages/meditations/[id]/(full)/+Page.tsx
+++ b/pages/meditations/[id]/(full)/+Page.tsx
@@ -7,7 +7,13 @@ import { MeditationTemplate } from '../../../../components/templates'
  * Embed button so visitors can grab the iframe snippet.
  */
 export function Page() {
-  const { meditation, musicTracks } = useData<MeditationPageData>()
+  const { meditation, musicTracks, relatedLectures } = useData<MeditationPageData>()
 
-  return <MeditationTemplate meditation={meditation} musicTracks={musicTracks} />
+  return (
+    <MeditationTemplate
+      meditation={meditation}
+      musicTracks={musicTracks}
+      relatedLectures={relatedLectures}
+    />
+  )
 }

--- a/pages/meditations/[id]/(full)/+data.ts
+++ b/pages/meditations/[id]/(full)/+data.ts
@@ -1,22 +1,20 @@
 import type { PageContextServer } from 'vike/types'
-import type { WebConfig, RelatedLectureCard } from '../../../../server/cms-types'
-import { getWebConfig, getRelatedLectures } from '../../../../server/cms-client'
+import type { WebConfig } from '../../../../server/cms-types'
+import { getWebConfig } from '../../../../server/cms-client'
 import { loadMeditation, type MeditationData } from '../_meditation'
 
 export interface MeditationPageData extends MeditationData {
   settings: WebConfig
-  /** Lectures related to this meditation, shown below the player. Empty when
-   * the site has no audiences configured, there are none, or the fetch
-   * degrades (the section is then omitted). */
-  relatedLectures: RelatedLectureCard[]
 }
 
 /**
  * Fetch the meditation (shared with the embed route) plus the WebConfig that
- * LayoutChrome needs, in parallel — then the related lectures, which is
- * audience-gated so it needs the config's `audiences` first. Related content is
- * fetched only here on the full route (the embed route stays player-only), and
- * `getRelatedLectures` degrades to [] on any failure, so it never blocks the page.
+ * LayoutChrome needs to render the nav, in parallel.
+ *
+ * Related lectures are NOT fetched here: the ranking endpoint is slow (~5s+), so
+ * blocking SSR on it trips Vike's slow-hook warning. The full route renders the
+ * related section client-side instead (RelatedContentLoader via the template's
+ * showRelated flag).
  */
 export async function data(pageContext: PageContextServer): Promise<MeditationPageData> {
   const [base, settings] = await Promise.all([
@@ -24,11 +22,5 @@ export async function data(pageContext: PageContextServer): Promise<MeditationPa
     getWebConfig({ locale: pageContext.locale }),
   ])
 
-  const relatedLectures = await getRelatedLectures({
-    id: base.id,
-    locale: pageContext.locale,
-    audiences: settings.audiences,
-  })
-
-  return { ...base, settings, relatedLectures }
+  return { ...base, settings }
 }

--- a/pages/meditations/[id]/(full)/+data.ts
+++ b/pages/meditations/[id]/(full)/+data.ts
@@ -1,15 +1,22 @@
 import type { PageContextServer } from 'vike/types'
-import type { WebConfig } from '../../../../server/cms-types'
-import { getWebConfig } from '../../../../server/cms-client'
+import type { WebConfig, RelatedLectureCard } from '../../../../server/cms-types'
+import { getWebConfig, getRelatedLectures } from '../../../../server/cms-client'
 import { loadMeditation, type MeditationData } from '../_meditation'
 
 export interface MeditationPageData extends MeditationData {
   settings: WebConfig
+  /** Lectures related to this meditation, shown below the player. Empty when
+   * the site has no audiences configured, there are none, or the fetch
+   * degrades (the section is then omitted). */
+  relatedLectures: RelatedLectureCard[]
 }
 
 /**
  * Fetch the meditation (shared with the embed route) plus the WebConfig that
- * LayoutChrome needs to render the nav, in parallel.
+ * LayoutChrome needs, in parallel — then the related lectures, which is
+ * audience-gated so it needs the config's `audiences` first. Related content is
+ * fetched only here on the full route (the embed route stays player-only), and
+ * `getRelatedLectures` degrades to [] on any failure, so it never blocks the page.
  */
 export async function data(pageContext: PageContextServer): Promise<MeditationPageData> {
   const [base, settings] = await Promise.all([
@@ -17,5 +24,11 @@ export async function data(pageContext: PageContextServer): Promise<MeditationPa
     getWebConfig({ locale: pageContext.locale }),
   ])
 
-  return { ...base, settings }
+  const relatedLectures = await getRelatedLectures({
+    id: base.id,
+    locale: pageContext.locale,
+    audiences: settings.audiences,
+  })
+
+  return { ...base, settings, relatedLectures }
 }

--- a/pages/preview/(full)/+data.ts
+++ b/pages/preview/(full)/+data.ts
@@ -17,13 +17,7 @@
  */
 
 import type { PageContextServer } from 'vike/types'
-import {
-  getDocumentById,
-  getMeditationSongs,
-  getRelatedLectures,
-  getRelatedMeditations,
-  getWebConfig,
-} from '../../../server/cms-client'
+import { getDocumentById, getMeditationSongs, getWebConfig } from '../../../server/cms-client'
 import { resolveContentIndexBlocks } from '../../../server/content-index'
 import { render } from 'vike/abort'
 import { type CollectionType, type FullPreviewData } from '../_components'
@@ -104,18 +98,10 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
   }
 
   // Background music for meditation previews — keeps the live player in sync
-  // with the published routes (other collections have none).
+  // with the published routes (other collections have none). Related content is
+  // NOT fetched here — the preview page renders it client-side like the live
+  // routes (RelatedContentLoader), since the ranking endpoints are slow.
   const musicTracks = collection === 'meditations' ? await getMeditationSongs({ id, locale }) : []
-
-  // Related content for the full preview — mirrors the published routes'
-  // cross-type sections (meditation → related lectures, lecture → related
-  // meditations). Both degrade to [] on failure, so preview never breaks.
-  const relatedLectures =
-    collection === 'meditations'
-      ? await getRelatedLectures({ id, locale, audiences: settings.audiences })
-      : undefined
-  const relatedMeditations =
-    collection === 'lectures' ? await getRelatedMeditations({ id, locale }) : undefined
 
   // Return discriminated union based on collection type
   return {
@@ -124,7 +110,5 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
     locale,
     musicTracks,
     settings,
-    relatedLectures,
-    relatedMeditations,
   } as PreviewPageData
 }

--- a/pages/preview/(full)/+data.ts
+++ b/pages/preview/(full)/+data.ts
@@ -17,7 +17,13 @@
  */
 
 import type { PageContextServer } from 'vike/types'
-import { getDocumentById, getMeditationSongs, getWebConfig } from '../../../server/cms-client'
+import {
+  getDocumentById,
+  getMeditationSongs,
+  getRelatedLectures,
+  getRelatedMeditations,
+  getWebConfig,
+} from '../../../server/cms-client'
 import { resolveContentIndexBlocks } from '../../../server/content-index'
 import { render } from 'vike/abort'
 import { type CollectionType, type FullPreviewData } from '../_components'
@@ -101,6 +107,16 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
   // with the published routes (other collections have none).
   const musicTracks = collection === 'meditations' ? await getMeditationSongs({ id, locale }) : []
 
+  // Related content for the full preview — mirrors the published routes'
+  // cross-type sections (meditation → related lectures, lecture → related
+  // meditations). Both degrade to [] on failure, so preview never breaks.
+  const relatedLectures =
+    collection === 'meditations'
+      ? await getRelatedLectures({ id, locale, audiences: settings.audiences })
+      : undefined
+  const relatedMeditations =
+    collection === 'lectures' ? await getRelatedMeditations({ id, locale }) : undefined
+
   // Return discriminated union based on collection type
   return {
     collection: collection as CollectionType,
@@ -108,5 +124,7 @@ export async function data(pageContext: PageContextServer): Promise<PreviewPageD
     locale,
     musicTracks,
     settings,
+    relatedLectures,
+    relatedMeditations,
   } as PreviewPageData
 }

--- a/pages/preview/_components/LecturePreview.tsx
+++ b/pages/preview/_components/LecturePreview.tsx
@@ -10,7 +10,7 @@
 'use client'
 
 import { useLivePreview } from '@payloadcms/live-preview-react'
-import type { Lecture, RelatedMeditationCard } from './types'
+import type { Lecture } from './types'
 import { LectureTemplate } from '../../../components/templates'
 import { resolveLecture } from '../../../lib/lecture-shape'
 
@@ -19,19 +19,16 @@ export interface LecturePreviewProps {
   /** Current locale — selects which subtitle track is the default. */
   locale?: string
   /**
-   * Related meditations (from the loader), shown below the player. Fixed for the
-   * preview session — live updates only carry the edited lecture's own fields.
-   * @default []
+   * Whether the underlying template shows the Embed button — also gates the
+   * client-loaded related-content section, since both are full-chrome features
+   * shown in the full preview but not the bare embed preview. @default true
    */
-  relatedMeditations?: RelatedMeditationCard[]
-  /** Whether the underlying template shows the Embed button. @default true */
   showEmbedButton?: boolean
 }
 
 export function LecturePreview({
   initialData,
   locale,
-  relatedMeditations = [],
   showEmbedButton = true,
 }: LecturePreviewProps) {
   // useLivePreview listens for postMessage updates from SahajCloud admin.
@@ -49,8 +46,8 @@ export function LecturePreview({
     <LectureTemplate
       lecture={lecture}
       locale={locale}
-      relatedMeditations={relatedMeditations}
       showEmbedButton={showEmbedButton}
+      showRelated={showEmbedButton}
     />
   )
 }

--- a/pages/preview/_components/LecturePreview.tsx
+++ b/pages/preview/_components/LecturePreview.tsx
@@ -10,7 +10,7 @@
 'use client'
 
 import { useLivePreview } from '@payloadcms/live-preview-react'
-import type { Lecture } from './types'
+import type { Lecture, RelatedMeditationCard } from './types'
 import { LectureTemplate } from '../../../components/templates'
 import { resolveLecture } from '../../../lib/lecture-shape'
 
@@ -18,6 +18,12 @@ export interface LecturePreviewProps {
   initialData: Lecture
   /** Current locale — selects which subtitle track is the default. */
   locale?: string
+  /**
+   * Related meditations (from the loader), shown below the player. Fixed for the
+   * preview session — live updates only carry the edited lecture's own fields.
+   * @default []
+   */
+  relatedMeditations?: RelatedMeditationCard[]
   /** Whether the underlying template shows the Embed button. @default true */
   showEmbedButton?: boolean
 }
@@ -25,6 +31,7 @@ export interface LecturePreviewProps {
 export function LecturePreview({
   initialData,
   locale,
+  relatedMeditations = [],
   showEmbedButton = true,
 }: LecturePreviewProps) {
   // useLivePreview listens for postMessage updates from SahajCloud admin.
@@ -38,5 +45,12 @@ export function LecturePreview({
   // Normalize full lectures and clips into the same shape the template expects.
   const lecture = resolveLecture(liveData ?? initialData)
 
-  return <LectureTemplate lecture={lecture} locale={locale} showEmbedButton={showEmbedButton} />
+  return (
+    <LectureTemplate
+      lecture={lecture}
+      locale={locale}
+      relatedMeditations={relatedMeditations}
+      showEmbedButton={showEmbedButton}
+    />
+  )
 }

--- a/pages/preview/_components/MeditationPreview.tsx
+++ b/pages/preview/_components/MeditationPreview.tsx
@@ -8,7 +8,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { Meditation, MeditationSong } from './types'
+import type { Meditation, MeditationSong, RelatedLectureCard } from './types'
 import { MeditationTemplate } from '../../../components/templates'
 import { mergePreviewData } from './mergePreviewData'
 
@@ -21,6 +21,13 @@ export interface MeditationPreviewProps {
    * @default []
    */
   musicTracks?: MeditationSong[]
+  /**
+   * Related lectures (from the loader), shown below the player. Like music, the
+   * list is fixed for the preview session — live updates only carry the edited
+   * meditation's own fields.
+   * @default []
+   */
+  relatedLectures?: RelatedLectureCard[]
   /** Whether the underlying template shows the Embed button. @default true */
   showEmbedButton?: boolean
 }
@@ -55,6 +62,7 @@ function getSahajCloudOrigin(): string {
 export function MeditationPreview({
   initialData,
   musicTracks = [],
+  relatedLectures = [],
   showEmbedButton = true,
 }: MeditationPreviewProps) {
   // Get the server URL, defaulting to empty string if not configured
@@ -155,6 +163,7 @@ export function MeditationPreview({
     <MeditationTemplate
       meditation={meditation}
       musicTracks={musicTracks}
+      relatedLectures={relatedLectures}
       seekTo={seekCommand}
       showEmbedButton={showEmbedButton}
       timeDisplay="elapsed"

--- a/pages/preview/_components/MeditationPreview.tsx
+++ b/pages/preview/_components/MeditationPreview.tsx
@@ -8,7 +8,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { Meditation, MeditationSong, RelatedLectureCard } from './types'
+import type { Meditation, MeditationSong } from './types'
 import { MeditationTemplate } from '../../../components/templates'
 import { mergePreviewData } from './mergePreviewData'
 
@@ -22,13 +22,10 @@ export interface MeditationPreviewProps {
    */
   musicTracks?: MeditationSong[]
   /**
-   * Related lectures (from the loader), shown below the player. Like music, the
-   * list is fixed for the preview session — live updates only carry the edited
-   * meditation's own fields.
-   * @default []
+   * Whether the underlying template shows the Embed button — also gates the
+   * client-loaded related-content section, since both are full-chrome features
+   * shown in the full preview but not the bare embed preview. @default true
    */
-  relatedLectures?: RelatedLectureCard[]
-  /** Whether the underlying template shows the Embed button. @default true */
   showEmbedButton?: boolean
 }
 
@@ -62,7 +59,6 @@ function getSahajCloudOrigin(): string {
 export function MeditationPreview({
   initialData,
   musicTracks = [],
-  relatedLectures = [],
   showEmbedButton = true,
 }: MeditationPreviewProps) {
   // Get the server URL, defaulting to empty string if not configured
@@ -163,9 +159,9 @@ export function MeditationPreview({
     <MeditationTemplate
       meditation={meditation}
       musicTracks={musicTracks}
-      relatedLectures={relatedLectures}
       seekTo={seekCommand}
       showEmbedButton={showEmbedButton}
+      showRelated={showEmbedButton}
       timeDisplay="elapsed"
       onPlaybackTimeUpdate={handlePlaybackTimeUpdate}
     />

--- a/pages/preview/_components/Preview.tsx
+++ b/pages/preview/_components/Preview.tsx
@@ -46,7 +46,6 @@ export function Preview({ data, showEmbedButton = true }: PreviewProps) {
         <MeditationPreview
           initialData={data.initialData}
           musicTracks={data.musicTracks}
-          relatedLectures={data.relatedLectures}
           showEmbedButton={showEmbedButton}
         />
       )
@@ -55,7 +54,6 @@ export function Preview({ data, showEmbedButton = true }: PreviewProps) {
         <LecturePreview
           initialData={data.initialData}
           locale={data.locale}
-          relatedMeditations={data.relatedMeditations}
           showEmbedButton={showEmbedButton}
         />
       )

--- a/pages/preview/_components/Preview.tsx
+++ b/pages/preview/_components/Preview.tsx
@@ -46,6 +46,7 @@ export function Preview({ data, showEmbedButton = true }: PreviewProps) {
         <MeditationPreview
           initialData={data.initialData}
           musicTracks={data.musicTracks}
+          relatedLectures={data.relatedLectures}
           showEmbedButton={showEmbedButton}
         />
       )
@@ -54,6 +55,7 @@ export function Preview({ data, showEmbedButton = true }: PreviewProps) {
         <LecturePreview
           initialData={data.initialData}
           locale={data.locale}
+          relatedMeditations={data.relatedMeditations}
           showEmbedButton={showEmbedButton}
         />
       )

--- a/pages/preview/_components/types.ts
+++ b/pages/preview/_components/types.ts
@@ -13,6 +13,8 @@ import type {
   Lecture,
   WebConfig,
   MeditationSong,
+  RelatedLectureCard,
+  RelatedMeditationCard,
 } from '../../../server/cms-types'
 
 export type CollectionType = 'pages' | 'meditations' | 'lectures'
@@ -34,11 +36,17 @@ export type BasePreviewData =
       initialData: Meditation
       musicTracks: MeditationSong[]
       locale: string
+      /** Related lectures, rendered below the player on the chromed full preview.
+       * Omitted on the bare embed preview (mirrors the embed route). */
+      relatedLectures?: RelatedLectureCard[]
     }
   | {
       collection: 'lectures'
       initialData: Lecture
       locale: string
+      /** Related meditations, rendered below the player on the chromed full
+       * preview. Omitted on the bare embed preview. */
+      relatedMeditations?: RelatedMeditationCard[]
     }
 
 /**
@@ -57,13 +65,25 @@ export type FullPreviewData =
       musicTracks: MeditationSong[]
       locale: string
       settings: WebConfig
+      /** Related lectures, rendered below the player in the full preview. */
+      relatedLectures?: RelatedLectureCard[]
     }
   | {
       collection: 'lectures'
       initialData: Lecture
       locale: string
       settings: WebConfig
+      /** Related meditations, rendered below the player in the full preview. */
+      relatedMeditations?: RelatedMeditationCard[]
     }
 
 // Re-export types for convenience
-export type { Page, Meditation, Lecture, WebConfig, MeditationSong }
+export type {
+  Page,
+  Meditation,
+  Lecture,
+  WebConfig,
+  MeditationSong,
+  RelatedLectureCard,
+  RelatedMeditationCard,
+}

--- a/pages/preview/_components/types.ts
+++ b/pages/preview/_components/types.ts
@@ -13,8 +13,6 @@ import type {
   Lecture,
   WebConfig,
   MeditationSong,
-  RelatedLectureCard,
-  RelatedMeditationCard,
 } from '../../../server/cms-types'
 
 export type CollectionType = 'pages' | 'meditations' | 'lectures'
@@ -36,17 +34,11 @@ export type BasePreviewData =
       initialData: Meditation
       musicTracks: MeditationSong[]
       locale: string
-      /** Related lectures, rendered below the player on the chromed full preview.
-       * Omitted on the bare embed preview (mirrors the embed route). */
-      relatedLectures?: RelatedLectureCard[]
     }
   | {
       collection: 'lectures'
       initialData: Lecture
       locale: string
-      /** Related meditations, rendered below the player on the chromed full
-       * preview. Omitted on the bare embed preview. */
-      relatedMeditations?: RelatedMeditationCard[]
     }
 
 /**
@@ -65,25 +57,13 @@ export type FullPreviewData =
       musicTracks: MeditationSong[]
       locale: string
       settings: WebConfig
-      /** Related lectures, rendered below the player in the full preview. */
-      relatedLectures?: RelatedLectureCard[]
     }
   | {
       collection: 'lectures'
       initialData: Lecture
       locale: string
       settings: WebConfig
-      /** Related meditations, rendered below the player in the full preview. */
-      relatedMeditations?: RelatedMeditationCard[]
     }
 
 // Re-export types for convenience
-export type {
-  Page,
-  Meditation,
-  Lecture,
-  WebConfig,
-  MeditationSong,
-  RelatedLectureCard,
-  RelatedMeditationCard,
-}
+export type { Page, Meditation, Lecture, WebConfig, MeditationSong }

--- a/server/api-routes.ts
+++ b/server/api-routes.ts
@@ -39,11 +39,17 @@ export function registerApiRoutes(app: Hono<CmsEnv>): void {
     } catch {
       return c.json({ items: [] }, 400)
     }
-    const cards = await getRelatedMeditations({ id, locale: parseLocale(c.req.query('locale')) })
 
-    c.header('Cache-Control', CACHE_CONTROL)
+    // Related content never 500s — degrade to an empty section on any failure.
+    try {
+      const cards = await getRelatedMeditations({ id, locale: parseLocale(c.req.query('locale')) })
 
-    return c.json({ items: relatedMeditationsToCards(cards) })
+      c.header('Cache-Control', CACHE_CONTROL)
+
+      return c.json({ items: relatedMeditationsToCards(cards) })
+    } catch {
+      return c.json({ items: [] })
+    }
   })
 
   // Lectures related to a meditation (audience-gated: audiences come from the
@@ -57,11 +63,18 @@ export function registerApiRoutes(app: Hono<CmsEnv>): void {
       return c.json({ items: [] }, 400)
     }
     const locale = parseLocale(c.req.query('locale'))
-    const settings = await getWebConfig({ locale })
-    const cards = await getRelatedLectures({ id, locale, audiences: settings.audiences })
 
-    c.header('Cache-Control', CACHE_CONTROL)
+    // getWebConfig can rethrow after exhausting retries (the fetchers themselves
+    // degrade internally). Related content never 500s — fall back to empty.
+    try {
+      const settings = await getWebConfig({ locale })
+      const cards = await getRelatedLectures({ id, locale, audiences: settings.audiences })
 
-    return c.json({ items: relatedLecturesToCards(cards) })
+      c.header('Cache-Control', CACHE_CONTROL)
+
+      return c.json({ items: relatedLecturesToCards(cards) })
+    } catch {
+      return c.json({ items: [] })
+    }
   })
 }

--- a/server/api-routes.ts
+++ b/server/api-routes.ts
@@ -1,0 +1,67 @@
+/**
+ * Same-origin JSON API routes for client-loaded content.
+ *
+ * The related-content endpoints (SahajCloud #523) rank by subtle-system-node
+ * overlap server-side and are **slow** (~5–12s, not server-cached upstream).
+ * Fetching them inside a Vike `data()` hook blocks SSR and trips Vike's slow-
+ * hook warning, so instead the player pages render immediately and load related
+ * content **client-side** from these routes (see RelatedContentLoader). The
+ * routes wrap the same KV-cached fetchers, so the slow upstream call happens at
+ * most once per cache window; the browser just waits asynchronously for it.
+ *
+ * These run inside the `contextStorage()` middleware (registered first in
+ * entry.ts), so `getCmsContext()` resolves the API key / KV binding normally.
+ */
+
+import type { Hono } from 'hono'
+import type { CmsEnv } from './cms-context'
+import { getRelatedMeditations, getRelatedLectures, getWebConfig } from './cms-client'
+import { relatedMeditationsToCards, relatedLecturesToCards } from '../lib/related-content'
+import { idSchema } from './validation'
+import type { Locale } from './cms-types'
+
+/** Constrain the locale query param to the safe URL charset (default `en`). */
+function parseLocale(raw: string | undefined): Locale {
+  return (raw && /^[a-z]{2}(-[a-z]{2})?$/i.test(raw) ? raw : 'en') as Locale
+}
+
+/** Cache the JSON briefly in the browser/CDN; the heavy work is already KV-cached
+ * server-side. stale-while-revalidate keeps repeat views instant. */
+const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=1800'
+
+export function registerApiRoutes(app: Hono<CmsEnv>): void {
+  // Meditations related to a lecture (not audience-gated).
+  app.get('/api/related-meditations/:lectureId', async (c) => {
+    let id: string
+
+    try {
+      id = idSchema.parse(c.req.param('lectureId'))
+    } catch {
+      return c.json({ items: [] }, 400)
+    }
+    const cards = await getRelatedMeditations({ id, locale: parseLocale(c.req.query('locale')) })
+
+    c.header('Cache-Control', CACHE_CONTROL)
+
+    return c.json({ items: relatedMeditationsToCards(cards) })
+  })
+
+  // Lectures related to a meditation (audience-gated: audiences come from the
+  // site config; getRelatedLectures short-circuits to [] when none are set).
+  app.get('/api/related-lectures/:meditationId', async (c) => {
+    let id: string
+
+    try {
+      id = idSchema.parse(c.req.param('meditationId'))
+    } catch {
+      return c.json({ items: [] }, 400)
+    }
+    const locale = parseLocale(c.req.query('locale'))
+    const settings = await getWebConfig({ locale })
+    const cards = await getRelatedLectures({ id, locale, audiences: settings.audiences })
+
+    c.header('Cache-Control', CACHE_CONTROL)
+
+    return c.json({ items: relatedLecturesToCards(cards) })
+  })
+}

--- a/server/cms-client.test.ts
+++ b/server/cms-client.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest'
-import { getPageBySlug, getWebConfig, partitionPublishedPages } from './cms-client'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getPageBySlug,
+  getWebConfig,
+  partitionPublishedPages,
+  getRelatedMeditations,
+  getRelatedLectures,
+} from './cms-client'
 import { createPayloadClient } from './payload-client'
 import type { Page } from './cms-types'
 
@@ -9,6 +15,10 @@ vi.mock('./payload-client', () => ({
   createPayloadClient: vi.fn(),
   validateSDKResponse: (value: unknown) => value,
 }))
+// The shaped nested-route fetchers (related-*) read apiKey/baseURL from context.
+vi.mock('./cms-context', () => ({
+  getCmsContext: () => ({ apiKey: 'test-key', baseURL: 'https://cms.test', kv: undefined }),
+}))
 // Silence the Sentry warning emitted on unresolved page references.
 vi.mock('@sentry/react', () => ({ captureMessage: vi.fn() }))
 vi.mock('./kv-cache', async (importOriginal) => {
@@ -16,6 +26,11 @@ vi.mock('./kv-cache', async (importOriginal) => {
 
   return { ...actual, withCache: (opts: { fetchFn: () => unknown }) => opts.fetchFn() }
 })
+
+/** Build a fetch Response stub for the given status + JSON body. */
+function fetchResponse(status: number, body: unknown) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
 
 const page = (id: number, slug: string): Page => ({ id, slug, title: 'T' }) as unknown as Page
 
@@ -90,5 +105,152 @@ describe('getPageBySlug query shape', () => {
     // ...and the embedded page select omits the heavy `content` field.
     expect(args.populate.pages.slug).toBe(true)
     expect(args.populate.pages.content).toBeUndefined()
+  })
+})
+
+describe('getRelatedMeditations', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('maps shaped docs to cards and requests locale + limit on the lecture route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      fetchResponse(200, {
+        docs: [
+          {
+            id: 141,
+            title: 'Meditation for Vishuddhi',
+            durationMinutes: 19,
+            thumbnailUrl: 'https://imagedelivery.net/acct/abc/public',
+            narratorName: 'Sidd',
+          },
+        ],
+        source: 'fallback',
+        relevanceCount: 0,
+      }),
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const cards = await getRelatedMeditations({ id: '163', locale: 'en', limit: 6 })
+
+    expect(cards).toEqual([
+      {
+        id: 141,
+        title: 'Meditation for Vishuddhi',
+        durationMinutes: 19,
+        thumbnailUrl: 'https://imagedelivery.net/acct/abc/public',
+        narratorName: 'Sidd',
+      },
+    ])
+    const url = fetchMock.mock.calls[0][0] as string
+
+    expect(url).toContain('/api/lectures/163/related-meditations')
+    expect(url).toContain('locale=en')
+    expect(url).toContain('limit=6')
+  })
+
+  it('drops docs missing a public title or thumbnail (no blank cards / broken images)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fetchResponse(200, {
+          docs: [
+            { id: 1, title: '', durationMinutes: 10, thumbnailUrl: 'https://x/y/public' },
+            { id: 2, title: 'Ok', durationMinutes: 10, thumbnailUrl: '' },
+            { id: 3, title: 'Good', durationMinutes: 12, thumbnailUrl: 'https://x/z/public' },
+          ],
+        }),
+      ),
+    )
+
+    const cards = await getRelatedMeditations({ id: '163', locale: 'en' })
+
+    expect(cards.map((c) => c.id)).toEqual([3])
+    // narratorName is optional in the payload; defaults to '' so the card type holds.
+    expect(cards[0].narratorName).toBe('')
+  })
+
+  it('degrades to [] on an unknown lecture id (404)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fetchResponse(404, {})))
+
+    expect(await getRelatedMeditations({ id: '999999', locale: 'en' })).toEqual([])
+  })
+
+  it('degrades to [] (never throws) on a server error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fetchResponse(500, {})))
+
+    expect(await getRelatedMeditations({ id: '163', locale: 'en' })).toEqual([])
+  })
+})
+
+describe('getRelatedLectures', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('short-circuits to [] without a request when no audiences are configured', async () => {
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await getRelatedLectures({ id: '142', locale: 'en', audiences: [] })).toEqual([])
+    // Defensive: the field is typed required, but pre-config it can be nullish at
+    // runtime (the deploy ships an empty audience set) — guard against it anyway.
+    expect(
+      await getRelatedLectures({
+        id: '142',
+        locale: 'en',
+        audiences: null as unknown as [],
+      }),
+    ).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends audiences (bare ids + populated objects) and maps duration seconds', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      fetchResponse(200, {
+        docs: [
+          {
+            id: 150,
+            title: 'Truth Has to Be Experienced',
+            duration: 952,
+            thumbnailUrl: 'https://img.youtube.com/vi/abc/mqdefault.jpg',
+            hlsUrl: 'https://player.vimeo.com/external/1.m3u8',
+          },
+        ],
+        source: 'audience-fallback',
+      }),
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const cards = await getRelatedLectures({
+      id: '142',
+      locale: 'en',
+      // Mixed bare id + populated audience object → both ids sent.
+      audiences: [1, { id: 6 } as never],
+      limit: 6,
+    })
+
+    expect(cards).toEqual([
+      {
+        id: 150,
+        title: 'Truth Has to Be Experienced',
+        durationSeconds: 952,
+        thumbnailUrl: 'https://img.youtube.com/vi/abc/mqdefault.jpg',
+      },
+    ])
+    const url = fetchMock.mock.calls[0][0] as string
+
+    expect(url).toContain('/api/meditations/142/related-lectures')
+    expect(url).toContain('audiences=1,6')
+    expect(url).toContain('limit=6')
+  })
+
+  it('degrades to [] on a server error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fetchResponse(500, {})))
+
+    expect(await getRelatedLectures({ id: '142', locale: 'en', audiences: [1] })).toEqual([])
   })
 })

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -37,6 +37,7 @@ import type {
   AuthorsSelect,
   VideosSelect,
   WmWebConfigSelect,
+  Audience,
 } from './payload-types'
 import type {
   Locale,
@@ -739,8 +740,9 @@ export async function getMeditationSongs(
   }
 }
 
-/** Extract audience document ids (populated object or bare id) as strings. */
-function audienceIdList(audiences: WebConfig['audiences']): string[] {
+/** Extract audience document ids (populated object or bare id) as strings.
+ * Shared with the content-index `/for-audience` lecture feed (server/content-index.ts). */
+export function audienceIdList(audiences: (number | Audience)[] | null | undefined): string[] {
   if (!audiences) {
     return []
   }
@@ -883,7 +885,9 @@ export async function getRelatedLectures(
     locale: options.locale,
     limit,
     // Fold audiences into the key so a config change can't serve a stale list.
-    audiences,
+    // Pass a copy: generateCacheKey sorts array values in place, and the URL
+    // below reuses `audiences` — don't let the key build mutate it.
+    audiences: [...audiences],
   })
 
   try {

--- a/server/cms-client.ts
+++ b/server/cms-client.ts
@@ -38,7 +38,16 @@ import type {
   VideosSelect,
   WmWebConfigSelect,
 } from './payload-types'
-import type { Locale, Page, Song, WebConfig, PageListItem, MeditationSong } from './cms-types'
+import type {
+  Locale,
+  Page,
+  Song,
+  WebConfig,
+  PageListItem,
+  MeditationSong,
+  RelatedMeditationCard,
+  RelatedLectureCard,
+} from './cms-types'
 
 // ============================================================================
 // Common Options Interfaces
@@ -723,6 +732,210 @@ export async function getMeditationSongs(
     Sentry.captureMessage('getMeditationSongs failed; rendering meditation voice-only', {
       level: 'warning',
       tags: { source: 'getMeditationSongs' },
+      extra: { meditationId: options.id, locale: options.locale ?? null },
+    })
+
+    return []
+  }
+}
+
+/** Extract audience document ids (populated object or bare id) as strings. */
+function audienceIdList(audiences: WebConfig['audiences']): string[] {
+  if (!audiences) {
+    return []
+  }
+
+  return audiences
+    .map((a) => (typeof a === 'number' ? String(a) : a?.id != null ? String(a.id) : null))
+    .filter((id): id is string => id !== null)
+}
+
+/**
+ * Retrieves the meditations related to a lecture via the shaped nested route
+ * `GET /api/lectures/:id/related-meditations` (SahajCloud #523).
+ *
+ * Like `/songs`, this is not a collection `find`: it encapsulates the
+ * subtle-system-node-overlap ranking (with a recency top-up fallback) server-
+ * side, returns a fixed card projection, and ignores `select`/`populate`/`depth`
+ * (it honors `locale` + `limit`). The SDK can't model it, so we issue a raw
+ * authenticated fetch wrapped in the shared cache + retry layer.
+ *
+ * The endpoint drops any card missing a public title / duration / thumbnail, so
+ * the internal `label` never leaks. Meditation titles aren't localized, so the
+ * endpoint returns an empty list for non-English locales — the caller simply
+ * renders no related section (graceful, not an error). Degrades to `[]` for an
+ * unknown lecture id (404) and, after retries, any failure.
+ *
+ * @param options.id - The lecture document ID (the anchor)
+ * @param options.locale - The locale to retrieve meditation cards in
+ * @param options.limit - Max cards to request (default 8)
+ */
+export async function getRelatedMeditations(
+  options: LocalizedQueryOptions & {
+    id: string
+    limit?: number
+  },
+): Promise<RelatedMeditationCard[]> {
+  const limit = options.limit ?? 8
+  const cacheKey = generateCacheKey('related-meditations', {
+    id: options.id,
+    locale: options.locale,
+    limit,
+  })
+
+  try {
+    return await withCache({
+      cacheKey,
+      ttl: CacheTTL.LIST,
+      fetchFn: async () => {
+        const { apiKey, baseURL } = getCmsContext()
+        const url =
+          `${baseURL}/api/lectures/${encodeURIComponent(options.id)}/related-meditations` +
+          `?locale=${encodeURIComponent(options.locale)}&limit=${limit}`
+
+        const response = await fetch(url, {
+          headers: { Authorization: `clients API-Key ${apiKey}` },
+        })
+
+        console.log(`[PayloadCMS] GET ${url} → ${response.status}`)
+
+        // Unknown lecture id (or no related route) → no related content.
+        if (response.status === 404) return []
+
+        if (!response.ok) {
+          throw new Error(`getRelatedMeditations(${options.id}) failed: ${response.status}`)
+        }
+
+        const body = (await response.json()) as {
+          docs?: Array<Record<string, unknown>>
+        }
+        const docs = Array.isArray(body.docs) ? body.docs : []
+
+        // The endpoint already shapes cards, but guard the fields we render so a
+        // partial doc can never surface a blank card or a broken thumbnail.
+        return docs
+          .filter(
+            (doc): doc is Record<string, unknown> =>
+              typeof doc.id === 'number' &&
+              typeof doc.title === 'string' &&
+              doc.title.length > 0 &&
+              typeof doc.thumbnailUrl === 'string' &&
+              doc.thumbnailUrl.length > 0,
+          )
+          .map((doc) => ({
+            id: doc.id as number,
+            title: doc.title as string,
+            durationMinutes: typeof doc.durationMinutes === 'number' ? doc.durationMinutes : 0,
+            thumbnailUrl: doc.thumbnailUrl as string,
+            narratorName: typeof doc.narratorName === 'string' ? doc.narratorName : '',
+          }))
+      },
+    })
+  } catch (error) {
+    // Related content is supplementary — a failure to load it must never break
+    // the lecture page. Degrade to no related section and surface to Sentry.
+    console.warn(`[getRelatedMeditations] degrading to none for lecture ${options.id}:`, error)
+    Sentry.captureMessage('getRelatedMeditations failed; rendering lecture without related', {
+      level: 'warning',
+      tags: { source: 'getRelatedMeditations' },
+      extra: { lectureId: options.id, locale: options.locale ?? null },
+    })
+
+    return []
+  }
+}
+
+/**
+ * Retrieves the lectures related to a meditation via the shaped nested route
+ * `GET /api/meditations/:id/related-lectures` (the mirror of the endpoint
+ * above). Unlike `/related-meditations`, this endpoint is audience-gated: it
+ * *requires* the site's `audiences` (a 400 without), so with none configured we
+ * short-circuit to `[]` rather than issue a request that would 400.
+ *
+ * The endpoint returns the full lecture player projection ranked by node
+ * overlap with an audience/recency fallback; we surface only the card subset
+ * (id, title, thumbnail, playable duration). Degrades to `[]` for an unknown
+ * meditation id (404) and, after retries, any failure.
+ *
+ * @param options.id - The meditation document ID (the anchor)
+ * @param options.locale - The locale to retrieve lecture cards in
+ * @param options.audiences - The site's fixed audiences (WebConfig.audiences)
+ * @param options.limit - Max cards to request (default 8)
+ */
+export async function getRelatedLectures(
+  options: LocalizedQueryOptions & {
+    id: string
+    audiences: WebConfig['audiences']
+    limit?: number
+  },
+): Promise<RelatedLectureCard[]> {
+  const audiences = audienceIdList(options.audiences)
+
+  // Audience-gated: with none configured the site can't call the endpoint
+  // (it 400s), so degrade to no related section — matching the /for-audience
+  // content-index behavior. An admin sets audiences in WeMeditate Web config.
+  if (audiences.length === 0) {
+    return []
+  }
+  const limit = options.limit ?? 8
+  const cacheKey = generateCacheKey('related-lectures', {
+    id: options.id,
+    locale: options.locale,
+    limit,
+    // Fold audiences into the key so a config change can't serve a stale list.
+    audiences,
+  })
+
+  try {
+    return await withCache({
+      cacheKey,
+      ttl: CacheTTL.LIST,
+      fetchFn: async () => {
+        const { apiKey, baseURL } = getCmsContext()
+        const url =
+          `${baseURL}/api/meditations/${encodeURIComponent(options.id)}/related-lectures` +
+          `?locale=${encodeURIComponent(options.locale)}&limit=${limit}` +
+          `&audiences=${audiences.join(',')}`
+
+        const response = await fetch(url, {
+          headers: { Authorization: `clients API-Key ${apiKey}` },
+        })
+
+        console.log(`[PayloadCMS] GET ${url} → ${response.status}`)
+
+        if (response.status === 404) return []
+
+        if (!response.ok) {
+          throw new Error(`getRelatedLectures(${options.id}) failed: ${response.status}`)
+        }
+
+        const body = (await response.json()) as {
+          docs?: Array<Record<string, unknown>>
+        }
+        const docs = Array.isArray(body.docs) ? body.docs : []
+
+        return docs
+          .filter(
+            (doc): doc is Record<string, unknown> =>
+              typeof doc.id === 'number' &&
+              typeof doc.title === 'string' &&
+              doc.title.length > 0 &&
+              typeof doc.thumbnailUrl === 'string' &&
+              doc.thumbnailUrl.length > 0,
+          )
+          .map((doc) => ({
+            id: doc.id as number,
+            title: doc.title as string,
+            durationSeconds: typeof doc.duration === 'number' ? doc.duration : 0,
+            thumbnailUrl: doc.thumbnailUrl as string,
+          }))
+      },
+    })
+  } catch (error) {
+    console.warn(`[getRelatedLectures] degrading to none for meditation ${options.id}:`, error)
+    Sentry.captureMessage('getRelatedLectures failed; rendering meditation without related', {
+      level: 'warning',
+      tags: { source: 'getRelatedLectures' },
       extra: { meditationId: options.id, locale: options.locale ?? null },
     })
 

--- a/server/cms-types.ts
+++ b/server/cms-types.ts
@@ -108,3 +108,39 @@ export interface MeditationSong {
   title: string
   url: string
 }
+
+/**
+ * A related meditation card, as returned by
+ * `GET /api/lectures/:id/related-meditations` (SahajCloud #523).
+ *
+ * A *shaped* endpoint (like `/songs`): it encapsulates the node-overlap ranking
+ * server-side, returns a fixed projection, and — crucially — drops any card
+ * missing a public title / duration / thumbnail, so it never leaks the internal
+ * admin `label`. Every field here is guaranteed present and displayable. The
+ * grid is English-only in practice: meditation titles aren't localized, so the
+ * endpoint returns an empty list for non-English locales (a hidden section, not
+ * an error). See `getRelatedMeditations` in cms-client.
+ */
+export interface RelatedMeditationCard {
+  id: number
+  title: string
+  durationMinutes: number
+  thumbnailUrl: string
+  narratorName: string
+}
+
+/**
+ * A related lecture card, as returned by
+ * `GET /api/meditations/:id/related-lectures` (the pre-existing mirror of the
+ * endpoint above; requires the site's `audiences`).
+ *
+ * The endpoint returns the full lecture *player* projection (hls, subtitles,
+ * clip window); we surface only the card-relevant subset. `durationSeconds` is
+ * the playable length (clip window or full duration). See `getRelatedLectures`.
+ */
+export interface RelatedLectureCard {
+  id: number
+  title: string
+  durationSeconds: number
+  thumbnailUrl: string
+}

--- a/server/content-index.ts
+++ b/server/content-index.ts
@@ -25,6 +25,7 @@ import {
   type ContentIndexBlockFields,
   type ResolvedCardItem,
 } from '../lib/cms-blocks'
+import { audienceIdList } from './cms-client'
 // Type-only import (erased at build): the songs index resolves to MusicLibrary tracks.
 import type { Track } from '../components/molecules/AudioPlayer/types'
 
@@ -97,17 +98,6 @@ function stripQueryParam(endpoint: string, key: string): string {
   return kept.length > 0 ? `${path}?${kept.join('&')}` : path
 }
 
-/** Extract audience document ids (populated object or bare id) as strings. */
-function audienceIds(audiences: ResolveOptions['audiences']): string[] {
-  if (!audiences) {
-    return []
-  }
-
-  return audiences
-    .map((a) => (typeof a === 'number' ? String(a) : a?.id != null ? String(a.id) : null))
-    .filter((id): id is string => id !== null)
-}
-
 /**
  * Cache key for a content-index resolve. Audience ids are folded in for lectures
  * so a WmWebConfig audience change doesn't serve a stale `/for-audience` list.
@@ -119,7 +109,7 @@ function contentIndexCacheKey(fields: ContentIndexBlockFields, options: ResolveO
     // and return the wrong shape from cache (a songs Track[] vs a card list).
     type: fields.type,
     locale: options.locale,
-    audiences: fields.type === 'lectures' ? audienceIds(options.audiences) : undefined,
+    audiences: fields.type === 'lectures' ? audienceIdList(options.audiences) : undefined,
   })
 }
 
@@ -140,7 +130,7 @@ async function fetchContentIndexDocs(
   }
   // Lectures resolve via the /for-audience feed keyed on the site's fixed
   // audiences; with none configured the block degrades to empty (not an error).
-  const audiences = type === 'lectures' ? audienceIds(options.audiences) : []
+  const audiences = type === 'lectures' ? audienceIdList(options.audiences) : []
 
   if (type === 'lectures' && audiences.length === 0) {
     return []

--- a/server/entry.ts
+++ b/server/entry.ts
@@ -1,22 +1,27 @@
-import { apply, serve } from "@photonjs/hono";
-import { Hono } from "hono";
-import { contextStorage } from "hono/context-storage";
-import type { CmsEnv } from "./cms-context";
+import { apply, serve } from '@photonjs/hono'
+import { Hono } from 'hono'
+import { contextStorage } from 'hono/context-storage'
+import type { CmsEnv } from './cms-context'
+import { registerApiRoutes } from './api-routes'
 
-const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000
 
-export default startServer();
+export default startServer()
 
 function startServer() {
-  const app = new Hono<CmsEnv>();
+  const app = new Hono<CmsEnv>()
 
   // Enable context storage for AsyncLocalStorage-based config access
   // This MUST be registered before other middleware
-  app.use(contextStorage());
+  app.use(contextStorage())
 
-  apply(app, []);
+  // Same-origin JSON endpoints (client-loaded related content). Registered
+  // before Vike's handler so they take precedence over the page catch-all.
+  registerApiRoutes(app)
+
+  apply(app, [])
 
   return serve(app, {
     port,
-  });
+  })
 }


### PR DESCRIPTION
## Summary

- Adds a cross-type "related content" section below the player on the full meditation and lecture pages, built on SahajCloud's mirror endpoints ([backend #523](https://github.com/sydevs/SahajCloud/pull/523)): a meditation page shows **related lectures**, a lecture page shows **related meditations**.
- Because those ranking endpoints are **slow (~5–12s, not upstream-cached)**, the section is **loaded client-side** from two thin same-origin JSON routes — the player page renders immediately (no slow-`data()`-hook warnings) and the carousel fills in with a loading spinner.
- Cards render in a `ContentCarousel` with a coordinated `size` prop, visibility-based focus fade, and edge-hiding arrows.

## Changes

- `server/api-routes.ts` (+ `server/entry.ts`) — `GET /api/related-meditations/:lectureId` and `/api/related-lectures/:meditationId`: validate the id + locale, call the KV-cached shaped-endpoint fetchers (`getRelated*` in `cms-client.ts`, which degrade to `[]` and never leak the internal `label`), and return mapped cards.
- `server/cms-client.ts` — `getRelatedMeditations` / `getRelatedLectures` (audience-gated → short-circuits when no audiences); shared `audienceIdList` (deduped with `content-index.ts`).
- `components/organisms/RelatedContent/` — `RelatedContentLoader` (client fetch → spinner → carousel, nothing when empty) + the pure `RelatedContent` (renders `ContentCarousel`).
- Templates render the loader behind a `showRelated` flag; `(full)` routes + full preview enable it; embed routes stay bare.
- `components/molecules/blocks/ContentCarousel` — `size` variants (image + title/gap/play button coordinated), arrows hidden at the ends and centered on the image, and **focus fade driven by `slidesInView`** so every fully-visible card stays bright (not just one). `ContentCard` — long titles wrap to the image width instead of widening the slide.

## Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm exec tsc --noEmit`)
- Tests: ✓ 367 passed (`pnpm test:run`) — incl. fetcher (degrade/404/short-circuit), mapper, and RelatedContent markup tests
- Build: ✓ Success (`pnpm build`)

## Preview deployment

- Cloudflare previews build per PR (Workers + Ladle Pages); the deployed render is fetch-tested by the CI smoke matrix.

## Manual verification (done in-browser via Puppeteer)

The relation rule + card shape are decided by the backend (node-overlap ranking with an audience/recency fallback), so the section is data-dependent. Verified on the running app:

1. **Lecture page** → "Related meditations" carousel loads (spinner → cards) with real titles + duration badges; page `data()` ~0.8s (was ~12s).
2. **Meditation page** → "Related lectures" carousel (needs the site's **Audiences** set, which they are).
3. **Carousel behaviour** — multiple fully-visible cards stay bright, edge peekers fade (`inViewThreshold` 0.95); arrows hide at first/last and sit centered on the image; long titles wrap within the image width.
4. **Embed** routes stay player-only; **non-English** meditation pages omit the related-meditations grid (titles aren't localized upstream) — graceful, not an error.

## Notes for reviewer

- **Cross-type by design.** #42 originally scoped meditation→meditations, but the backend went cross-type (#523). "Excluding the current item" (AC-1) is satisfied inherently.
- **Client-load tradeoff.** Related content isn't in the SSR HTML — it loads after mount (fine for below-the-player supplementary content). The `/api/related-*` routes are public reads wrapping the KV-cached fetchers, so the slow upstream call happens ≤once per cache window.
- **Known upstream limitations (not blockers):** slow ranking endpoints (worth optimizing backend-side), English-only meditation titles, dominant-node-derived titles, hardcoded English section headings.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
